### PR TITLE
Improve default semantic triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,11 +647,14 @@ listed as a trigger, the same thing would happen when the user typed `foo->`.
 Default: `[see next line]`
 
     let g:ycm_semantic_triggers =  {
-      \   'c,cpp,objc,objcpp' : ['->', '.', '::'],
+      \   'c' : ['->', '.'],
+      \   'objc' : ['->', '.'],
+      \   'cpp,objcpp' : ['->', '.', '::'],
       \   'perl,php' : ['->'],
-      \   'cs,java,javascript,d,vim,ruby,python,perl6,scala,vb' : ['.'],
+      \   'cs,java,javascript,d,vim,ruby,python,perl6,scala,vb,elixir' : ['.'],
       \   'lua' : ['.', ':'],
-      }
+      \   'erlang' : [':'],
+    }
 
 FAQ
 ---

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -97,10 +97,13 @@ let g:ycm_global_ycm_extra_conf =
 
 let g:ycm_semantic_triggers =
       \ get( g:, 'ycm_semantic_triggers', {
-      \   'c,cpp,objc,objcpp' : ['->', '.', '::'],
+      \   'c' : ['->', '.'],
+      \   'objc' : ['->', '.'],
+      \   'cpp,objcpp' : ['->', '.', '::'],
       \   'perl,php' : ['->'],
-      \   'cs,java,javascript,d,vim,ruby,python,perl6,scala,vb' : ['.'],
+      \   'cs,java,javascript,d,vim,ruby,python,perl6,scala,vb,elixir' : ['.'],
       \   'lua' : ['.', ':'],
+      \   'erlang' : [':'],
       \ } )
 
 " On-demand loading. Let's use the autoload folder and not slow down vim's


### PR DESCRIPTION
There's the need for a different way to define semantic triggers, for instance in Obj-C it should trigger the semantic completer once `[identifier` has been typed.
