### PR TITLE
Add possibility to disable identifier completion engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,8 +656,8 @@ option is set to `2`, then when the user types a second alphanumeric character
 after a whitespace character, completion suggestions will be triggered. This
 option is NOT used for semantic completion.
 
-Setting this option to a high number like `99` effectively turns off the
-identifier completion engine and just leaves the semantic engine.
+Special value `-1` disables identifier completion engine and just leaves the
+semantic engine.
 
 Default: `2`
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -520,6 +520,10 @@ function! s:InvokeCompletion()
     return
   endif
 
+  if g:ycm_min_num_of_chars_for_completion < 0
+    return
+  endif
+
   if s:InsideCommentOrStringAndShouldStop() || s:OnBlankLine()
     return
   endif


### PR DESCRIPTION
A really simple change allowing to disable identifier completion engine by setting `g:ycm_min_num_of_chars_for_completion` to negative value.

Can be temporary solution for #597
