### PR TITLE
YCM does not work out of a box for Ubuntu 12.04

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -207,6 +207,10 @@ if ( EXTRA_RPATH )
   set( CMAKE_INSTALL_RPATH "${EXTRA_RPATH}:${CMAKE_INSTALL_RPATH}" )
 endif()
 
+if ( UNIX )
+  set( EXTRA_LIBS rt )
+endif()
+
 #############################################################################
 
 # Due to a bug/misconfiguration/stupidity, boost 1.52 and libc++ don't like each
@@ -228,6 +232,7 @@ target_link_libraries( ${PROJECT_NAME}
                        BoostParts
                        ${PYTHON_LIBRARIES}
                        ${LIBCLANG_TARGET}
+                       ${EXTRA_LIBS}
                      )
 
 if ( LIBCLANG_TARGET )


### PR DESCRIPTION
Starting Vim with freshly installed YCM fails with:

```
Error importing ycm_core. Are you sure you have placed a version 3.2+ libclang.[so|dll|dylib] in folder... /home/rjeczalik/.vim/bundle/YouCompleteMe/autoload/../python/ycm_core.so: undefined symbol: clock_gettime
```

I've attached a diff to link it additionally with librt.
