### PR TITLE
Use IPv4 to connect to ycmd

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -123,7 +123,7 @@ class YouCompleteMe( object ):
           args.append('--keep_logfiles')
 
       self._server_popen = utils.SafePopen( args, stdout = PIPE, stderr = PIPE)
-      BaseRequest.server_location = 'http://localhost:' + str( server_port )
+      BaseRequest.server_location = 'http://127.0.0.1:' + str( server_port )
       BaseRequest.hmac_secret = hmac_secret
 
     self._NotifyUserIfServerCrashed()


### PR DESCRIPTION
On my machine, the ycmd is started on IPv4 address only. On the other hand, the completion module in Vim tries to connect to ycmd using IPv6 only. This results in _Resource temporarily unavailable_ errors.

I do not know the reason why this happens. But I guess the Bottle framework just does not support IPv6. And the Requests module tries just the first resolved address for _localhost_.

(I have not signed the Google CLA, but I'm releasing this change as a public domain.)
