### PR TITLE
Use locale overload of std::isupper

### DIFF
--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -21,6 +21,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/function.hpp>
 #include <algorithm>
+#include <locale>
 
 using boost::algorithm::istarts_with;
 
@@ -29,9 +30,9 @@ namespace YouCompleteMe {
 namespace {
 
 char ChangeCharCase( char c ) {
-  if ( std::isupper( c ) )
-    return std::tolower( c );
-  return std::toupper( c );
+  if ( std::isupper( c, std::locale() ) )
+    return std::tolower( c, std::locale() );
+  return std::toupper( c, std::locale() );
 }
 
 


### PR DESCRIPTION
ChangeCharCase uses `std::isupper` with `char` -- however, in `<locale>`, there is only a templated overload of `std::isupper` with a second, non-optional `std::locale` argument.

http://en.cppreference.com/w/cpp/locale/isupper

This PR explicitly includes `<locale>`, and converts the use of `std::isupper`, `std::tolower` and `std::toupper` to the `std::locale` overloads.
