### PR TITLE
Pass -DPYTHON flags to cmake

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,9 @@ for flag in $@; do
     --omnisharp-completer)
       omnisharp_completer=true
       ;;
+    -DPYTHON*)
+     cmake_args="$cmake_args $flag"
+     ;;
     *)
       usage
       ;;


### PR DESCRIPTION
This enables usage of non standard python installations such as those provided by pyenv
