### PR TITLE
Add Cmdline completion

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -100,6 +100,9 @@ let g:ycm_key_detailed_diagnostics =
 let g:ycm_cache_omnifunc =
       \ get( g:, 'ycm_cache_omnifunc', 1 )
 
+let g:ycm_key_cmdline_completion =
+      \ get( g:, 'ycm_key_cmdline_completion', ['<C-N>', '<C-P>'] )
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart

--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -71,6 +71,19 @@ def CompletionStartColumn():
   return start_column
 
 
+def CmdlineCompletionStartColumn():
+  """Returns the 0-based index where the completion string should start in the
+  cmdline.
+  """
+
+  line = vimsupport.CurrentCmdline()
+  start_column = vimsupport.CurrentCmdlineColumn()
+
+  while start_column > 0 and utils.IsIdentifierChar( line[ start_column - 1 ] ):
+    start_column -= 1
+  return start_column
+
+
 def CurrentIdentifierFinished():
   current_column = vimsupport.CurrentColumn()
   previous_char_index = current_column - 1

--- a/python/ycm/client/cmdline_completion_request.py
+++ b/python/ycm/client/cmdline_completion_request.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2013  Strahinja Val Markovic  <val@markovic.io>
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from ycm import base
+from ycm import vimsupport
+from ycm.client.base_request import ( BaseRequest, BuildRequestData,
+                                      JsonFromFuture )
+
+TIMEOUT_SECONDS = 0.5
+
+class CmdlineCompletionRequest( BaseRequest ):
+  def __init__( self ):
+    super( CmdlineCompletionRequest, self ).__init__()
+
+    self._completion_start_column = base.CmdlineCompletionStartColumn()
+
+    self.request_data = BuildRequestData( self._completion_start_column )
+    self.request_data[ 'line_value' ] = vimsupport.CurrentCmdline()
+    self.request_data[ 'column_num' ] = vimsupport.CurrentCmdlineColumn()
+
+
+  def CompletionStartColumn( self ):
+    return self._completion_start_column
+
+
+  def Start( self, query ):
+    self.request_data[ 'query' ] = query
+    self._response_future = self.PostDataToHandlerAsync( self.request_data,
+                                                         'completions',
+                                                         TIMEOUT_SECONDS )
+
+  def Done( self ):
+    return self._response_future.done()
+
+
+  def Response( self ):
+    if not self._response_future:
+      return []
+    try:
+      return [ completion_data[ 'insertion_text' ]
+               for completion_data in JsonFromFuture( self._response_future ) ]
+    except Exception as e:
+      vimsupport.PostVimMessage( str( e ) )
+    return []
+

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -30,6 +30,7 @@ from ycm.completers.completer_utils import FiletypeCompleterExistsForFiletype
 from ycm.client.base_request import BaseRequest, BuildRequestData
 from ycm.client.command_request import SendCommandRequest
 from ycm.client.completion_request import CompletionRequest
+from ycm.client.cmdline_completion_request import CmdlineCompletionRequest
 from ycm.client.omni_completion_request import OmniCompletionRequest
 from ycm.client.event_notification import ( SendEventNotificationAsync,
                                             EventNotification )
@@ -115,11 +116,17 @@ class YouCompleteMe( object ):
     self._SetupServer()
 
 
-  def CreateCompletionRequest( self, force_semantic = False ):
+  def CreateCompletionRequest( self,
+                               force_semantic = False,
+                               cmdline_completion = False ):
     # We have to store a reference to the newly created CompletionRequest
     # because VimScript can't store a reference to a Python object across
     # function calls... Thus we need to keep this request somewhere.
-    if ( not self.NativeFiletypeCompletionAvailable() and
+    if cmdline_completion:
+      self._latest_completion_request = ( CmdlineCompletionRequest()
+                                          if self._IsServerAlive() else
+                                          None )
+    elif ( not self.NativeFiletypeCompletionAvailable() and
          self.CurrentFiletypeCompletionEnabled() and
          self._omnicomp.ShouldUseNow() ):
       self._latest_completion_request = OmniCompletionRequest( self._omnicomp )


### PR DESCRIPTION
It works in the cmdline mode. For example, you are typing to replace `ycm` with `youcompleteme` with command `%s/ycm!youco^!gc`. The cursor is `^`, now you can hit `<C-N>` to get auto completion. Hit `<C-N>` or `<C-P>` to  choose next or previous candidates.
