### PR TITLE
Implement completer-specific commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,15 @@ This will print out various debug information for the current file. Useful to
 see what compile commands will be used for the file if you're using the semantic
 completion engine.
 
+### The `YcmCompleter` command
+
+This command can be used to invoke completer-specific commands.  If the first
+argument is of the form `ft=...` the completer for that file type will be used
+(for example `ft=cpp`), else the native completer of the current buffer will be
+used.
+Call `YcmCompleter` without further arguments for information about the
+commands you can call for the selected completer.
+
 Options
 -------
 

--- a/python/completers/completer.py
+++ b/python/completers/completer.py
@@ -23,6 +23,7 @@ import vimsupport
 import ycm_core
 from collections import defaultdict
 
+NO_USER_COMMANDS = 'This completer does not define any commands.'
 
 class Completer( object ):
   """A base class for all Completers in YCM.
@@ -96,7 +97,15 @@ class Completer( object ):
   their specific events occur. For instance, the identifier completer collects
   all the identifiers in the file in OnFileReadyToParse() which gets called when
   the user stops typing for 2 seconds (Vim's CursorHold and CursorHoldI events).
-  """
+
+  One special function is OnUserCommand. It is called when the user uses the
+  command :YcmCompleter and is passed all extra arguments used on command
+  invocation (e.g. OnUserCommand(['first argument', 'second'])).  This can be
+  used for completer-specific commands such as reloading external
+  configuration.
+  When the command is called with no arguments you should print a short summary
+  of the supported commands or point the user to the help section where this
+  information can be found."""
 
   __metaclass__ = abc.ABCMeta
 
@@ -232,6 +241,10 @@ class Completer( object ):
 
   def OnInsertLeave( self ):
     pass
+
+
+  def OnUserCommand( self, arguments ):
+    vimsupport.PostVimMessage( NO_USER_COMMANDS )
 
 
   def OnCurrentIdentifierFinished( self ):

--- a/python/ycm.py
+++ b/python/ycm.py
@@ -53,6 +53,10 @@ class YouCompleteMe( object ):
     return self.identcomp
 
 
+  def GetOmniCompleter( self ):
+    return self.omnicomp
+
+
   def GetFiletypeCompleter( self ):
     filetypes = vimsupport.CurrentFiletypes()
 


### PR DESCRIPTION
This provides a framework for completer-writers to create completer-specific commands. I have in mind to use this for the clang completer to force reloading of a flags module via `:YcmCompleter reload` once my other pull request is merged.
