### PR TITLE
add new flag to turn off default clang handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,18 @@ Default: `1`
 
     let g:ycm_cache_omnifunc = 1
 
+### The `g:ycm_use_custom_clang_handling` option
+
+By default ycm removes -arch flags and automatically adds the clang_includes
+directory to the include path. In cases where this is not desired (perhaps
+the -arch flag is needed to compile source files correctly, or one needs to
+include a different clang includes directory), this option can be used to 
+turn that off.
+
+Default: `0`
+
+    let g:ycm_use_custom_clang_handling = 0
+
 FAQ
 ---
 

--- a/python/ycm/completers/cpp/clang_completer.py
+++ b/python/ycm/completers/cpp/clang_completer.py
@@ -43,7 +43,7 @@ class ClangCompleter( Completer ):
     self._max_diagnostics_to_display = user_options[
       'max_diagnostics_to_display' ]
     self._completer = ycm_core.ClangCompleter()
-    self._flags = Flags()
+    self._flags = Flags(user_options['use_custom_clang_handling'])
     self._diagnostic_store = None
 
 

--- a/python/ycm/completers/general/filename_completer.py
+++ b/python/ycm/completers/general/filename_completer.py
@@ -31,7 +31,7 @@ class FilenameCompleter( Completer ):
 
   def __init__( self, user_options ):
     super( FilenameCompleter, self ).__init__( user_options )
-    self._flags = Flags()
+    self._flags = Flags(user_options['use_custom_clang_handling'])
 
     self._path_regex = re.compile( """
       # 1 or more 'D:/'-like token or '/' or '~' or './' or '../'

--- a/python/ycm/server/default_settings.json
+++ b/python/ycm/server/default_settings.json
@@ -15,6 +15,7 @@
   "complete_in_comments": 0,
   "complete_in_strings": 1,
   "max_diagnostics_to_display": 30,
+  "use_custom_clang_handling" : 0,
   "filetype_whitelist": {
     "*": 1
   },


### PR DESCRIPTION
ycm removes the -arch flag and adds clang_includes directory
for the common case. An option 'use_custom_clang_handling'
is added to turn this off in cases where the -arch flag is necessary
to compile source files correctly and .ycm_extra_conf.py specifies
an alternate clang_includes directory.
