### PR TITLE
Add MinGW-64 support

### DIFF
--- a/cpp/BoostParts/CMakeLists.txt
+++ b/cpp/BoostParts/CMakeLists.txt
@@ -96,18 +96,23 @@ endif()
 
 # Solves the conflict in names of hypot in python sources and boost::python
 if( MINGW )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cmath")
+  set(CXX_FLAGS "${CXX_FLAGS} -include cmath")
 endif()
 
-include_directories(
-  SYSTEM
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${PYTHON_INCLUDE_DIRS}
-  )
+if( SYSTEM_IS_SUNOS )
+  # SunOS needs this setting for thread support
+  set(CXX_FLAGS "${CXX_FLAGS} -pthreads")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS}")
+
+include_directories(SYSTEM
+                    ${CMAKE_CURRENT_SOURCE_DIR}
+                    ${PYTHON_INCLUDE_DIRS})
 
 add_definitions(${DEFENITIONS})
 
-add_library( BoostParts ${SOURCES} )
+add_library(BoostParts ${SOURCES})
 
 #############################################################################
 
@@ -132,9 +137,7 @@ if( MSVC )
     set_target_properties( ${PROJECT_NAME} PROPERTIES STATIC_LIBRARY_FLAGS "/LTCG" )
 endif()
 
-if( SYSTEM_IS_SUNOS )
-  # SunOS needs this setting for thread support
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthreads" )
-endif()
 
+# Export the module configurations
+set(BoostParts_CXX_FLAGS   "${CXX_FLAGS}"   CACHE INTERNAL "BoostParts cxx falgs")
 set(BoostParts_DEFENITIONS "${DEFENITIONS}" CACHE INTERNAL "BoostParts defenitions")

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -217,17 +217,14 @@ if ( UNIX AND NOT APPLE )
   set( EXTRA_LIBS rt )
 endif()
 
-# Solves the conflict in names of hypot in python sources and boost::python
-if( MINGW )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cmath")
-endif()
+# Import cxx flags from BoostParts module
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${BoostParts_CXX_FLAGS}")
 
 # Import defenitions from BoostParts module
 add_definitions(${BoostParts_DEFENITIONS})
 
-add_library( ${PROJECT_NAME} SHARED
-             ${SOURCES}
-           )
+add_library(${PROJECT_NAME} SHARED
+             ${SOURCES})
 
 target_link_libraries( ${PROJECT_NAME}
                        BoostParts
@@ -313,11 +310,6 @@ if ( COMPILER_IS_CLANG AND NOT CMAKE_GENERATOR_IS_XCODE AND NOT
 endif()
 
 #############################################################################
-
-if( SYSTEM_IS_SUNOS )
-  # SunOS needs this setting for thread support
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthreads" )
-endif()
 
 if (NOT MINGW)
   # Tests does not works properly for MinGW yet.


### PR DESCRIPTION
A few updates in 'CMakeLists.txt' to provide support of MinGW-64 and 64 bit Windows.

This is minor updates. I suggest further improvements of the build system of the project.
