### PR TITLE
Allow empty &filetype and nofile.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -189,10 +189,6 @@ endfunction
 
 
 function! s:AllowedToCompleteInCurrentFile()
-  if empty( &filetype ) || getbufvar(winbufnr(winnr()), "&buftype") ==# 'nofile'
-    return 0
-  endif
-
   let whitelist_allows = has_key( g:ycm_filetype_whitelist, '*' ) ||
         \ has_key( g:ycm_filetype_whitelist, &filetype )
   let blacklist_allows = !has_key( g:ycm_filetype_blacklist, &filetype )


### PR DESCRIPTION
Some generic completers like untisnips and filename completers are useful everywhere. Also some of the special buffers like vimshell use buftype as `nofile`. The filename completer is quite useful. 
