### PR TITLE
Fix FilterAndSortCandidates behavior

### DIFF
--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -65,16 +65,7 @@ boost::python::list FilterAndSortCandidates(
   pylist filtered_candidates;
 
   if ( query.empty() ) {
-    if ( candidate_property.empty() )
       return candidates;
-
-    int num_candidates = len( candidates );
-
-    for ( int i = 0; i < num_candidates; ++i ) {
-      filtered_candidates.append( candidates[ i ][ candidate_property ] );
-    }
-
-    return filtered_candidates;
   }
 
   std::vector< const Candidate * > repository_candidates =


### PR DESCRIPTION
While working on #307 i've noticed another bug. When `g:ycm_min_num_of_chars_for_completion` is set to 0 ultisnips_completer returns a list instead of dict, so the `<snip>` type and description is abscent. Check the screenshot:

![wrong](https://f.cloud.github.com/assets/1290755/484046/7f7c89b8-b8cf-11e2-82b7-26147004ae48.jpg)

This problem was introduced in c3b7e5576258d956a8b059b0ee86f147d67e6fb5. Currently  `FilterAndSortCandidates(data, 'word', '')` when `data` type is dict returns a list ( generated from `'word'` dict key ) while  `FilterAndSortCandidates(data, '', '')` is working as intended ( returns `data` ).
