### PR TITLE
Added call to communicate() after terminating server

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -149,6 +149,7 @@ class YouCompleteMe( object ):
   def _ServerCleanup( self ):
     if self._IsServerAlive():
       self._server_popen.terminate()
+      self._server_popen.communicate()
     utils.RemoveIfExists( self._temp_options_filename )
 
     if not self._user_options[ 'server_keep_logfiles' ]:


### PR DESCRIPTION
I know Windows isn't officially supported, but without adding a call to communicate() after terminating the server process, I was consistently seeing access issues due to the process still running when trying to remove the stderr/stdout files.  I could've just turned off server_keep_logfiles, but it seems like a pretty non-intrusive change.

I have signed the Google CLA.
