### PR TITLE
Only use libc++ when we have it

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -67,8 +67,7 @@ endif()
 if ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
   set( COMPILER_IS_CLANG true )
 
-  # The Travis CI build machines don't have libc++ installed
-  if ( NOT DEFINED ENV{TRAVIS} AND HAS_LIBCXX11)
+  if ( HAS_LIBCXX11 )
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++" )
   endif()
 


### PR DESCRIPTION
Fixes #523 and #721

Checked  on  Arch Linux 3.12.5-1 with:
- clang/clang++ 3.3
- libc++ uninstalled
- libc++abi installed
- cmake 2.8.12.1

Fix:
The binary links against libstdc++ when libc++ is not installed
