### PR TITLE
Fix errors when building on Windows with VS

### DIFF
--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -59,13 +59,15 @@ public:
                                std::vector< Result > &results ) const;
 
 private:
-  std::list< const Candidate * > &GetCandidateList(
+  std::list< const Candidate *,
+    std::allocator < const Candidate * > > &GetCandidateList(
     const std::string &filetype,
     const std::string &filepath );
 
   // filepath -> *( *candidate )
   typedef boost::unordered_map < std::string,
-          boost::shared_ptr< std::list< const Candidate * > > >
+          boost::shared_ptr< std::list< const Candidate *,
+          std::allocator < const Candidate * > > > >
           FilepathToCandidates;
 
   // filetype -> *( filepath -> *( *candidate ) )


### PR DESCRIPTION
The problem was introduced in 2805b0fe856a66ee80e0b7ff8d7bf9577f87daf5. Compilation ( using VS 10 ) fails with a bunch of weird errors ( sorry for screenshot but its more understandable than log ):

![errors](https://f.cloud.github.com/assets/1290755/565163/e58bea9c-c5e9-11e2-9a94-e7e25a8bd358.png)

This patch fixes this errors but i didnt test it on Linux ( yet ).
