### PR TITLE
Add a useful fallback ycm extra config.

### DIFF
--- a/.ycm.py
+++ b/.ycm.py
@@ -1,0 +1,110 @@
+# This file is NOT licensed under the GPLv3, which is the license for the rest
+# of YouCompleteMe.
+#
+# Here's the license text for this file:
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <http://unlicense.org/>
+
+import os
+import ycm_core
+
+def DirectoryOfThisScript():
+  return os.path.dirname( os.path.abspath( __file__ ) )
+
+
+def MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
+  if not working_directory:
+    return list( flags )
+  new_flags = []
+  make_next_absolute = False
+  path_flags = [ '-isystem', '-I', '-iquote', '--sysroot=' ]
+  for flag in flags:
+    new_flag = flag
+
+    if make_next_absolute:
+      make_next_absolute = False
+      if not flag.startswith( '/' ):
+        new_flag = os.path.join( working_directory, flag )
+
+    for path_flag in path_flags:
+      if flag == path_flag:
+        make_next_absolute = True
+        break
+
+      if flag.startswith( path_flag ):
+        path = flag[ len( path_flag ): ]
+        new_flag = path_flag + os.path.join( working_directory, path )
+        break
+
+    if new_flag:
+      new_flags.append( new_flag )
+  return new_flags
+
+def AppendFileType(filename, flags):
+  for flag in flags:
+    if flag.startswith("-x"):
+        return
+
+  if filename.endswith(".cpp") or filename.endswith(".hpp") \
+    or filename.endswith(".cxx"):
+    flags.extend(["-x", "c++"])
+  elif filename.endswith(".c") or filename.endswith(".h"):
+    flags.extend(["-x", "c"])
+
+def FlagsForFile( filename, **kwargs ):
+  dn = os.path.dirname(filename)
+  while not os.path.isfile(dn + "/.ycm"):
+    if dn == "/":
+        break
+    dn = os.path.realpath(dn + "/..")
+
+  flags_file = open(dn + "/.ycm")
+  flags = flags_file.read()
+
+  if flags.startswith("-"):
+    #This is a CFLAGS
+    flags = flags.split()
+    final_flags = MakeRelativePathsInFlagsAbsolute(flags, dn)
+  else :
+    #This is a path to database
+    #If the path starts with a whitespace, remove it.
+    #This way we can handle path starts with dash.
+    if flags.startswith(" "):
+        flags = flags[1:]
+    database = ycm_core.CompilationDatabase(flags)
+    # Bear in mind that compilation_info.compiler_flags_ does NOT return a
+    # python list, but a "list-like" StringVec object
+    compilation_info = database.GetCompilationInfoForFile( filename )
+    final_flags = MakeRelativePathsInFlagsAbsolute(
+      compilation_info.compiler_flags_,
+      compilation_info.compiler_working_dir_ )
+
+  AppendFileType(filename, final_flags)
+
+  return {
+    'flags': final_flags,
+    'do_cache': True
+  }

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -505,6 +505,11 @@ projects.
 Yes, Clang's 'CompilationDatabase' system [20] is also supported. Again, see
 the above linked example file.
 
+YCM also provides a default '.ycm.py' that searches for a '.ycm'
+file (also recursively), and reads its content as compilation flags or path
+to a compilation database. You could put that file anywhere, and point
+*g:ycm_global_ycm_extra_conf* to it.
+
 If Clang encounters errors when compiling the header files that your file
 includes, then it's probably going to take a long time to get completions. When
 the completion menu finally appears, it's going to have a large number of


### PR DESCRIPTION
This fallback config python module searchs for a .ycm file recursively,
and use its contents as CFLAGS or a path to a compilation database.
