### PR TITLE
Add trailing slash to ycmd_folder_path

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -44,7 +44,7 @@ endif
 
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
 let s:python_folder_path = s:script_folder_path . '/../python/'
-let s:ycmd_folder_path = s:script_folder_path . '/../third_party/ycmd'
+let s:ycmd_folder_path = s:script_folder_path . '/../third_party/ycmd/'
 
 function! s:YcmLibsPresentIn( path_prefix )
   if filereadable(a:path_prefix . 'ycm_client_support.so') &&


### PR DESCRIPTION
Installing YouCompleteMe from scratch produces the error message about ycm_core.[so|pyd|dll] not being detected. Appending the trailing slash to ycmd_folder_path fixes this problem.
