### PR TITLE
Bug fix, was triggering an error in the command line edit window (ie. th...

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -164,7 +164,7 @@ endfunction
 
 
 function! s:AllowedToCompleteInCurrentFile()
-  if empty( &filetype )
+  if empty( &filetype ) || getbufvar(winbufnr(winnr()), "&buftype") ==# 'nofile'
     return 0
   endif
 


### PR DESCRIPTION
...e window you get by hitting c-f in command line) after not moving the cursor for a few seconds (ie. when CursorHold event is fired)

Not sure if everyone else is getting this error, but before this fix every time I tried editing something in the command line edit window I'd get the error 'undefined variable: b:ycm_changedtick' as well as a bunch of other errors.
