### PR TITLE
Check current word length before invoking completion

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -507,6 +507,27 @@ function! s:InsideCommentOrStringAndShouldStop()
   return retval
 endfunction
 
+function! s:WordTooShortToComplete()
+  if g:ycm_min_num_of_chars_for_completion == 0
+    return 0
+  end
+
+  let current_col = col('.')
+
+  " handle first char of new word (by searching for end of previous)
+  let [pend_line, pend_col] = searchpos('\>', 'bn', line('.'))
+  if pend_line != 0 && pend_col == current_col - 1
+    return 1
+  end
+
+  " get length of current word (by searching start of current word)
+  let [cstart_line, cstart_col] = searchpos('\<', 'bcn', line('.'))
+  if current_col - cstart_col < g:ycm_min_num_of_chars_for_completion
+    return 1
+  end
+
+  return 0
+endfunction
 
 function! s:OnBlankLine()
   return pyeval( 'not vim.current.line or vim.current.line.isspace()' )
@@ -518,7 +539,7 @@ function! s:InvokeCompletion()
     return
   endif
 
-  if s:InsideCommentOrStringAndShouldStop() || s:OnBlankLine()
+  if s:InsideCommentOrStringAndShouldStop() || s:OnBlankLine() || s:WordTooShortToComplete()
     return
   endif
 


### PR DESCRIPTION
This simple change adds a check of current word length before invoking the completion. If the length of current word is smaller than `g:ycm_min_num_of_chars_for_completion`, completion is not invoked. This prevents `User defined completion (^U^N^P) Pattern not found` vim error message to appear.

The error message is annoying and useless if `g:ycm_min_num_of_chars_for_completion` is set high.
