### PR TITLE
Added option to close the preview window after leaving insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,18 @@ Default: `0`
 
     let g:ycm_autoclose_preview_window_after_completion = 0
 
+### The `g:ycm_autoclose_preview_window_after_insertion` option
+
+When this option is set to `1`, YCM will auto-close the `preview` window after
+the user leaves insert mode. This option is irrelevant if
+`g:ycm_autoclose_preview_window_after_completion` is set or if no `preview`
+window is triggered. See the `g:ycm_add_preview_to_completeopt` option for more
+details.
+
+Default: `0`
+
+    let g:ycm_autoclose_preview_window_after_insertion = 0
+
 ### The `g:ycm_max_diagnostics_to_display` option
 
 This option controls the maximum number of diagnostics shown to the user when
@@ -787,7 +799,8 @@ types to write the function call.
 
 If you would like this window to auto-close after you select a completion
 string, set the `g:ycm_autoclose_preview_window_after_completion` option to `1`
-in your `vimrc` file.
+in your `vimrc` file. Similarly, the `g:ycm_autoclose_preview_window_after_insertion`
+option can be set to close the `preview` window after leaving insert mode.
 
 If you don't want this window to ever show up, add `set completeopt-=preview` to
 your `vimrc`. Also make sure that the `g:ycm_add_preview_to_completeopt` option

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -238,7 +238,9 @@ function! s:OnCursorMovedInsertMode()
   endif
 
   call s:IdentifierFinishedOperations()
-  call s:ClosePreviewWindowIfNeeded()
+  if g:ycm_autoclose_preview_window_after_completion
+    call s:ClosePreviewWindowIfNeeded()
+  endif
   call s:InvokeCompletion()
 endfunction
 
@@ -260,7 +262,10 @@ function! s:OnInsertLeave()
   let s:omnifunc_mode = 0
   call s:UpdateDiagnosticNotifications()
   py ycm_state.OnInsertLeave()
-  call s:ClosePreviewWindowIfNeeded()
+  if g:ycm_autoclose_preview_window_after_completion ||
+        \ g:ycm_autoclose_preview_window_after_insertion
+    call s:ClosePreviewWindowIfNeeded()
+  endif
 endfunction
 
 
@@ -306,10 +311,6 @@ endfunction
 
 
 function! s:ClosePreviewWindowIfNeeded()
-  if !g:ycm_autoclose_preview_window_after_completion
-    return
-  endif
-
   if s:searched_and_results_found
     " This command does the actual closing of the preview window. If no preview
     " window is shown, nothing happens.

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -91,6 +91,9 @@ let g:ycm_collect_identifiers_from_comments_and_strings =
 let g:ycm_autoclose_preview_window_after_completion =
       \ get( g:, 'ycm_autoclose_preview_window_after_completion', 0 )
 
+let g:ycm_autoclose_preview_window_after_insertion =
+      \ get( g:, 'ycm_autoclose_preview_window_after_insertion', 0 )
+
 let g:ycm_max_diagnostics_to_display =
       \ get( g:, 'ycm_max_diagnostics_to_display', 30 )
 


### PR DESCRIPTION
With `g:ycm_autoclose_preview_window_after_completion`, the preview window is auto-closed when I start typing. But, for example, when auto-completing a method I want to call, it'd be useful for the preview window to stay open so I can still see the called method's signature while I type.

To do that, I added the `g:ycm_autoclose_preview_window_after_insertion` option, which auto-closes the preview window after leaving insert mode.
