### PR TITLE
Fixed usage of database file in example .ycm_extra_conf.py.

### DIFF
--- a/cpp/ycm/.ycm_extra_conf.py
+++ b/cpp/ycm/.ycm_extra_conf.py
@@ -92,7 +92,7 @@ flags = [
 # 'flags' list of compilation flags. Notice that YCM itself uses that approach.
 compilation_database_folder = ''
 
-if compilation_database_folder:
+if os.path.exists( compilation_database_folder ):
   database = ycm_core.CompilationDatabase( compilation_database_folder )
 else:
   database = None


### PR DESCRIPTION
Checking the path is set is not enough, we should also check the path
exists. This allows people to have a general-purpose
.ycm_extra_conf.conf that automatically loads a database file if exists,
and falls back to the manual flags if not.
