### PR TITLE
Fix boost compilation issue with glibc 2.18

### DIFF
--- a/cpp/BoostParts/boost/cstdint.hpp
+++ b/cpp/BoostParts/boost/cstdint.hpp
@@ -41,7 +41,10 @@
 // so we disable use of stdint.h when GLIBC does not define __GLIBC_HAVE_LONG_LONG.
 // See https://svn.boost.org/trac/boost/ticket/3548 and http://sources.redhat.com/bugzilla/show_bug.cgi?id=10990
 //
-#if defined(BOOST_HAS_STDINT_H) && (!defined(__GLIBC__) || defined(__GLIBC_HAVE_LONG_LONG))
+#if defined(BOOST_HAS_STDINT_H)					\
+  && (!defined(__GLIBC__)					\
+      || defined(__GLIBC_HAVE_LONG_LONG)			\
+      || (defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 17)))))
 
 // The following #include is an implementation artifact; not part of interface.
 # ifdef __hpux


### PR DESCRIPTION
this fix issue 153 https://github.com/Valloric/YouCompleteMe/issues/513.
patch taken from boost upstream https://svn.boost.org/trac/boost/changeset/84950
