### PR TITLE
FIx errors in vim after following YCM's README on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ provided on a best-effort basis and may not work for you.
 
 Install the latest version of [MacVim][]. Yes, MacVim. And yes, the _latest_.
 Even if you don't like the MacVim GUI, you can use the Vim binary that is inside
-the MacVim.app package (`MacVim.app/Contents/MacOS/Vim`).
+the MacVim.app package by aliasing `vim` to `mvim -v`.
 
 Install YouCompleteMe with [Vundle][].
 


### PR DESCRIPTION
```
E254: Cannot allocate color White
E254: Cannot allocate color Black
Error detected while processing /Users/rick/.vimrc:
line  15:
E484: Can't open file /usr/local/bin/vim/runtime/syntax/syntax.vim
```

I got those errors when trying to use `MacVim.app/Contents/MacOS/Vim` directly. Apparently, the correct method is to use `mvim -v`. You can alias `vim` to it.

More info for MacVim + vim + OS X: http://stackoverflow.com/a/5679658/195864
