### PR TITLE
Add python3 support to YouCompleteMe

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -37,19 +37,19 @@ function! youcompleteme#Enable()
     return
   endif
 
-  py import sys
-  py import vim
-  exe 'python sys.path.insert( 0, "' . s:script_folder_path . '/../python" )'
-  py import ycm
+  py3 import sys
+  py3 import vim
+  exe 'python3 sys.path.insert( 0, "' . s:script_folder_path . '/../python" )'
+  py3 import ycm
 
-  if !pyeval( 'ycm.CompatibleWithYcmCore()')
+  if !py3eval( 'ycm.CompatibleWithYcmCore()')
     echohl WarningMsg |
       \ echomsg "YouCompleteMe unavailable: ycm_core too old, PLEASE RECOMPILE ycm_core" |
       \ echohl None
     return
   endif
 
-  py ycm_state = ycm.YouCompleteMe()
+  py3 ycm_state = ycm.YouCompleteMe()
 
   augroup youcompleteme
     autocmd!
@@ -193,7 +193,7 @@ function! s:OnBufferDelete( deleted_buffer_file )
     return
   endif
 
-  py ycm_state.OnBufferDelete( vim.eval( 'a:deleted_buffer_file' ) )
+  py3 ycm_state.OnBufferDelete( vim.eval( 'a:deleted_buffer_file' ) )
 endfunction
 
 
@@ -211,7 +211,7 @@ endfunction
 
 
 function! s:OnFileReadyToParse()
-  py ycm_state.OnFileReadyToParse()
+  py3 ycm_state.OnFileReadyToParse()
 endfunction
 
 
@@ -219,7 +219,7 @@ function! s:SetCompleteFunc()
   let &completefunc = 'youcompleteme#Complete'
   let &l:completefunc = 'youcompleteme#Complete'
 
-  if pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
+  if py3eval( 'ycm_state.NativeFiletypeCompletionUsable()' )
     let &omnifunc = 'youcompleteme#OmniComplete'
     let &l:omnifunc = 'youcompleteme#OmniComplete'
 
@@ -275,7 +275,7 @@ function! s:OnInsertLeave()
 
   let s:omnifunc_mode = 0
   call s:UpdateDiagnosticNotifications()
-  py ycm_state.OnInsertLeave()
+  py3 ycm_state.OnInsertLeave()
   if g:ycm_autoclose_preview_window_after_completion ||
         \ g:ycm_autoclose_preview_window_after_insertion
     call s:ClosePreviewWindowIfNeeded()
@@ -344,18 +344,18 @@ endfunction
 
 function! s:UpdateDiagnosticNotifications()
   if get( g:, 'loaded_syntastic_plugin', 0 ) &&
-        \ pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' ) &&
-        \ pyeval( 'ycm_state.DiagnosticsForCurrentFileReady()' )
+        \ py3eval( 'ycm_state.NativeFiletypeCompletionUsable()' ) &&
+        \ py3eval( 'ycm_state.DiagnosticsForCurrentFileReady()' )
     SyntasticCheck
   endif
 endfunction
 
 
 function! s:IdentifierFinishedOperations()
-  if !pyeval( 'ycm.CurrentIdentifierFinished()' )
+  if !py3eval( 'ycm.CurrentIdentifierFinished()' )
     return
   endif
-  py ycm_state.OnCurrentIdentifierFinished()
+  py3 ycm_state.OnCurrentIdentifierFinished()
   let s:omnifunc_mode = 0
 endfunction
 
@@ -376,7 +376,7 @@ endfunction
 
 
 function! s:OnBlankLine()
-  return pyeval( 'not vim.current.line or vim.current.line.isspace()' )
+  return py3eval( 'not vim.current.line or vim.current.line.isspace()' )
 endfunction
 
 
@@ -414,24 +414,24 @@ endfunction
 
 function! s:CompletionsForQuery( query, use_filetype_completer )
   if a:use_filetype_completer
-    py completer = ycm_state.GetFiletypeCompleter()
+    py3 completer = ycm_state.GetFiletypeCompleter()
   else
-    py completer = ycm_state.GetIdentifierCompleter()
+    py3 completer = ycm_state.GetIdentifierCompleter()
   endif
 
   " TODO: don't trigger on a dot inside a string constant
-  py completer.CandidatesForQueryAsync( vim.eval( 'a:query' ) )
+  py3 completer.CandidatesForQueryAsync( vim.eval( 'a:query' ) )
 
   let l:results_ready = 0
   while !l:results_ready
-    let l:results_ready = pyeval( 'completer.AsyncCandidateRequestReady()' )
+    let l:results_ready = py3eval( 'completer.AsyncCandidateRequestReady()' )
     if complete_check()
       let s:searched_and_results_found = 0
       return { 'words' : [], 'refresh' : 'always'}
     endif
   endwhile
 
-  let l:results = pyeval( 'completer.CandidatesFromStoredRequest()' )
+  let l:results = py3eval( 'completer.CandidatesFromStoredRequest()' )
   let s:searched_and_results_found = len( l:results ) != 0
   return { 'words' : l:results, 'refresh' : 'always' }
 endfunction
@@ -459,13 +459,13 @@ function! youcompleteme#Complete( findstart, base )
 
 
     " TODO: make this a function-local variable instead of a script-local one
-    let s:completion_start_column = pyeval( 'ycm.CompletionStartColumn()' )
+    let s:completion_start_column = py3eval( 'ycm.CompletionStartColumn()' )
     let s:should_use_filetype_completion =
-          \ pyeval( 'ycm_state.ShouldUseFiletypeCompleter(' .
+          \ py3eval( 'ycm_state.ShouldUseFiletypeCompleter(' .
           \ s:completion_start_column . ')' )
 
     if !s:should_use_filetype_completion &&
-          \ !pyeval( 'ycm_state.ShouldUseIdentifierCompleter(' .
+          \ !py3eval( 'ycm_state.ShouldUseIdentifierCompleter(' .
           \ s:completion_start_column . ')' )
       " for vim, -2 means not found but don't trigger an error message
       " see :h complete-functions
@@ -481,7 +481,7 @@ endfunction
 function! youcompleteme#OmniComplete( findstart, base )
   if a:findstart
     let s:omnifunc_mode = 1
-    let s:completion_start_column = pyeval( 'ycm.CompletionStartColumn()' )
+    let s:completion_start_column = py3eval( 'ycm.CompletionStartColumn()' )
     return s:completion_start_column
   else
     return s:CompletionsForQuery( a:base, 1 )
@@ -490,7 +490,7 @@ endfunction
 
 
 function! s:ShowDetailedDiagnostic()
-  py ycm_state.ShowDetailedDiagnostic()
+  py3 ycm_state.ShowDetailedDiagnostic()
 endfunction
 
 command! YcmShowDetailedDiagnostic call s:ShowDetailedDiagnostic()
@@ -500,13 +500,13 @@ command! YcmShowDetailedDiagnostic call s:ShowDetailedDiagnostic()
 " required (currently that's on buffer save) OR when the SyntasticCheck command
 " is invoked
 function! youcompleteme#CurrentFileDiagnostics()
-  return pyeval( 'ycm_state.GetDiagnosticsForCurrentFile()' )
+  return py3eval( 'ycm_state.GetDiagnosticsForCurrentFile()' )
 endfunction
 
 
 function! s:DebugInfo()
   echom "Printing YouCompleteMe debug information..."
-  let debug_info = pyeval( 'ycm_state.DebugInfo()' )
+  let debug_info = py3eval( 'ycm_state.DebugInfo()' )
   for line in split( debug_info, "\n" )
     echom '-- ' . line
   endfor
@@ -526,16 +526,16 @@ function! s:CompleterCommand(...)
 
   if a:0 > 0 && strpart(a:1, 0, 3) == 'ft='
     if a:1 == 'ft=ycm:omni'
-      py completer = ycm_state.GetOmniCompleter()
+      py3 completer = ycm_state.GetOmniCompleter()
     elseif a:1 == 'ft=ycm:ident'
-      py completer = ycm_state.GetIdentifierCompleter()
+      py3 completer = ycm_state.GetIdentifierCompleter()
     else
-      py completer = ycm_state.GetFiletypeCompleterForFiletype(
+      py3 completer = ycm_state.GetFiletypeCompleterForFiletype(
                    \ vim.eval('a:1').lstrip('ft=') )
     endif
     let arguments = arguments[1:]
-  elseif pyeval( 'ycm_state.NativeFiletypeCompletionAvailable()' )
-    py completer = ycm_state.GetFiletypeCompleter()
+  elseif py3eval( 'ycm_state.NativeFiletypeCompletionAvailable()' )
+    py3 completer = ycm_state.GetFiletypeCompleter()
   else
     echohl WarningMsg |
       \ echomsg "No native completer found for current buffer." |
@@ -544,28 +544,28 @@ function! s:CompleterCommand(...)
     return
   endif
 
-  py completer.OnUserCommand( vim.eval( 'l:arguments' ) )
+  py3 completer.OnUserCommand( vim.eval( 'l:arguments' ) )
 endfunction
 
 command! -nargs=* YcmCompleter call s:CompleterCommand(<f-args>)
 
 function! s:ForceCompile()
-  if !pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
+  if !py3eval( 'ycm_state.NativeFiletypeCompletionUsable()' )
     echom "Native filetype completion not supported for current file, "
           \ . "cannot force recompilation."
     return 0
   endif
 
   echom "Forcing compilation, this will block Vim until done."
-  py ycm_state.OnFileReadyToParse()
+  py3 ycm_state.OnFileReadyToParse()
   while 1
-    let diagnostics_ready = pyeval(
+    let diagnostics_ready = py3eval(
           \ 'ycm_state.DiagnosticsForCurrentFileReady()' )
     if diagnostics_ready
       break
     endif
 
-    let getting_completions = pyeval(
+    let getting_completions = py3eval(
           \ 'ycm_state.GettingCompletions()' )
 
     if !getting_completions
@@ -598,7 +598,7 @@ function! s:ShowDiagnostics()
     return
   endif
 
-  let diags = pyeval( 'ycm_state.GetDiagnosticsForCurrentFile()' )
+  let diags = py3eval( 'ycm_state.GetDiagnosticsForCurrentFile()' )
   if !empty( diags )
     call setloclist( 0, diags )
     lopen

--- a/cpp/BoostParts/CMakeLists.txt
+++ b/cpp/BoostParts/CMakeLists.txt
@@ -28,12 +28,6 @@ project( BoostParts )
 set( Python_ADDITIONAL_VERSIONS 2.7 2.6 2.5 )
 find_package( PythonLibs 2.5 REQUIRED )
 
-if ( NOT PYTHONLIBS_VERSION_STRING VERSION_LESS "3.0.0" )
-  message( FATAL_ERROR
-    "CMake found python3 libs instead of python2 libs. YCM works only with "
-    "python2.\n" )
-endif()
-
 file( GLOB_RECURSE SOURCES *.cpp )
 
 # We need to remove all the thread cpp files and then add them on a per-platform

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -22,12 +22,6 @@ project( ycm_core )
 set( Python_ADDITIONAL_VERSIONS 2.7 2.6 2.5 )
 find_package( PythonLibs 2.5 REQUIRED )
 
-if ( NOT PYTHONLIBS_VERSION_STRING VERSION_LESS "3.0.0" )
-  message( FATAL_ERROR
-    "CMake found python3 libs instead of python2 libs. YCM works only with "
-    "python2.\n" )
-endif()
-
 option( USE_CLANG_COMPLETER "Use Clang semantic completer for C/C++/ObjC" OFF )
 option( PATH_TO_LLVM_ROOT "Path to the root of a LLVM+Clang binary distribution" )
 option( USE_SYSTEM_LIBCLANG "Set to ON to use the system libclang library" OFF )

--- a/python/completers/completer.py
+++ b/python/completers/completer.py
@@ -308,7 +308,7 @@ def TriggersForFiletype():
   triggers = vim.eval( 'g:ycm_semantic_triggers' )
   triggers_for_filetype = defaultdict( list )
 
-  for key, value in triggers.iteritems():
+  for key, value in triggers.items():
     filetypes = key.split( ',' )
     for filetype in filetypes:
       triggers_for_filetype[ filetype ].extend( value )

--- a/python/completers/cpp/clang_completer.py
+++ b/python/completers/cpp/clang_completer.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 import vim
 import vimsupport
 import ycm_core
-from flags import Flags
+from completers.cpp.flags import Flags
 
 CLANG_FILETYPES = set( [ 'c', 'cpp', 'objc', 'objcpp' ] )
 MAX_DIAGNOSTICS_TO_DISPLAY = int( vimsupport.GetVariableValue(

--- a/python/completers/cpp/flags.py
+++ b/python/completers/cpp/flags.py
@@ -54,7 +54,7 @@ class Flags( object ):
     order and return the filename of the first module that was allowed to load.
     If no module was found or allowed to load, None is returned."""
 
-    if not self.module_for_file.has_key( filename ):
+    if not filename in self.module_for_file:
       for flags_module_file in _FlagsModuleSourceFilesForFile( filename ):
         if self.modules.Load( flags_module_file ):
           self.module_for_file[ filename ] = flags_module_file
@@ -92,7 +92,7 @@ class Flags( object ):
 
     module_file = os.path.abspath(module_file)
     if self.modules.Reload( module_file ):
-      for filename, module in self.module_for_file.iteritems():
+      for filename, module in self.module_for_file.items():
         if module == module_file:
           del self.flags_for_file[ filename ]
       return True
@@ -135,7 +135,7 @@ class FlagsModules( object ):
     This will return None if the module was not allowed to be loaded."""
 
     if not force:
-      if self.modules.has_key( module_file ):
+      if module_file in self.modules:
         return self.modules[ module_file ]
 
       if not self.ShouldLoad( module_file ):
@@ -184,7 +184,7 @@ def _PathsToAllParentFolders( filename ):
   if not parent_folders[0]:
     parent_folders[0] = os.path.sep
   parent_folders = [ os.path.join( *parent_folders[:i + 1] )
-                     for i in xrange( len( parent_folders ) ) ]
+                     for i in range( len( parent_folders ) ) ]
   return reversed( parent_folders )
 
 


### PR DESCRIPTION
I'm making this pull request more as a request / proof of concept that this works. If this wasn't the right thing to do, sorry in advance.

Anyhow, I mainly do my python dev with python3. Since this plugin runs as python2, the jedi competer is not particularily useful to me unless it runs as python3.

So I ported YouCompleteMe to run with python3. This, atm, makes it impossible to run it with python2, but it could work in theory. Everything tested works, and jedi completes as python3.

I'm not sure how to improve this so it can exist side-by-side with the existing python2 support, but I thought it might be worth sharing. Any pointers to improve this would be appreciated if you're interested in this at all.
