### PR TITLE
Detach from controlling terminal to avoid receiving SIGINT.

### DIFF
--- a/python/ycm/server/ycmd.py
+++ b/python/ycm/server/ycmd.py
@@ -112,7 +112,7 @@ def Main():
 
   # If not on windows, detach from controlling terminal to prevent
   # SIGINT from killing us.
-  if sys.platform is not 'win32':
+  if not utils.OnWindows():
     os.setsid()
 
   # This can't be a top-level import because it transitively imports


### PR DESCRIPTION
This fixes #698. It has only been tested on one Linux system.
