### PR TITLE
Fix README typo for g:ycm_semantic_triggers value

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ Default: `[see next line]`
       \   'cs,java,javascript,d,vim,ruby,python,perl6,scala,vb,elixir' : ['.'],
       \   'lua' : ['.', ':'],
       \   'erlang' : [':'],
-    }
+      \ }
 
 FAQ
 ---


### PR DESCRIPTION
This is so minor I'm embarrassed to submit it. YCM is awesome!
