### PR TITLE
Fix test failure: HMAC key was not properly encoded in error responses

### DIFF
--- a/python/ycm/server/handlers.py
+++ b/python/ycm/server/handlers.py
@@ -180,7 +180,7 @@ def DebugInfo():
 def ErrorHandler( httperror ):
   body = _JsonResponse( BuildExceptionResponse( httperror.exception,
                                                 httperror.traceback ) )
-  hmac_plugin.SetHmacHeader( body, user_options_store.Value( 'hmac_secret' ) )
+  hmac_plugin.SetHmacHeader( body, user_options_store.Value( 'hmac_secret' ).encode('utf8') )
   return body
 
 

--- a/python/ycm/server/tests/get_completions_test.py
+++ b/python/ycm/server/tests/get_completions_test.py
@@ -181,6 +181,8 @@ def GetCompletions_CsCompleter_DoesntStartWithAmbiguousMultipleSolutions_test():
   except AppError as e:
     if 'Found multiple solution files' in str(e):
       exception_caught = True
+    else:
+      raise
 
   # the test passes if we caught an exception when trying to start it,
   # so raise one if it managed to start


### PR DESCRIPTION
Fixes issues with tests failing. Doesn't seems to break anything else.
