### PR TITLE
Do not cache omnifunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,18 @@ Default: `[see next line]`
       \   'erlang' : [':'],
       \ }
 
+### The `g:ycm_cache_omnifunc` option
+
+Some omnicompletion engines do not work well with the YCM cache - in
+particular, they might not produce all possible results for a given prefix. By
+unsetting this option you can ensure that the omnicompletion engine is
+requeried on every keypress. That will ensure all completions will be
+presented, but might cause stuttering and lagginess if the omnifunc is slow.
+
+Default: `1`
+
+    let g:ycm_cache_omnifunc = 1
+
 FAQ
 ---
 

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -133,6 +133,8 @@ let g:ycm_semantic_triggers =
       \   'erlang' : [':'],
       \ } )
 
+let g:ycm_cache_omnifunc = 1
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart

--- a/python/completers/all/omni_completer.py
+++ b/python/completers/all/omni_completer.py
@@ -36,11 +36,27 @@ class OmniCompleter( Completer ):
     return []
 
 
+  def ShouldUseCache( self ):
+    return vimsupport.GetBoolValue( "g:ycm_cache_omnifunc" )
+
+
+  def ShouldUseNow( self, start_column ):
+    if self.ShouldUseCache():
+      return super( OmniCompleter, self ).ShouldUseNow( start_column )
+    return self.ShouldUseNowInner( start_column )
+
   def ShouldUseNowInner( self, start_column ):
     if not self.omnifunc:
       return False
     return super( OmniCompleter, self ).ShouldUseNowInner( start_column )
 
+
+  def CandidatesForQueryAsync( self, query, unused_start_column ):
+    if self.ShouldUseCache():
+      return super( OmniCompleter, self ).CandidatesForQueryAsync(
+          query, unused_start_column )
+    else:
+      return self.CandidatesForQueryAsyncInner( query, unused_start_column )
 
   def CandidatesForQueryAsyncInner( self, query, unused_start_column ):
     if not self.omnifunc:
@@ -80,6 +96,12 @@ class OmniCompleter( Completer ):
   def OnFileReadyToParse( self ):
     self.omnifunc = vim.eval( '&omnifunc' )
 
+
+  def CandidatesFromStoredRequest( self ):
+    if self.ShouldUseCache():
+      return super( OmniCompleter, self ).CandidatesFromStoredRequest()
+    else:
+      return self.CandidatesFromStoredRequestInner()
 
   def CandidatesFromStoredRequestInner( self ):
     return self.stored_candidates if self.stored_candidates else []


### PR DESCRIPTION
This is a continuation of #236 that makes caching in the omni_completer optional.

It's a bit of a hack - the right solution would be either:
- to allow specifying a set of characters that invalidate the completion cache but do not end an identifier (thus causing the completion engine to be re-queried with `"foo/"` instead of `""` when `/` is pressed - or `.`, `->` etc.). Still hackish, but less performance impact than this change.
- Or even better, to respect the return values from `omnifunc(find_start=1,"")` - which I tried to implement but found it a bit tricky. The `FindCompletionStart` function would have to be moved into a `Completer`, which probably means the `ShouldUseNow` functions should not take position any more (thus allowing the vim plugin to select a completer first, then query it for a starting position)... All in all, more of a change than I'm willing to undertake right now.

I based this on top of #236 because it's not very useful otherwise, but can rebase on top of master if desired.
