### PR TITLE
Check auto_stop_csharp_server when shutting down

### DIFF
--- a/python/ycm/completers/cs/cs_completer.py
+++ b/python/ycm/completers/cs/cs_completer.py
@@ -48,7 +48,7 @@ class CsharpCompleter( Completer ):
 
 
   def Shutdown( self ):
-    if ( self.user_options[ 'auto_start_csharp_server' ] and
+    if ( self.user_options[ 'auto_stop_csharp_server' ] and
          self._ServerIsRunning() ):
       self._StopServer()
 


### PR DESCRIPTION
Check auto_stop_csharp_server instead of auto_start_csharp_server when
shutting down
