### PR TITLE
Async Pong support

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -156,6 +156,12 @@ let g:ycm_warning_symbol =
 let g:ycm_goto_buffer_command =
       \ get( g:, 'ycm_goto_buffer_command', 'same-buffer' )
 
+let g:ycm_async_pong =
+      \ get( g:, 'ycm_async_pong', 1 )
+
+let g:ycm_async_pong_tty_patch =
+      \ get( g:, 'ycm_async_pong_tty_patch', 0 )
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart

--- a/python/ycm/async_pong.py
+++ b/python/ycm/async_pong.py
@@ -1,0 +1,68 @@
+import vim
+class Dispatch:
+  def __new__(tp, **kw):
+    try:
+      if vim.eval('has("gui_running")') != '0':
+        return GTK(**kw)
+      elif 'tty_patch' in kw and kw['tty_patch']:
+        return TTY(**kw)
+    except:
+      pass
+    return Nop(**kw)
+
+class Nop:
+  def __init__(self, **kw):
+    return
+  def Cleanup(self):
+    return
+  def __call__(self):
+    return
+
+try:
+  import termios
+  import fcntl
+  class TTY(Nop):
+    def __init__(self, **kw):
+      vim.command('nnoremap \uFEFF <CursorHold>')
+      vim.command('onoremap \uFEFF <CursorHold>')
+      vim.command('vnoremap \uFEFF <CursorHold>')
+      vim.command('inoremap \uFEFF <CursorHold>')
+      vim.command('cnoremap \uFEFF <Nop>')
+
+    def __call__(self):
+      for i in '\ufeff'.encode('utf-8'):
+        fcntl.ioctl(0, termios.TIOCSTI, bytes([i]))
+except:
+  pass
+
+
+try:
+  from gi.repository import GLib
+  import os
+  class GTK:
+    def __init__(self, **kw):
+      self.pipe=os.pipe()
+      ch=GLib.IOChannel(self.pipe[0])
+      ch.set_flags(GLib.IOFlags.NONBLOCK)
+      self.source=GLib.io_add_watch(ch, GLib.IOCondition.IN, self.Callback)
+
+    def Callback(self, ch, flags):
+      ch.read_to_end()
+      ch.read(1)
+      vim.command('doautocmd CursorHold')
+      return True
+
+    def Cleanup(self):
+      from gi.repository import GLib
+      GLib.source_remove(self.source)
+      os.close(self.pipe[0])
+      os.close(self.pipe[1])
+      self.pipe=None
+
+    def __call__(self):
+      if self.pipe:
+        os.write(self.pipe[1], b'!')
+except:
+  pass
+
+# vim: expandtab:ts=2:sw=2:sts=2

--- a/python/ycm/client/event_notification.py
+++ b/python/ycm/client/event_notification.py
@@ -44,6 +44,9 @@ class EventNotification( BaseRequest ):
   def Done( self ):
     return self._response_future.done()
 
+  def DoneCallback( self, cb ):
+    self._response_future.add_done_callback( lambda fut: cb() )
+
 
   def Response( self ):
     if self._cached_response:


### PR DESCRIPTION
The idea is to cause a CursorHold without waiting updatetime milliseconds. This way vim can be notified earlier when something happens.

Currently there are only two implementations.
- TTY: This [tiny patch](https://gist.github.com/mustrumr/9489318) makes it possible to map keys to CursorHold. Map \uFEFF to &lt;CursorHold&gt;. Inject \uFEFF in the tty.
- gtk+: Create a pipe and listen. doautocmd CursorHold when readable.
