### PR TITLE
Add spell_completer

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -130,6 +130,12 @@ let g:ycm_extra_conf_globlist =
 let g:ycm_filepath_completion_use_working_dir =
       \ get( g:, 'ycm_filepath_completion_use_working_dir', 0 )
 
+let g:ycm_spellsuggest_enable =
+      \ get( g:, 'g:ycm_spellsuggest_enable', 1 )
+
+let g:ycm_spellsuggest_max_candidates =
+      \ get( g:, 'g:ycm_spellsuggest_max_candidates', 5 )
+
 let g:ycm_semantic_triggers =
       \ get( g:, 'ycm_semantic_triggers', {
       \   'c' : ['->', '.'],

--- a/python/completers/general/general_completer_store.py
+++ b/python/completers/general/general_completer_store.py
@@ -21,6 +21,7 @@
 from completers.completer import Completer
 from completers.all.identifier_completer import IdentifierCompleter
 from filename_completer import FilenameCompleter
+from spell_completer import SpellCompleter
 
 try:
   from ultisnips_completer import UltiSnipsCompleter
@@ -42,14 +43,17 @@ class GeneralCompleterStore( Completer ):
     super( GeneralCompleterStore, self ).__init__()
     self._identifier_completer = IdentifierCompleter()
     self._filename_completer = FilenameCompleter()
+    self._spell_completer = SpellCompleter()
     self._ultisnips_completer = ( UltiSnipsCompleter()
                                   if USE_ULTISNIPS_COMPLETER else None )
     self._non_filename_completers = filter( lambda x: x,
                                             [ self._ultisnips_completer,
+                                              self._spell_completer,
                                               self._identifier_completer ] )
     self._all_completers = filter( lambda x: x,
                                    [ self._identifier_completer,
                                      self._filename_completer,
+                                     self._spell_completer,
                                      self._ultisnips_completer ] )
     self._current_query_completers = []
 

--- a/python/completers/general/spell_completer.py
+++ b/python/completers/general/spell_completer.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2013 Zhao Cai <caizhaoff@gmail.com>
+#                    Strahinja Val Markovic  <val@markovic.io>
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from completers.general_completer import GeneralCompleter
+import vim
+import vimsupport
+
+
+class SpellCompleter( GeneralCompleter ):
+  """
+  General completer that provides spell suggestions completions.
+  """
+
+  def __init__( self ):
+    super( SpellCompleter, self ).__init__()
+    self._candidates = []
+
+
+  def ShouldUseNowInner( self, start_column ):
+    return self.QueryLengthAboveMinThreshold( start_column ) and self.is_spell_on()
+
+
+  def SupportedFiletypes( self ):
+    return []
+
+
+  def CandidatesForQueryAsync( self, query, unused_start_column ):
+    self._candidates = self._GetCandidates(query)
+
+
+
+  def AsyncCandidateRequestReady( self ):
+    return True
+
+
+  def CandidatesFromStoredRequest( self ):
+    return self._candidates
+
+
+  def _GetCandidates( self, query):
+    return  [ { 'word': str( ss ),
+                'menu': str( '<spell> ' + ss ) }
+              for ss in vim.eval('spellsuggest("'
+                + vimsupport.EscapeForVim( query )
+                + '", ' + self.max_candidates()
+                + ')')
+            ]
+
+  @classmethod
+  def is_spell_on(cls):
+    return vimsupport.GetBoolValue('&spell') and vimsupport.GetBoolValue('g:ycm_spellsuggest_enable')
+
+  @classmethod
+  def max_candidates(cls):
+    return vimsupport.GetVariableValue('g:ycm_spellsuggest_max_candidates')


### PR DESCRIPTION
It is enabled only when `g:ycm_spellsuggest_enable` and `&spell`. Good for people who do not always spells correctly. 

I do not know how ( and necessary ) to make this async.

add two options 
- g:ycm_spellsuggest_enable
- g:ycm_spellsuggest_max_candidates
