### PR TITLE
Add XCode system library path to fix --system-libclang building

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -198,7 +198,8 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
                   /usr/lib
                   /usr/lib/llvm
                   ${SYS_LLVM_PATHS}
-                  /Library/Developer/CommandLineTools/usr/lib )
+                  /Library/Developer/CommandLineTools/usr/lib,
+                  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib )
     set( EXTERNAL_LIBCLANG_PATH ${TEMP} )
   else()
     # For Macs, we do things differently; look further in this file.


### PR DESCRIPTION
At least on my Os X 10.9.1 installation, the libclang resides in:

/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib

The directory:

/Library/Developer/CommandLineTools/usr/lib

Does not even exist on my system, that might be only for Xcode 4 installations. 
