### PR TITLE
Blacklist Pandoc file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,7 @@ Default: `[see next line]`
           \ 'unite' : 1,
           \ 'text' : 1,
           \ 'vimwiki' : 1,
+          \ 'pandoc' : 1
           \}
 
 ### The `g:ycm_filetype_specific_completion_to_disable` option

--- a/python/ycm/server/default_settings.json
+++ b/python/ycm/server/default_settings.json
@@ -26,7 +26,8 @@
     "markdown": 1,
     "unite": 1,
     "text": 1,
-    "vimwiki": 1
+    "vimwiki": 1,
+    "pandoc": 1
   },
   "auto_start_csharp_server": 1,
   "auto_stop_csharp_server": 1,


### PR DESCRIPTION
Pandoc enhances Markdown and therefore is used for prose, which doesn't suit
YCM well.
