### PR TITLE
Switch to upstream Jedi API

### DIFF
--- a/python/completers/python/jedi_completer.py
+++ b/python/completers/python/jedi_completer.py
@@ -123,9 +123,9 @@ class JediCompleter( ThreadedCompleter ):
     script = self._GetJediScript()
     try:
       if declaration:
-        definitions = script.get_definition()
+        definitions = script.goto_definitions()
       else:
-        definitions = script.goto()
+        definitions = script.goto_assignments()
     except jedi.NotFoundError:
       vimsupport.PostVimMessage(
                   "Cannot follow nothing. Put your cursor on a valid name." )
@@ -140,7 +140,7 @@ class JediCompleter( ThreadedCompleter ):
     if len( definition_list ) == 1:
       definition = definition_list[ 0 ]
       if definition.in_builtin_module():
-        if isinstance( definition.definition, jedi.keywords.Keyword ):
+        if isinstance( definition.name, jedi.keywords.Keyword ):
           vimsupport.PostVimMessage(
                   "Cannot get the definition of Python keywords." )
         else:


### PR DESCRIPTION
This replaces deprecated API calls to the new ones. Also this partially fixes #320 by replacing removed `definition` attr with a `name` attr.

However, `isinstance( definition.name, jedi.keywords.Keyword )` still needs a `is_keyword` property, as mentioned. For now it will always return `Builtin modules cannot be displayed` error, whether it's a keyword or not.
