### PR TITLE
Add mono to command OmniSharpServer for non-windows systems

### DIFF
--- a/python/ycm/completers/cs/cs_completer.py
+++ b/python/ycm/completers/cs/cs_completer.py
@@ -122,7 +122,7 @@ class CsharpCompleter( ThreadedCompleter ):
       vimsupport.PostVimMessage( SERVER_NOT_FOUND_MSG.format( omnisharp ) )
       return
 
-    if not platform.startswith('win'):
+    if not platform.startswith( 'win' ):
       omnisharp = "mono " + omnisharp
 
     solutionfile = os.path.join( folder, solutionfile )


### PR DESCRIPTION
Not all Unix systems can execute .NET binaries. To solve this problem OmniSharp plugin use this approach: https://github.com/nosami/Omnisharp/blob/master/autoload/OmniSharp.vim#L276
I just translated that into python.
