### PR TITLE
Make identifier chars configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,22 @@ Default: `[see next line]`
       \   'erlang' : [':'],
       \ }
 
+### The `g:ycm_identifier_chars` option
+
+This option controls which non-alphanumeric characters are allowed in
+identifiers for the various completion engines. YouCompleteMe will use
+everything from the last disallowed char to your cursor position as the input
+to completion engines.
+
+For example, given `object.method_|` (| being the cursor position), and the
+default `g:ycm_identifier_chars = '_'`, `method_` will be used as the search
+string. Or, given `namespace/a-clojure-me|` and `g:ycm_identifier_chars = '-_'`
+`a-clojure-me` will be the search string.
+
+Default: `'_'`
+
+    let g:ycm_identifier_chars = '_'
+
 FAQ
 ---
 

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -133,6 +133,9 @@ let g:ycm_semantic_triggers =
       \   'erlang' : [':'],
       \ } )
 
+let g:ycm_identifier_chars =
+      \ get( g:, 'ycm_identifier_chars', '_' )
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart

--- a/python/ycm_utils.py
+++ b/python/ycm_utils.py
@@ -16,9 +16,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+from vimsupport import GetVariableValue
 
 def IsIdentifierChar( char ):
-  return char.isalnum() or char == '_'
+  return char.isalnum() or char in GetVariableValue( "g:ycm_identifier_chars" )
 
 
 def SanitizeQuery( query ):


### PR DESCRIPTION
Some languages allow more non-alphabetic characters in identifiers than just `'_'`. This pull request allows the user to configure which non-alphabetic chars should be accepted as part of identifiers.

For example for clojure development I set this to `'_-/.><'`.

I went for the simplest solution here, but it might be worth it to make it a regex. I can make that change if it's preferred.
