### PR TITLE
Multiple instances of semantic completer

### DIFF
--- a/python/ycm/completers/cs/cs_completer.py
+++ b/python/ycm/completers/cs/cs_completer.py
@@ -51,7 +51,8 @@ class CsharpCompleter( ThreadedCompleter ):
 
 
   def OnVimLeave( self ):
-    if vimsupport.GetBoolValue( 'g:ycm_auto_stop_csharp_server' ) and self._ServerIsRunning():
+    if (vimsupport.GetBoolValue( 'g:ycm_auto_stop_csharp_server' )
+        and self._ServerIsRunning()):
       self._StopServer()
 
 
@@ -91,9 +92,10 @@ class CsharpCompleter( ThreadedCompleter ):
 
   def DebugInfo( self ):
     if self._ServerIsRunning():
-      return "Logfiles:\n{}\n{}".format(self._filename_stdout, self._filename_stderr)
+      return 'Logfiles:\n{}\n{}'.format(
+          self._filename_stdout, self._filename_stderr )
     else:
-      return "Server is not running"
+      return 'Server is not running'
 
 
   def _StartServer( self ):
@@ -134,11 +136,12 @@ class CsharpCompleter( ThreadedCompleter ):
     command = [ omnisharp + ' -p ' + str( self._omnisharp_port ) + ' -s ' +
                 path_to_solutionfile ]
 
-    filename_format = tempfile.gettempdir() + '/omnisharp_{port}_{sln}_{std}.log'
+    filename_format = ( tempfile.gettempdir()
+        + '/omnisharp_{port}_{sln}_{std}.log' )
     self._filename_stdout = filename_format.format(
-        port=self._omnisharp_port, sln=solutionfile, std='stdout')
+        port=self._omnisharp_port, sln=solutionfile, std='stdout' )
     self._filename_stderr = filename_format.format(
-        port=self._omnisharp_port, sln=solutionfile, std='stderr')
+        port=self._omnisharp_port, sln=solutionfile, std='stderr' )
 
     with open( self._filename_stderr, 'w' ) as fstderr:
       with open( self._filename_stdout, 'w' ) as fstdout:
@@ -157,13 +160,14 @@ class CsharpCompleter( ThreadedCompleter ):
 
   def _ServerIsRunning( self, port=None ):
     """ Check if the OmniSharp server is running """
-    return self._GetResponse( '/checkalivestatus', silent=True, port=port) != None
+    return self._GetResponse( '/checkalivestatus',
+        silent=True, port=port ) != None
 
 
   def _FindFreePort( self ):
     """ Find port without an omnisharp instance running on it """
     port = self._omnisharp_port
-    while self._ServerIsRunning(port):
+    while self._ServerIsRunning( port ):
       port += 1
     return port
 
@@ -179,17 +183,17 @@ class CsharpCompleter( ThreadedCompleter ):
     line, column = vimsupport.CurrentLineAndColumn()
 
     parameters = {}
-    parameters['line'], parameters['column'] = line + 1, column + 1
-    parameters['buffer'] = '\n'.join( vim.current.buffer )
-    parameters['filename'] = vim.current.buffer.name
+    parameters[ 'line' ], parameters[ 'column' ] = line + 1, column + 1
+    parameters[ 'buffer' ] = '\n'.join( vim.current.buffer )
+    parameters[ 'filename' ] = vim.current.buffer.name
 
     completions = self._GetResponse( '/autocomplete', parameters )
     return completions if completions != None else []
 
 
-  def _GetResponse( self, endPoint, parameters={}, silent=False, port=None):
+  def _GetResponse( self, endPoint, parameters={}, silent=False, port=None ):
     """ Handle communication with server """
-    target = urlparse.urljoin( self._PortToHost(port), endPoint )
+    target = urlparse.urljoin( self._PortToHost( port ), endPoint )
     parameters = urllib.urlencode( parameters )
     try:
       response = urllib2.urlopen( target, parameters )
@@ -210,4 +214,3 @@ def _FindSolutionFiles():
       break
     solutionfiles = glob.glob1( folder, '*.sln' )
   return solutionfiles, folder
-


### PR DESCRIPTION
While the previous PR was still pending I got PR's from @mispencer, two of which included here.
This PR brings two features:
- Enable redirecting the server output to files instead of /dev/null in order to make debugging easier.
- Enable multiple instances of the completion server (at different ports) to allow working on different projects at the same time.

Especially the latter problem is rather tricky, and its hard to say if the offered solutions are the best ones, so I suppose this will require some discussion.

To redirect the server output, two new vim variables are introduced allowing the user to specify the file name for the stderr and the stdout. An alternative solution could be to have fixed file names (parametrized by the port number) in some log directory. This would remove the need for two new vim variables. I don't know which solution is preferred.

To enable multiple instances of the completion server, the completer tries to find a new port by scanning upwards from the initial port until a port is found with no omnisharp instance running on it. This will work almost always. But this does not cover the case where a different application is using one of those ports. It appears to be rather tricky to solve this neatly. 
- You cannot determine the free port in the python script, and pass it to the server, because in the meanwhile another application could have taken the port.
- You cannot let the server choose a port, because then the port is unknown to the script.

We could use a trial-on-error approach and pay attention to the stderr of the completion server. This sounds rather difficult and messy to me though. Any thoughts about this?

Although this PR specifically applies to the C# completer, I suppose that other future completers with a client-server architecture are likely to encounter these same problems so it might be worth it to solve these problems thoroughly.
