### PR TITLE
let g:ycm_global_ycm_extra_conf accept "~"

### DIFF
--- a/python/completers/cpp/flags.py
+++ b/python/completers/cpp/flags.py
@@ -29,8 +29,9 @@ YCM_EXTRA_CONF_FILENAME = '.ycm_extra_conf.py'
 NO_EXTRA_CONF_FILENAME_MESSAGE = ('No {0} file detected, so no compile flags '
   'are available. Thus no semantic support for C/C++/ObjC/ObjC++.').format(
     YCM_EXTRA_CONF_FILENAME )
-GLOBAL_YCM_EXTRA_CONF_FILE = vimsupport.GetVariableValue(
-  "g:ycm_global_ycm_extra_conf" )
+GLOBAL_YCM_EXTRA_CONF_FILE = os.path.expanduser( 
+    vimsupport.GetVariableValue( "g:ycm_global_ycm_extra_conf" )
+)
 
 class Flags( object ):
   def __init__( self ):


### PR DESCRIPTION
The python function os.path.exists does not expand "~" to user home folder so if you set g:ycm_global_ycm_extra_conf with "~" the file will not be load. Of course user can always use absolute path instead but I think accepting "~" is a better idea.
