### PR TITLE
fix typo in installation instructions…

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@ mkdir ycm_temp
 cd ycm_temp
 curl -O http://llvm.org/releases/3.2/clang+llvm-3.2-x86_64-apple-darwin11.tar.gz
 tar -zxvf clang+llvm-3.2-x86_64-apple-darwin11.tar.gz
-cp clang+llvm-3.2-x86_64-apple-darwin11/lib/libclang.dylib ~/.vim/bundle/YouCompleteMe/python
+cp clang+llvm-3.2-x86_64-apple-darwin11/lib/libclang.dylib ~/.vim/bundles/YouCompleteMe/python
 </code></pre>
 
 <p>Compiling YCM <strong>with</strong> semantic support for C-family languages (previous step


### PR DESCRIPTION
shouldn't this be bundles not bundle? I hit a stop when I was following your instructions here, and I think pathogen normally installs to bundles… all your other scripts point there. Thanks for making such a neat plugin.
