### PR TITLE
Fix completing strings with a dash symbol

### DIFF
--- a/python/ycm_utils.py
+++ b/python/ycm_utils.py
@@ -18,7 +18,7 @@
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
 def IsIdentifierChar( char ):
-  return char.isalnum() or char == '_'
+  return char.isalnum() or char == '_' or char == '-'
 
 
 def SanitizeQuery( query ):


### PR DESCRIPTION
When string has a dash symbol ycm.CompletionStartColumn() method returned a index of a dash. It acts as a trigger, so completer thought that he must get a query after dash.

This actually affects not only filename completer, but all completers. 

This patch fixes this problem. However, one issue still left. Consider following string: `~/.vim/bundle/-^`, where ^ is a cursor position. This will not return any completions, but if we add anything after dash it will work fine.

Partially fixes #281
