### PR TITLE
OmniSharp completer error message using incorrect naming format

### DIFF
--- a/python/ycm/completers/cs/cs_completer.py
+++ b/python/ycm/completers/cs/cs_completer.py
@@ -34,7 +34,7 @@ import tempfile
 
 SERVER_NOT_FOUND_MSG = ( 'OmniSharp server binary not found at {0}. ' +
 'Did you compile it? You can do so by running ' +
-'"./install.sh --omnisharp_completer".' )
+'"./install.sh --omnisharp-completer".' )
 
 class CsharpCompleter( ThreadedCompleter ):
   """


### PR DESCRIPTION
The not found message used to instruct users on how to install the OmniSharp completer was using an underscore while the argument for the install script uses a hyphen. The message now uses the correct naming format.
