### PR TITLE
Improve detailed diagnostic

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangUtils.cpp
+++ b/cpp/ycm/ClangCompleter/ClangUtils.cpp
@@ -54,114 +54,129 @@ namespace {
  * @return the string describing the given diagnostic.
  */
 std::string CXDiagnosticToLocationAndRangesText( CXDiagnostic cxdiagnostic ) {
-    // resulting map of <file name, map<line number, description>>
-    std::map<std::string, std::map<unsigned, std::string>> result;
+  // resulting map of <file name, map<line number, description>>
+  std::map<std::string, std::map<unsigned, std::string>> result;
 
-    // retrieve the context of the diagnostic's location
-    const CXSourceLocation cxlocation = clang_getDiagnosticLocation( cxdiagnostic );
-    CXFile loc_file;
-    unsigned loc_line;
-    unsigned loc_col;
-    clang_getSpellingLocation( cxlocation, &loc_file, &loc_line, &loc_col, 0 );
-    const std::string loc_path = CXStringToString( clang_getFileName( loc_file ) );
+  // retrieve the context of the diagnostic's location
+  const CXSourceLocation cxlocation = clang_getDiagnosticLocation( cxdiagnostic );
+  CXFile loc_file;
+  unsigned loc_line;
+  unsigned loc_col;
+  clang_getSpellingLocation( cxlocation, &loc_file, &loc_line, &loc_col, 0 );
+  const std::string loc_path = CXStringToString( clang_getFileName( loc_file ) );
 
-    // map all the ranges in a map of <file name, map<line number, set<ranges' column indexes>>>
-    const unsigned num_ranges = clang_getDiagnosticNumRanges( cxdiagnostic );
-    std::map<std::string, std::map<unsigned, std::set<unsigned>>> range_idxs{};
-    for ( unsigned range = 0; range < num_ranges; ++range ) {
-        CXSourceLocation range_start = clang_getRangeStart(
-                clang_getDiagnosticRange( cxdiagnostic, range ) );
-        CXSourceLocation range_end = clang_getRangeEnd(
-                clang_getDiagnosticRange( cxdiagnostic, range ) );
+  // map all the ranges in a map of <file name, map<line number, set<ranges' column indexes>>>
+  const unsigned num_ranges = clang_getDiagnosticNumRanges( cxdiagnostic );
+  std::map<std::string, std::map<unsigned, std::set<unsigned>>> range_idxs {};
 
-        CXFile start_file, end_file;
-        unsigned start_col, end_col, start_line, end_line;
-        clang_getSpellingLocation( range_start, &start_file, &start_line, &start_col, 0 );
-        clang_getSpellingLocation( range_end, &end_file, &end_line, &end_col, 0 );
+  for ( unsigned range = 0; range < num_ranges; ++range ) {
+    CXSourceLocation range_start = clang_getRangeStart(
+                                     clang_getDiagnosticRange( cxdiagnostic, range ) );
+    CXSourceLocation range_end = clang_getRangeEnd(
+                                   clang_getDiagnosticRange( cxdiagnostic, range ) );
 
-        const std::string start_path = CXStringToString( clang_getFileName( start_file ) );
-        const std::string end_path = CXStringToString( clang_getFileName( end_file ) );
-        if ( start_path == end_path ) {
-            // retrieve the file's lines ranges. Create it if none exists.
-            std::map<unsigned, std::set<unsigned>>& range_lines = range_idxs[start_path];
-            for ( unsigned l = start_line; l <= end_line; ++l ) {
-                // retrieve the ranged columns for the current line. Create it if none exists.
-                std::set<unsigned>& range_line = range_lines[l];
-                for ( unsigned c = start_col; c < end_col; ++c ) {
-                    range_line.insert( c );
-                }
-            }
+    CXFile start_file, end_file;
+    unsigned start_col, end_col, start_line, end_line;
+    clang_getSpellingLocation( range_start, &start_file, &start_line, &start_col, 0 );
+    clang_getSpellingLocation( range_end, &end_file, &end_line, &end_col, 0 );
+
+    const std::string start_path = CXStringToString( clang_getFileName( start_file ) );
+    const std::string end_path = CXStringToString( clang_getFileName( end_file ) );
+
+    if ( start_path == end_path ) {
+      // retrieve the file's lines ranges. Create it if none exists.
+      std::map<unsigned, std::set<unsigned>> &range_lines = range_idxs[start_path];
+
+      for ( unsigned l = start_line; l <= end_line; ++l ) {
+        // retrieve the ranged columns for the current line. Create it if none exists.
+        std::set<unsigned> &range_line = range_lines[l];
+
+        for ( unsigned c = start_col; c < end_col; ++c ) {
+          range_line.insert( c );
+        }
+      }
+    } else {
+      // The range spans on multiple files... only take the first character of the first
+      // line
+      std::map<unsigned, std::set<unsigned>> &range_lines = range_idxs[start_path];
+      std::set<unsigned> &range_line = range_lines[start_line];
+      range_line.insert( start_col );
+    }
+  }
+
+  // for each range generate the underlines. If the line is also referenced
+  // by the diagnostic's location then add the caret under the location.
+  bool loc_processed = false; // true if the location has been processed
+
+  for ( auto current_file : range_idxs ) {
+    const std::string current_path = current_file.first;
+    std::map<unsigned, std::string> &result_file = result[current_path];
+
+    for ( auto current_line : current_file.second ) {
+      // retrieve the current line result
+      std::string &result_line = result_file[current_line.first];
+      const std::set<unsigned> &line_idxs = current_line.second;
+      unsigned max_col = *line_idxs.rbegin();
+      bool processing_location = false;
+
+      if ( current_path == loc_path and current_line.first == loc_line ) {
+        loc_processed = true;
+        unsigned max_col = max_col > loc_col ? max_col : loc_col;
+        processing_location = true;
+      }
+
+      for ( unsigned current_col = 1; current_col <= max_col; ++current_col ) {
+        if ( processing_location and current_col == loc_col ) {
+          result_line.append( "^" );
+        } else if ( line_idxs.find( current_col ) != line_idxs.end() ) {
+          result_line.append( "~" );
         } else {
-            // The range spans on multiple files... only take the first character of the first
-            // line
-            std::map<unsigned, std::set<unsigned>>& range_lines = range_idxs[start_path];
-            std::set<unsigned>& range_line = range_lines[start_line];
-            range_line.insert(start_col);
+          result_line.append( " " );
         }
+      }
+    }
+  }
+
+  // if the ranges are not on the same line as the location, add the location
+  if ( not loc_processed ) {
+    std::map<unsigned, std::string> &result_file = result[loc_path];
+    std::string result_line( loc_col > 0 ? loc_col - 1 : 0 , ' ' );
+    result_line.append( "^" );
+    result_file[loc_line] = result_line;
+  }
+
+  // for each underline, read the corresponding line in the source file and generate the
+  // resulting description (~= source line \n underline)
+  std::string str_result;
+
+  for ( auto current_file : result ) {
+    if ( current_file.first != loc_path ) {
+      str_result.append( current_file.first + ": context:\n" );
     }
 
-    // for each range generate the underlines. If the line is also referenced by the
-    // diagnostic's location then add the caret under the location.
-    bool loc_processed = false; // true if the location has been processed
-    for ( auto current_file : range_idxs ) {
-        const std::string current_path = current_file.first;
-        std::map<unsigned, std::string>& result_file = result[current_path];
-        for ( auto current_line : current_file.second ) {
-            // retrieve the current line result
-            std::string& result_line = result_file[current_line.first];
-            const std::set<unsigned>& line_idxs = current_line.second;
-            unsigned max_col = *line_idxs.rbegin();
-            bool processing_location = false;
-            if ( current_path == loc_path and current_line.first == loc_line ) {
-                loc_processed = true;
-                unsigned max_col = max_col > loc_col ? max_col : loc_col;
-                processing_location = true;
-            }
-            for ( unsigned current_col = 1; current_col <= max_col; ++current_col ) {
-                if ( processing_location and current_col == loc_col ) {
-                    result_line.append("^");
-                } else if ( line_idxs.find( current_col ) != line_idxs.end() ) {
-                    result_line.append("~");
-                } else {
-                    result_line.append(" ");
-                }
-            }
-        }
-    }
-    // if the ranges are not on the same line as the location, add the location
-    if ( not loc_processed ) {
-        std::map<unsigned, std::string>& result_file = result[loc_path];
-        std::string result_line(loc_col > 0 ? loc_col - 1 : 0 , ' ');
-        result_line.append("^");
-        result_file[loc_line] = result_line;
-    }
+    std::ifstream infile( current_file.first );
+    std::string line;
+    unsigned current_line_idx = 0;
 
-    // for each underline, read the corresponding line in the source file and generate the
-    // resulting description (~= source line \n underline)
-    std::string str_result;
-    for ( auto current_file : result ) {
-        if (current_file.first != loc_path) {
-            str_result.append(current_file.first + ": context:\n");
-        }
-        std::ifstream infile( current_file.first );
-        std::string line;
-        unsigned current_line_idx = 0;
-        for ( auto current_line : current_file.second ) {
-            line = "YCM ERROR WHILE READING FILE \"" + current_file.first + "\"";
-            while ( infile.good() and std::getline( infile, line ) ) {
-                if ( ++current_line_idx == current_line.first ) {
-                    break;
-                }
-                line = "YCM ERROR WHILE READING FILE \"" + current_file.first + "\"";
-            }
-            // prepend the source code line
-            std::string index = std::to_string(current_line_idx) + ": ";
-            str_result.append(index + line + "\n"
-                    + std::string(index.size(), ' ') + current_line.second + "\n");
-        }
-    }
+    for ( auto current_line : current_file.second ) {
+      line = "YCM ERROR WHILE READING FILE \"" + current_file.first + "\"";
 
-    return str_result;
+      while ( infile.good() and std::getline( infile, line ) ) {
+        if ( ++current_line_idx == current_line.first ) {
+          break;
+        }
+
+        line = "YCM ERROR WHILE READING FILE \"" + current_file.first + "\"";
+      }
+
+      // prepend the source code line
+      std::string index = std::to_string( current_line_idx ) + ": ";
+      str_result.append( index + line + "\n"
+            + std::string( index.size(), ' ' ) + current_line.second + "\n" );
+    }
+  }
+
+  return str_result;
 }
 
 


### PR DESCRIPTION
The messages printed by the command YcmShowDetailedDiagnostic are quite different from the one generated by clang.
1. format can be improved: there are no new lines between messages.
2. content can be improved: only the diagnostic messages are shown. No context is displayed like the ones clang display with the option "-fcaret-diagnostics"

This patch:
1. adds new lines between messages
2. adds context messages a la clang. It displays even more information than clang. It shows all the ranges of code in all the files corresponding to a diagnostic. I added this because we show only one diagnostic at a time so there are less messages than a full compilation would generate.

For example:
with files main.hpp and main.cpp like this:

```
#ifndef _TMP_MAIN_HPP_
#define _TMP_MAIN_HPP_ 

#include <string>

#define TEST t

namespace nam {
int test(char c, int a)
{
    return a;
}

int test(std::string s, int i)
{
    return std::stoi(s);
}
}
class Test {
};

#endif /* _TMP_MAIN_HPP_ */
```

```
#include <iostream>
#include <vector>

#include <main.hpp>


int main()
{
  Test t;
  if (TEST



          == std::string("a")) // (1)
    return 0;
  if (nam::test) // (2)
      return 32;
  nam::test('s', t); // (3)
  return 42;
}
```

we would display the diagnostics:
<b> diagnostic 1 </b>

```
/.../projects/programming/tmp/src/main.cpp:14:11: error: invalid operands to binary expression ('Test' and 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >')
)
10:   if (TEST
          ~~~~
14:           == std::string("a"))
              ^  ~~~~~~~~~~~~~~~~
```

<b> diagnostic 2 </b>

```
/.../projects/programming/tmp/src/main.cpp:16:7: error: reference to overloaded function could not be resolved; did you mean to call it?
16:   if (nam::test)
          ^~~~~~~~~
/.../projects/programming/tmp/./src/main.hpp:9:5: note: possible target for call
9: int test(char c, int a)
       ^
/.../projects/programming/tmp/./src/main.hpp:14:5: note: possible target for call
14: int test(std::string s, int i)
        ^
```

<b> diagnostic 3 </b>

```
/.../projects/programming/tmp/src/main.cpp:18:3: error: no matching function for call to 'test'
18:   nam::test('s', t);
      ^~~~~~~~~
/.../projects/programming/tmp/./src/main.hpp:9:5: note: candidate function not viable: no known conversion from 'Test' to 'int' for 2nd argument
9: int test(char c, int a)
       ^
/.../projects/programming/tmp/src/main.cpp: context:
18:   nam::test('s', t);
                     ~
/.../projects/programming/tmp/./src/main.hpp:14:5: note: candidate function not viable: no known conversion from 'char' to 'std::string' (aka 'basic_string<char, char_traits<char>, all
ocator<char> >') for 1st argument
14: int test(std::string s, int i)
        ^
/.../projects/programming/tmp/src/main.cpp: context:
18:   nam::test('s', t);
                ~~~
```
