### PR TITLE
create secure tempdir per process

### DIFF
--- a/python/ycm/utils.py
+++ b/python/ycm/utils.py
@@ -26,6 +26,7 @@ import socket
 import stat
 from distutils.spawn import find_executable
 import subprocess
+import atexit
 
 WIN_PYTHON27_PATH = 'C:\python27\pythonw.exe'
 WIN_PYTHON26_PATH = 'C:\python26\pythonw.exe'
@@ -46,15 +47,14 @@ def ToUtf8IfNeeded( value ):
     return value
   return str( value )
 
+_tempdir = None
 
 def PathToTempDir():
-  tempdir = os.path.join( tempfile.gettempdir(), 'ycm_temp' )
-  if not os.path.exists( tempdir ):
-    os.makedirs( tempdir )
-    # Needed to support multiple users working on the same machine;
-    # see issue 606.
-    MakeFolderAccessibleToAll( tempdir )
-  return tempdir
+  global _tempdir
+  if _tempdir is None:
+    _tempdir = tempfile.mkdtemp( prefix='ycm_temp' )
+    atexit.register( RemoveDirectoryIfExists, _tempdir )
+  return _tempdir
 
 
 def MakeFolderAccessibleToAll( path_to_folder ):
@@ -88,6 +88,11 @@ def RemoveIfExists( filename ):
   except OSError:
     pass
 
+def RemoveDirectoryIfExists( directory ):
+  try:
+    os.rmdir( directory )
+  except OSError:
+    pass
 
 def Memoize( obj ):
   cache = obj.cache = {}

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -76,6 +76,7 @@ class YouCompleteMe( object ):
     self._omnicomp = OmniCompleter( user_options )
     self._latest_completion_request = None
     self._latest_file_parse_request = None
+    self._server_tempdir = None
     self._server_stdout = None
     self._server_stderr = None
     self._server_popen = None
@@ -101,7 +102,8 @@ class YouCompleteMe( object ):
                   SERVER_IDLE_SUICIDE_SECONDS )]
 
       if not self._user_options[ 'server_use_vim_stdout' ]:
-        filename_format = os.path.join( utils.PathToTempDir(),
+        self._server_tempdir = utils.PathToTempDir()
+        filename_format = os.path.join( self._server_tempdir,
                                         'server_{port}_{std}.log' )
 
         self._server_stdout = filename_format.format( port = server_port,


### PR DESCRIPTION
  Default /tmp/ycm_temp dir is accessible by everyone.
  Different users on same machine is able to read logs.

  This patch creates /tmp/ycm_temp per process and only owner of
  ycmd proccess can access this directories.

  We use this patch to provide secure log directories in debian.
