### PR TITLE
Fix OmniSharp launch under Windows

### DIFF
--- a/python/ycm/completers/cs/cs_completer.py
+++ b/python/ycm/completers/cs/cs_completer.py
@@ -27,7 +27,6 @@ import urllib2
 import urllib
 import urlparse
 import json
-import subprocess
 import logging
 
 SERVER_NOT_FOUND_MSG = ( 'OmniSharp server binary not found at {0}. ' +
@@ -170,7 +169,7 @@ class CsharpCompleter( Completer ):
       with open( self._filename_stdout, 'w' ) as fstdout:
         # shell=True is needed for Windows so OmniSharp does not spawn
         # in a new visible window
-        subprocess.Popen( command, stdout=fstdout, stderr=fstderr, shell=True )
+        utils.SafePopen( command, stdout=fstdout, stderr=fstderr, shell=True )
 
     self._logger.info( 'Starting OmniSharp server' )
 

--- a/python/ycm/utils.py
+++ b/python/ycm/utils.py
@@ -25,6 +25,7 @@ import functools
 import socket
 import stat
 from distutils.spawn import find_executable
+import subprocess
 
 WIN_PYTHON27_PATH = 'C:\python27\pythonw.exe'
 WIN_PYTHON26_PATH = 'C:\python26\pythonw.exe'
@@ -162,3 +163,18 @@ def AddThirdPartyFoldersToSysPath():
 def ForceSemanticCompletion( request_data ):
   return ( 'force_semantic' in request_data and
            bool( request_data[ 'force_semantic' ] ) )
+
+def SafePopen( args, bufsize = 0, executable = None, stdin = None,
+               stdout = None, stderr = None, preexec_fn = None,
+               close_fds = False, shell = False, cwd = None, env = None,
+               universal_newlines = False, startupinfo = None,
+               creationflags = 0 ):
+  if stdin is None:
+    # We need this on Windows otherwise bad things happen. See issue #637.
+    stdin = subprocess.PIPE if OnWindows() else None
+
+  return subprocess.Popen( args, bufsize, executable, stdin, stdout, stderr,
+                           preexec_fn, close_fds, shell, cwd, env,
+                           universal_newlines, startupinfo, creationflags )
+
+

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -19,7 +19,6 @@
 
 import os
 import vim
-import subprocess
 import tempfile
 import json
 from ycm import vimsupport
@@ -93,7 +92,7 @@ class YouCompleteMe( object ):
       BaseRequest.server_location = 'http://localhost:' + str( server_port )
 
       if self._user_options[ 'server_use_vim_stdout' ]:
-        self._server_popen = subprocess.Popen( args )
+        self._server_popen = utils.SafePopen( args )
       else:
         filename_format = os.path.join( utils.PathToTempDir(),
                                         'server_{port}_{std}.log' )
@@ -102,15 +101,12 @@ class YouCompleteMe( object ):
                                                       std = 'stdout' )
         self._server_stderr = filename_format.format( port = server_port,
                                                       std = 'stderr' )
-        # We need this on Windows otherwise bad things happen. See issue #637.
-        stdin = subprocess.PIPE if utils.OnWindows() else None
 
         with open( self._server_stderr, 'w' ) as fstderr:
           with open( self._server_stdout, 'w' ) as fstdout:
-            self._server_popen = subprocess.Popen( args,
-                                                   stdin = stdin,
-                                                   stdout = fstdout,
-                                                   stderr = fstderr )
+            self._server_popen = utils.SafePopen( args,
+                                                  stdout = fstdout,
+                                                  stderr = fstderr )
     self._NotifyUserIfServerCrashed()
 
 


### PR DESCRIPTION
Small changes to be able to launch OmniSharp under Windows.
The biggest change to me is that I removed the shell=True parameter from the call to subprocess.Popen, though I can't see any reason why we'd need this. Was there a specific reason for this parameter ?

Also I tested the change under Windows and Linux and nothing's broken.
