### PR TITLE
Fix python subprocess call

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -101,9 +101,16 @@ class YouCompleteMe( object ):
 
         with open( self._server_stderr, 'w' ) as fstderr:
           with open( self._server_stdout, 'w' ) as fstdout:
+            startupinfo = None
+            if os.name == 'nt':
+              startupinfo = subprocess.STARTUPINFO()
+              startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             self._server_popen = subprocess.Popen( args,
+                                                   startupinfo = startupinfo,
+                                                   stdin = subprocess.PIPE,
                                                    stdout = fstdout,
                                                    stderr = fstderr )
+
     self._NotifyUserIfServerCrashed()
 
 


### PR DESCRIPTION
When the python subprocess call is made on windows, use stdin=subprocess.PIPE
and start the process minimized so that it does not encounter a bug in python or
take the foreground from vim

See: http://bugs.python.org/issue3905#msg153234

This fixes Issue #637
