### PR TITLE
Changes to make YCM installation on Cygwin easier.

### DIFF
--- a/cpp/BoostParts/boost/python/detail/wrap_python.hpp
+++ b/cpp/BoostParts/boost/python/detail/wrap_python.hpp
@@ -82,9 +82,7 @@
 // Some things we need in order to get Python.h to work with compilers other
 // than MSVC on Win32
 //
-// only performing the check for defined(__CYGWIN__) on 32-bit systems
-// ensuring that SIZEOF_LONG is only altered on 32-bit CYGWIN systems
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__CYGWIN__)
 # if defined(__GNUC__) && defined(__CYGWIN__)
 
 #  define SIZEOF_LONG 4


### PR DESCRIPTION
Since you mentioned that you would entertain pull requests for Windows support (#684), could you take a look at this one. Made changes to install.sh and cpp/BoostParts/boost/python/detail/wrap_python.hpp to make the installation on Windows (via cygwin) easier.
I have tried to follow the coding style and other steps mentioned on CONTRIBUTING.md. 
Testing: Couldn't actually write a test for this change, but I have it on Cygwin and Cygwin-64, and on Ubuntu (64-bit).
I have signed the Google CLA.

Updated install.sh allowing it to discover PYTHON_INCLUDE_DIR and PYTHON_LIBRARY

Also changed wrap_python.hpp to only check for defined(**CYGWIN**)
on 32-bit systems. Previously this check was OR'd with the check
for defined(**WIN32**) causing the system to erroneously update the
SIZEOF_LONG value and subsequently resulting in "make ycm_core"
failing with "LONG_BIT definition appears wrong for platform" on
CYGWIN-64 systems.
