### PR TITLE
Automatically expand python parameters

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -251,6 +251,8 @@ function! s:OnCursorMovedInsertMode()
     return
   endif
 
+  py ycm_state.GetFiletypeCompleter().OnCursorMovedInsertMode()
+
   call s:IdentifierFinishedOperations()
   if g:ycm_autoclose_preview_window_after_completion
     call s:ClosePreviewWindowIfNeeded()

--- a/python/completers/python/jedi_completer.py
+++ b/python/completers/python/jedi_completer.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
 import vim
 from threading import Thread, Event
 from completers.completer import Completer
@@ -27,7 +28,7 @@ import sys
 from os.path import join, abspath, dirname
 
 # We need to add the jedi package to sys.path, but it's important that we clean
-# up after ourselves, because ycm.YouCompletMe.GetFiletypeCompleterForFiletype
+# up after ourselves, because ycm.YouCompleteMe.GetFiletypeCompleterForFiletype
 # removes sys.path[0] after importing completers.python.hook
 sys.path.insert( 0, join( abspath( dirname( __file__ ) ), 'jedi' ) )
 try:
@@ -81,19 +82,17 @@ class JediCompleter( Completer ):
   def CandidatesFromStoredRequestInner( self ):
     return self._candidates or []
 
+  
+  def OnCursorMovedInsertMode( self ):
+    if DidInvokeCallable():
+      _ExpandParams()
+
 
   def SetCandidates( self ):
     while True:
       try:
         WaitAndClear( self._query_ready )
-
-        filename = vim.current.buffer.name
-        line, column = vimsupport.CurrentLineAndColumn()
-        # Jedi expects lines to start at 1, not 0
-        line += 1
-        contents = '\n'.join( vim.current.buffer )
-        script = Script( contents, line, column, filename )
-
+        script = _GetJediScript()
         self._candidates = [ { 'word': str( completion.word ),
                                'menu': str( completion.description ),
                                'info': str( completion.doc ) }
@@ -104,8 +103,57 @@ class JediCompleter( Completer ):
       self._candidates_ready.set()
 
 
+CALLABLE_PATTERN = re.compile(r'.*\w\($')
+
+def DidInvokeCallable():
+  """
+  Returns True if there is an identifier followed by an opening bracket,
+  followed by the vim cursor. I.e. if it looks like `object.some_method(_`, and
+  not some arithmetic expression. 
+  """
+  line, column = vimsupport.CurrentLineAndColumn()
+  return CALLABLE_PATTERN.match( vim.current.buffer[ line ][ :column ] )
+
+
+def GetUltiSnipsManager():
+  try:
+    from UltiSnips import UltiSnips_Manager as manager
+    return manager
+  except ImportError:
+    return None
+  
+
 def WaitAndClear( event, timeout=None ):
-    flag_is_set = event.wait( timeout )
-    if flag_is_set:
-        event.clear()
-    return flag_is_set
+  flag_is_set = event.wait( timeout )
+  if flag_is_set:
+    event.clear()
+  return flag_is_set
+
+
+def _GetJediScript():
+  filename = vim.current.buffer.name
+  line, column = vimsupport.CurrentLineAndColumn()
+  # Jedi expects lines to start at 1, not 0
+  line += 1
+  contents = '\n'.join( vim.current.buffer )
+  encoding = vim.eval( '&encoding' )
+  return Script( contents, line, column, filename, encoding )
+
+
+def _FormatSnippet( params ):
+  params = [ '${{{}:{}}}'.format( index + 1, param )
+             for index, param in enumerate( params ) ]
+  return '{})$0'.format( ', '.join( params ) )
+
+
+def _ExpandParams():
+  manager = GetUltiSnipsManager()
+  script = _GetJediScript()
+  call_def = script.get_in_function_call()
+  if call_def is None or not manager:
+    # Either jedi can't look up the params, or UltiSnips is not found
+    return
+
+  params = [ param.get_code().strip() for param in call_def.params ]
+  snippet = _FormatSnippet(params)
+  manager.expand_anon(snippet)


### PR DESCRIPTION
Hi, this is a first stab to automatically expand the parameters of a python callable when invoked. Basically, whenever the opening parenthesis of a call is typed, like `object.some_method(_`, the expansion snippet is triggered.

By using the opening parenthesis as a trigger, parameter expansion will not get in the way when passing functions as parameters, such as in `map(object.some_method, [1, 2, 3])`.

For this to work in languages where overloading methods is possible, I guess the completer needs to know which index was selected in the popup menu.

Anyway, let me know what you think about this approach.
