### PR TITLE
Add -isysroot to list of INCLUDE_FLAGS.

### DIFF
--- a/python/ycm/completers/cpp/flags.py
+++ b/python/ycm/completers/cpp/flags.py
@@ -28,7 +28,7 @@ NO_EXTRA_CONF_FILENAME_MESSAGE = ( 'No {0} file detected, so no compile flags '
   'DOCS *NOW*, DON\'T file a bug report.' ).format(
     extra_conf_store.YCM_EXTRA_CONF_FILENAME )
 
-INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '--sysroot=' ]
+INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '--sysroot=', '-isysroot' ]
 
 class Flags( object ):
   """Keeps track of the flags necessary to compile a file.


### PR DESCRIPTION
The CompilationDatabase generated by cmake (sometimes?) includes -isysroot <path to platform sdk root>, which was being filtered out of the compile flags. This change adds the -isysroot flag to the list of INCLUDE_FLAGS.
