### PR TITLE
Fixed compilation under MSVC(11) 

### DIFF
--- a/cpp/BoostParts/CMakeLists.txt
+++ b/cpp/BoostParts/CMakeLists.txt
@@ -115,8 +115,6 @@ endif()
 
 # Special compiler and linker flags for MSVC
 if( MSVC )
-    add_definitions( /DUNICODE /D_UNICODE /Zc:wchar_t-  )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP" )
     set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oi /GL" )
     set_target_properties( ${PROJECT_NAME} PROPERTIES STATIC_LIBRARY_FLAGS "/LTCG" )
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -82,6 +82,12 @@ elseif( COMPILER_IS_CLANG )
   set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++" )
 endif()
 
+# For MSVC enable UNICODE and compilation on multiple processors
+if( MSVC )
+  add_definitions( /DUNICODE /D_UNICODE /Zc:wchar_t-  )
+	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP" )
+endif()
+
 # When used with Clang, adding the -std=c++0x flag to CMAKE_CXX_FLAGS will cause
 # the compiler to output a warning during linking:
 #  clang: warning: argument unused during compilation: '-std=c++0x'

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -29,9 +29,9 @@ if ( NOT PYTHONLIBS_VERSION_STRING VERSION_LESS "3.0.0" )
 endif()
 
 option( USE_CLANG_COMPLETER "Use Clang semantic completer for C/C++/ObjC" OFF )
-option( PATH_TO_LLVM_ROOT "Path to the root of a LLVM+Clang binary distribution" )
 option( USE_SYSTEM_LIBCLANG "Set to ON to use the system libclang library" OFF )
-option( EXTERNAL_LIBCLANG_PATH "Path libclang library to use" )
+set( PATH_TO_LLVM_ROOT "" CACHE PATH "Path to the root of a LLVM+Clang binary distribution" )
+set( EXTERNAL_LIBCLANG_PATH "" CACHE PATH  "Path libclang library to use" )
 
 if ( USE_CLANG_COMPLETER AND NOT USE_SYSTEM_LIBCLANG AND NOT PATH_TO_LLVM_ROOT )
   message( "Downloading Clang 3.2" )
@@ -104,7 +104,7 @@ endif()
 
 if ( NOT EXTERNAL_LIBCLANG_PATH AND PATH_TO_LLVM_ROOT )
   # Need TEMP because find_library does not work with an option variable
-  find_library( TEMP clang
+  find_library( TEMP NAMES clang libclang
                 PATHS ${PATH_TO_LLVM_ROOT}/lib
                 NO_DEFAULT_PATH )
   set( EXTERNAL_LIBCLANG_PATH ${TEMP} )
@@ -231,12 +231,19 @@ target_link_libraries( ${PROJECT_NAME}
                        ${EXTRA_LIBS}
                      )
 
-if ( LIBCLANG_TARGET )
-  add_custom_command(
-    TARGET ${PROJECT_NAME}
-    POST_BUILD
-    COMMAND cp "${LIBCLANG_TARGET}" "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
-  )
+if( LIBCLANG_TARGET )
+  if( NOT WIN32 )
+    add_custom_command(
+      TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy "${LIBCLANG_TARGET}" "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+    )
+  else()
+    add_custom_command(
+      TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy "${PATH_TO_LLVM_ROOT}/bin/libclang.dll" "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+  endif()
 endif()
 
 #############################################################################

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -166,7 +166,7 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
       continue;
 
     std::string identifier( matches[ 1 ] );
-    fs::path path( matches[ 2 ] );
+    fs::path path( matches[ 2 ].str() );
 
     if ( path.is_relative() )
       path = path_to_tag_file.parent_path() / path;


### PR DESCRIPTION
- compile both libs with /UNICODE and /MP
- moved shared flags & defines to root CMakeLists.txt
- fixed resolving EXTERNAL_LIBCLANG_PATH on Windows
- postbuild copy of libclang.dll
- change PATH_TO_LLVM_ROOT & EXTERNAL_LIBCLANG_PATH to PATH variables instead of BOOL options (for cmake-gui)
