### PR TITLE
Set runtime output for multi-config builds as well

### DIFF
--- a/third_party/ycmd/cpp/ycm/CMakeLists.txt
+++ b/third_party/ycmd/cpp/ycm/CMakeLists.txt
@@ -319,10 +319,19 @@ set_target_properties( ${SERVER_LIB} PROPERTIES PREFIX "")
 
 if ( WIN32 OR CYGWIN )
   # DLL platforms put dlls in the RUNTIME_OUTPUT_DIRECTORY
+  # First for the generic no-config case (e.g. with mingw)
   set_target_properties( ${CLIENT_LIB} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/../.. )
   set_target_properties( ${SERVER_LIB} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/../.. )
+  # Second, for multi-config builds (e.g. msvc)
+  foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
+    string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+    set_target_properties( ${CLIENT_LIB} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_SOURCE_DIR}/../.. )
+    set_target_properties( ${SERVER_LIB} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_SOURCE_DIR}/../.. )
+  endforeach()
 
   if ( WIN32 )
     # This is the extension for compiled Python modules on Windows


### PR DESCRIPTION
Multi-config builders need RUNTIME_OUTPUT_DIRECTORY to set for each config as well.

Improvement to related changes in https://github.com/Valloric/YouCompleteMe/pull/901

I have already signed the CLA.
