### PR TITLE
add support for g:syntastic_ignore_files

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -261,6 +261,18 @@ function! s:DiagnosticUiSupportedForCurrentFiletype()
   return get( s:diagnostic_ui_filetypes, &filetype, 0 )
 endfunction
 
+function! s:DiagnosticUiSkip()
+  let fname = expand('%')
+  " Since we stopped using Syntastic for diagnostics display, this option for
+  " Syntastic no longer works in YCM. So we should handle it ourselves.
+  " FIXME: a YCM option for this?
+  for pat in g:syntastic_ignore_files
+    if fname =~# pat
+      return 1
+    endif
+  endfor
+  return 0
+endfunction
 
 function! s:AllowedToCompleteInCurrentFile()
   if empty( &filetype ) ||
@@ -534,6 +546,7 @@ endfunction
 function! s:UpdateDiagnosticNotifications()
   let should_display_diagnostics = g:ycm_show_diagnostics_ui &&
         \ s:DiagnosticUiSupportedForCurrentFiletype() &&
+        \ !s:DiagnosticUiSkip() &&
         \ pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
 
   if !should_display_diagnostics


### PR DESCRIPTION
Since we stopped using Syntastic for diagnostics display, this option
for Syntastic no longer works in YCM. So we should handle it ourselves.

Expaination of g:syntastic_ignore_files:

https://github.com/scrooloose/syntastic/blob/50518b335d6bc486c895d4cb34c29417238cbe81/doc/syntastic.txt#L384

P.S. I've signed the Google CLA.
