### PR TITLE
Always use python_finder on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,11 +74,7 @@ function install {
   build_dir=`mktemp -d -t ycm_build.XXXXXX`
   pushd $build_dir
 
-  if [[ `uname -s` == "Darwin" ]]; then
-    cmake -G "Unix Makefiles" $(python_finder) "$@" . $ycm_dir/cpp
-  else
-    cmake -G "Unix Makefiles" "$@" . $ycm_dir/cpp
-  fi
+  cmake -G "Unix Makefiles" $(python_finder) "$@" . $ycm_dir/cpp
 
   make -j $(num_cores) ycm_support_libs
   popd


### PR DESCRIPTION
When using something like [pyenv](https://github.com/yyuu/pyenv) cmake fails to find the python library.
