### PR TITLE
Fix not working UltiSnips completer

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -64,7 +64,8 @@ function! youcompleteme#Enable()
   endif
 
   py from ycm.youcompleteme import YouCompleteMe
-  py ycm_state = YouCompleteMe( user_options_store.GetAll() )
+  py Snips_Manager = UltiSnips_Manager if 'UltiSnips_Manager' in locals() else None
+  py ycm_state = YouCompleteMe( user_options_store.GetAll(), Snips_Manager )
 
   call s:SetUpCpoptions()
   call s:SetUpCompleteopt()
@@ -334,7 +335,7 @@ function! s:OnBufferVisit()
 
   call s:SetUpCompleteopt()
   call s:SetCompleteFunc()
-  py ycm_state.OnBufferVisit()
+  py ycm_state.OnBufferVisit( ycm_state.UltiSnips_Manager )
   call s:OnFileReadyToParse()
 endfunction
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -37,11 +37,6 @@ from ycm.client.event_notification import ( SendEventNotificationAsync,
                                             EventNotification )
 from ycm.server.responses import ServerError
 
-try:
-  from UltiSnips import UltiSnips_Manager
-  USE_ULTISNIPS_DATA = True
-except ImportError:
-  USE_ULTISNIPS_DATA = False
 
 # We need this so that Requests doesn't end up using the local HTTP proxy when
 # talking to ycmd. Users should actually be setting this themselves when
@@ -68,7 +63,7 @@ SERVER_IDLE_SUICIDE_SECONDS = 10800  # 3 hours
 
 
 class YouCompleteMe( object ):
-  def __init__( self, user_options ):
+  def __init__( self, user_options, UltiSnips_Manager ):
     self._user_options = user_options
     self._user_notified_about_crash = False
     self._diag_interface = DiagnosticInterface( user_options )
@@ -83,6 +78,7 @@ class YouCompleteMe( object ):
     self._ycmd_keepalive = YcmdKeepalive()
     self._SetupServer()
     self._ycmd_keepalive.Start()
+    self.UltiSnips_Manager = UltiSnips_Manager
 
 
   def _SetupServer( self ):
@@ -239,11 +235,11 @@ class YouCompleteMe( object ):
                                 { 'unloaded_buffer': deleted_buffer_file } )
 
 
-  def OnBufferVisit( self ):
+  def OnBufferVisit( self, UltiSnips_Manager ):
     if not self._IsServerAlive():
       return
     extra_data = {}
-    _AddUltiSnipsDataIfNeeded( extra_data )
+    _AddUltiSnipsDataIfNeeded( extra_data, UltiSnips_Manager )
     SendEventNotificationAsync( 'BufferVisit', extra_data )
 
 
@@ -369,8 +365,8 @@ def _PathToServerScript():
   return os.path.join( dir_of_current_script, 'server/ycmd.py' )
 
 
-def _AddUltiSnipsDataIfNeeded( extra_data ):
-  if not USE_ULTISNIPS_DATA:
+def _AddUltiSnipsDataIfNeeded( extra_data, UltiSnips_Manager ):
+  if not UltiSnips_Manager:
     return
 
   try:


### PR DESCRIPTION
Fixes #820. Latest UltiSnips upstream changes was pretty huge. The most devastating change was that now UltiSnips uses a class instance of `SnippetManager` class for `UltiSnips_Manager` object instead of using `UltiSnips_Manager` from imported module. 

This alone is pretty harmless since UltiSnips defines `UltiSnips_Manager` in global scope, but for some reason ( unknown for me ) its not defined in `ycm_state._AddUltiSnipsDataIfNeeded` scope ( even with `global`. It should work with `global`, I guess this is some kind of limitation of Vim python bindings... ). Because of that, I made changes to pass `UltiSnips_Manager` instance directly to `OnBufferVisit` call. Sorry, dont know better solution here :(

Also some clarifications why I did not initialized a separate `SnippetManager` instance in `youcompleteme.py`. Currently UltiSnips sets its autocmds that sets proper filetypes for snippets to the methods of the initialized SnippetManager object. Because of that, if we will create a new instance it will not be able to get new filetypes on buffer switch and we will be stuck with just one filetype - `all`.

Also, I guess we should ping @SirVer, maybe he has a better solution.
