### PR TITLE
Fix install script so it finds the correct Python.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ function install {
     cmake -G "Unix  Makefiles" $1 . $ycm_dir/cpp
   fi
 
-  #make ycm_core
+  make ycm_core
   popd
 }
 


### PR DESCRIPTION
This fixes #18 and maybe some other related issues. In particular with homebrew python installations.

Similar fixes are done in various homebrew formula. For example, see: https://github.com/mxcl/homebrew/blob/51d054c/Library/Formula/opencv.rb#L50-73

There are a couple of other problems, but I don't think YouCompleteMe can do anything about them, as they are configuration issues with other projects.

For instance, homebrew vim works with the above fix, but homebrew macvim does not (at least I couldn't get it to without editing the formula), because the macvim seems bent on using system python.

Fix tested with:
OSX 10.7.5
Homebrew
Python (2.7.3) installed with homebrew
Vim 7.3 (patches 1-820) installed with homebrew
