### PR TITLE
Support test compilation in Cygwin

### DIFF
--- a/third_party/ycmd/build.sh
+++ b/third_party/ycmd/build.sh
@@ -91,9 +91,9 @@ function testrun {
   pushd $build_dir
 
   cmake -G "Unix Makefiles" "$@" . $SCRIPT_DIR/cpp
-  make -j $(num_cores) ycm_core_tests
+  make -j $(num_cores) ycm_support_libs ycm_core_tests
   cd ycm/tests
-  LD_LIBRARY_PATH=$SCRIPT_DIR ./ycm_core_tests
+  LD_LIBRARY_PATH=$ycm_dir/python PATH=$PATH:$ycm_dir/python ./ycm_core_tests
 
   popd
   rm -rf $build_dir

--- a/third_party/ycmd/cpp/ycm/Candidate.h
+++ b/third_party/ycmd/cpp/ycm/Candidate.h
@@ -18,6 +18,7 @@
 #ifndef CANDIDATE_H_R5LZH6AC
 #define CANDIDATE_H_R5LZH6AC
 
+#include "export.h"
 #include "LetterNode.h"
 
 #include <boost/scoped_ptr.hpp>
@@ -32,26 +33,32 @@ class Result;
 
 typedef std::bitset< NUM_LETTERS > Bitset;
 
+__export__
 Bitset LetterBitsetFromString( const std::string &text );
 
 // Public for tests
+__export__
 std::string GetWordBoundaryChars( const std::string &text );
 
 class Candidate : boost::noncopyable {
 public:
 
+  __export__
   explicit Candidate( const std::string &text );
 
+  __export__
   inline const std::string &Text() const {
     return text_;
   }
 
   // Returns true if the candidate contains the bits from the query (it may also
   // contain other bits)
+  __export__
   inline bool MatchesQueryBitset( const Bitset &query_bitset ) const {
     return ( letters_present_ & query_bitset ) == query_bitset;
   }
 
+  __export__
   Result QueryMatchResult( const std::string &query,
                            bool case_sensitive ) const;
 

--- a/third_party/ycmd/cpp/ycm/CandidateRepository.h
+++ b/third_party/ycmd/cpp/ycm/CandidateRepository.h
@@ -18,6 +18,8 @@
 #ifndef CANDIDATEREPOSITORY_H_K9OVCMHG
 #define CANDIDATEREPOSITORY_H_K9OVCMHG
 
+#include "export.h"
+
 #include <boost/utility.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/thread/mutex.hpp>
@@ -44,14 +46,17 @@ CandidateHolder;
 // This class is thread-safe.
 class CandidateRepository : boost::noncopyable {
 public:
+  __export__
   static CandidateRepository &Instance();
 
   int NumStoredCandidates();
 
+  __export__
   std::vector< const Candidate * > GetCandidatesForStrings(
     const std::vector< std::string > &strings );
 
 #ifdef USE_CLANG_COMPLETER
+  __export__
   std::vector< const Candidate * > GetCandidatesForStrings(
     const std::vector< CompletionData > &datas );
 #endif // USE_CLANG_COMPLETER

--- a/third_party/ycmd/cpp/ycm/IdentifierCompleter.h
+++ b/third_party/ycmd/cpp/ycm/IdentifierCompleter.h
@@ -18,6 +18,7 @@
 #ifndef COMPLETER_H_7AR4UGXE
 #define COMPLETER_H_7AR4UGXE
 
+#include "export.h"
 #include "IdentifierDatabase.h"
 
 #include <boost/utility.hpp>
@@ -36,7 +37,9 @@ class Candidate;
 
 class IdentifierCompleter : boost::noncopyable {
 public:
+  __export__
   IdentifierCompleter();
+  __export__
   IdentifierCompleter( const std::vector< std::string > &candidates );
   IdentifierCompleter( const std::vector< std::string > &candidates,
                        const std::string &filetype,
@@ -47,9 +50,11 @@ public:
     const std::string &filetype,
     const std::string &filepath );
 
+  __export__
   void AddIdentifiersToDatabaseFromTagFiles(
     const std::vector< std::string > &absolute_paths_to_tag_files );
 
+  __export__
   void AddIdentifiersToDatabaseFromBuffer(
     const std::string &buffer_contents,
     const std::string &filetype,
@@ -57,9 +62,11 @@ public:
     bool collect_from_comments_and_strings );
 
   // Only provided for tests!
+  __export__
   std::vector< std::string > CandidatesForQuery(
     const std::string &query ) const;
 
+  __export__
   std::vector< std::string > CandidatesForQueryAndType(
     const std::string &query,
     const std::string &filetype ) const;

--- a/third_party/ycmd/cpp/ycm/IdentifierUtils.h
+++ b/third_party/ycmd/cpp/ycm/IdentifierUtils.h
@@ -19,6 +19,7 @@
 #define IDENTIFIERUTILS_CPP_WFFUZNET
 
 #include "IdentifierDatabase.h"
+#include "export.h"
 
 #include <vector>
 #include <string>
@@ -32,11 +33,14 @@ namespace YouCompleteMe {
 // the parameter BUT if this code is compiled in C++11 mode a move constructor
 // can be called on the passed-in value. This is not possible if we accept the
 // param by const ref.
+__export__
 std::string RemoveIdentifierFreeText( std::string text );
 
+__export__
 std::vector< std::string > ExtractIdentifiersFromText(
   const std::string &text );
 
+__export__
 FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
   const boost::filesystem::path &path_to_tag_file );
 

--- a/third_party/ycmd/cpp/ycm/LetterNodeListMap.h
+++ b/third_party/ycmd/cpp/ycm/LetterNodeListMap.h
@@ -18,6 +18,8 @@
 #ifndef LETTERNODELISTMAP_H_BRK2UMC1
 #define LETTERNODELISTMAP_H_BRK2UMC1
 
+#include "export.h"
+
 #include <list>
 #include <boost/utility.hpp>
 #include <boost/array.hpp>
@@ -30,12 +32,15 @@ class LetterNode;
 
 extern const int kNumLetters;
 
+__export__
 int IndexForChar( char letter );
+__export__
 bool IsUppercase( char letter );
 
 class LetterNodeListMap : boost::noncopyable {
 public:
   LetterNodeListMap();
+  __export__
   ~LetterNodeListMap();
 
   bool HasLetter( char letter );

--- a/third_party/ycmd/cpp/ycm/export.h
+++ b/third_party/ycmd/cpp/ycm/export.h
@@ -1,0 +1,23 @@
+// Copyright (C) 2011, 2012  Google Inc.
+//
+// This file is part of YouCompleteMe.
+//
+// YouCompleteMe is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// YouCompleteMe is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+#if __CYGWIN__
+#define __export__ \
+    __declspec(dllexport)
+#else
+#define __export__ 
+#endif

--- a/third_party/ycmd/cpp/ycm/tests/CMakeLists.txt
+++ b/third_party/ycmd/cpp/ycm/tests/CMakeLists.txt
@@ -23,6 +23,8 @@ cmake_minimum_required( VERSION 2.8 )
 if ( COMPILER_IS_CLANG )
   set( CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -Wno-long-long -Wno-variadic-macros -Wno-missing-field-initializers -Wno-unused-private-field" )
+elseif ( CYGWIN AND CMAKE_COMPILER_IS_GNUCXX )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs" )
 endif()
 
 add_subdirectory( gmock )

--- a/third_party/ycmd/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/third_party/ycmd/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -174,10 +174,18 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
   expected[ "cpp" ][ ( testfile_parent / "bar" ).string() ]
   .push_back( "fooaaa" );
 
+#if __CYGWIN__
+  // TODO: Real absolute file test here
+  expected[ "c" ][ ( testfile_parent ).string() + "/foo/zoo" ].push_back( "Floo::goo" );
+  expected[ "c" ][ ( testfile_parent ).string() + "/foo/goo maa" ].push_back( "!goo" );
+
+  expected[ "cs" ][ ( testfile_parent ).string() + "/m_oo" ].push_back( "#bleh" );
+#else
   expected[ "c" ][ "/foo/zoo" ].push_back( "Floo::goo" );
   expected[ "c" ][ "/foo/goo maa" ].push_back( "!goo" );
 
   expected[ "cs" ][ "/m_oo" ].push_back( "#bleh" );
+#endif
 
   EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
                ContainerEq( expected ) );


### PR DESCRIPTION
- Building generates warnings-as-errors from unused-local-typedefs when building the tests. Pass -Wno-unused-local-typedefs to disable this warnings.
- The test executable won't link in Cygwin unless the references it needs are explicitly exported.
  ExtractIdentifiersFromTagsFileWork test fails because the absolute path will be in Windows form. Skip it.
- Making ycm_core_tests only compiles .dll.a and we need the .dll as well. Make ycm_support_lib as well to create the DLLs.
- Cygwin executables look in the PATH for DLLs (since they are considered executables). Add YCM's python directory to PATH in the run test call.

This is 2, 5, 6, 7 and 8 in #866.

I am not a C/C++ developer, so any improvements on this are more than welcome.

I have already signed the CLA.
