### PR TITLE
fix IndexError when min_num_of_chars is set to 0

### DIFF
--- a/python/completers/general/filename_completer.py
+++ b/python/completers/general/filename_completer.py
@@ -63,8 +63,8 @@ class FilenameCompleter( ThreadedCompleter ):
 
 
   def ShouldUseNowInner( self, start_column ):
-    return ( vim.current.line[ start_column - 1 ] == '/' or
-             self.AtIncludeStatementStart( start_column ) )
+    return ( start_column and ( vim.current.line[ start_column - 1 ] == '/' or
+             self.AtIncludeStatementStart( start_column ) ) )
 
 
   def SupportedFiletypes( self ):


### PR DESCRIPTION
Fixes #307. 

Error is thrown when `g:ycm_min_num_of_chars_for_completion` option is set to 0 or 1 and user tries to delete an identifier which starts at the beginning of the line.
