### PR TITLE
Let local YCM config file override global config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ or in any directory above it in the hierarchy (recursively); when the file is
 found, it is loaded (only once!) as a Python module. YCM calls a `FlagsForFile`
 method in that module which should provide it with the information necessary to
 compile the current file. (You can also provide a path to a global
-`.ycm_extra_conf.py` file and override this searching behavior. See the Options
+`.ycm_extra_conf.py` file, which will be used as a fallback. See the Options
 section for more details.)
 
 This system was designed this way so that the user can perform any arbitrary
@@ -622,11 +622,10 @@ Default: `<leader>d`
 
 ### The `g:ycm_global_ycm_extra_conf` option
 
-Normally, YCM searches for a `.ycm_extra_conf.py` file for compilation flags
-(see the User Guide for more details on how this works). You can use this option
-to override this searching behavior by providing a full, absolute path to a
-global `.ycm_extra_conf.py` file (although you can call the global file whatever
-you want).
+Normally, YCM searches for a '.ycm_extra_conf.py' file for compilation flags
+(see the User Guide for more details on how this works). This option specifies
+a fallback path to a config file which is used if no '.ycm_extra_conf.py' is
+found.
 
 You can place such a global file anywhere in your filesystem.
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -692,10 +692,9 @@ Default: '<leader>d'
 The *g:ycm_global_ycm_extra_conf* option
 
 Normally, YCM searches for a '.ycm_extra_conf.py' file for compilation flags
-(see the User Guide for more details on how this works). You can use this
-option to override this searching behavior by providing a full, absolute path
-to a global '.ycm_extra_conf.py' file (although you can call the global file
-whatever you want).
+(see the User Guide for more details on how this works). This option specifies
+a fallback path to a config file which is used if no '.ycm_extra_conf.py' is
+found.
 
 You can place such a global file anywhere in your filesystem.
 

--- a/python/completers/cpp/flags.py
+++ b/python/completers/cpp/flags.py
@@ -92,27 +92,31 @@ class Flags( object ):
 
 def _FlagsModuleSourceFileForFile( filename ):
   """For a given filename, finds its nearest YCM_EXTRA_CONF_FILENAME file that
-  will compute the flags necessary to compile the file. Returns None if no
-  YCM_EXTRA_CONF_FILENAME file could be found. Uses the global ycm_extra_conf
-  file if one is set."""
+  will compute the flags necessary to compile the file. If no
+  YCM_EXTRA_CONF_FILENAME file could be found, try to use
+  GLOBAL_YCM_EXTRA_CONF_FILE instead. If that also fails, return None.
+  Uses the global ycm_extra_conf file if one is set."""
 
-  if ( GLOBAL_YCM_EXTRA_CONF_FILE and
-       os.path.exists( GLOBAL_YCM_EXTRA_CONF_FILE ) ):
-    return GLOBAL_YCM_EXTRA_CONF_FILE
-
+  ycm_conf_file = None
   parent_folder = os.path.dirname( filename )
   old_parent_folder = ''
 
   while True:
     current_file = os.path.join( parent_folder, YCM_EXTRA_CONF_FILENAME )
     if os.path.exists( current_file ):
-      return current_file
+      ycm_conf_file = current_file
+      break
 
     old_parent_folder = parent_folder
     parent_folder = os.path.dirname( parent_folder )
+    if parent_folder is old_parent_folder:
+      break
 
-    if parent_folder == old_parent_folder:
-      return None
+  if ( not ycm_conf_file and GLOBAL_YCM_EXTRA_CONF_FILE and
+       os.path.exists( GLOBAL_YCM_EXTRA_CONF_FILE ) ):
+    ycm_conf_file = GLOBAL_YCM_EXTRA_CONF_FILE
+
+  return ycm_conf_file
 
 
 def _RandomName():


### PR DESCRIPTION
Currently, when VIM opens a source file, YCM always defaults to
'g:global_ycm_extra_conf_file' if it exists.

This commit changes YCM's behaviour so that it first tries to find the config
file in the source file's folder (or any of its parents folder), before
falling back to 'g:global_ycm_extra_conf_file'.
