### PR TITLE
fix jedi completions request

### DIFF
--- a/python/completers/python/jedi_completer.py
+++ b/python/completers/python/jedi_completer.py
@@ -71,11 +71,7 @@ class JediCompleter( Completer ):
 
 
   def AsyncCandidateRequestReadyInner( self ):
-    if self._completion_thread.is_alive():
-      return WaitAndClear( self._candidates_ready, timeout=0.005 )
-    else:
-      self._start_completion_thread()
-      return False
+    return self._candidates_ready.is_set()
 
 
   def CandidatesFromStoredRequestInner( self ):


### PR DESCRIPTION
Current threads implementation in Jedi completer makes an event loop in `SetCandidates` method which waits for a `query_ready` flag to set.

This means that this thread is always alive, so `self._completion_thread.is_alive()` always returns `True` and else clause never runs ( which is good, because if it will run it will make more and more daemon threads because of `_start_completion_thread()` call).

So, obvious fix is to just return `Set` flag of `_candidates_ready` event which is always set when thread done all the work and reset on CandidatesForQuery method call. Also it should speed things up a little
