### PR TITLE
[Try 2] Use the library path in the environment when looking up clang library.

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -170,8 +170,19 @@ endif()
 
 if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
   if ( USE_SYSTEM_LIBCLANG )
+    if ( APPLE )
+      set( ENV_LIB_PATHS ENV DYLD_LIBRARY_PATH )
+    elseif ( UNIX )
+      set( ENV_LIB_PATHS ENV LD_LIBRARY_PATH )
+    elseif ( WIN32 )
+      set( ENV_LIB_PATHS ENV PATH )
+    else ()
+      set( ENV_LIB_PATHS "" )
+    endif()
     # Need TEMP because find_library does not work with an option variable
-    find_library( TEMP clang PATHS
+    find_library( TEMP clang
+                  PATHS
+                  ${ENV_LIB_PATHS}
                   /usr/lib
                   /usr/lib/llvm )
     set( EXTERNAL_LIBCLANG_PATH ${TEMP} )


### PR DESCRIPTION
Use *LD_LIBRARY_PATH when configured to build against the systems libclang.
This patch makes the install script work even when libclang is in a custom path.

Signed-off-by: Ola Jeppsson ola.jeppsson@gmail.com
