### PR TITLE
add g:ycm_diagnostic_ignore_files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,24 @@ Default: `1`
 
     let g:ycm_show_diagnostics_ui = 1
 
+### The `g:ycm_diagnostic_ignore_files` option
+
+Use this option to specify files that do not display diagnostic UI. It's a list
+of regular-expression patterns. The full paths of files are matched against
+these patterns, and the matches are case sensitive. Use `\c` to specify case
+insensitive patterns. For example, if you do not want to diagnose the files in
+'/usr/include' and all the C header files, set this in ~/.vimrc:
+
+    let g:ycm_diagnostic_ignore_files = ['\m^/usr/include/',  '\m\c\.h$']
+
+This option is part of the Syntastic compatibility layer; if the option is not
+set, YCM will fall back to the value of the `g:syntastic_ignore_files` option
+before using this option's default.
+
+Default: `[]`
+
+    let g:ycm_diagnostic_ignore_files = []
+
 ### The `g:ycm_error_symbol` option
 
 YCM will use the value of this option as the symbol for errors in the Vim

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -262,6 +262,15 @@ function! s:DiagnosticUiSupportedForCurrentFiletype()
   return get( s:diagnostic_ui_filetypes, &filetype, 0 )
 endfunction
 
+function! s:DiagnosticUiSkip()
+  let fname = expand('%')
+  for pat in g:ycm_diagnostic_ignore_files
+    if fname =~# pat
+      return 1
+    endif
+  endfor
+  return 0
+endfunction
 
 function! s:AllowedToCompleteInCurrentFile()
   if empty( &filetype ) ||
@@ -529,6 +538,7 @@ endfunction
 function! s:UpdateDiagnosticNotifications()
   let should_display_diagnostics = g:ycm_show_diagnostics_ui &&
         \ s:DiagnosticUiSupportedForCurrentFiletype() &&
+        \ !s:DiagnosticUiSkip() &&
         \ pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
 
   if !should_display_diagnostics

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -44,42 +44,43 @@ Contents ~
   5. The |g:ycm_filetype_blacklist| option
   6. The |g:ycm_filetype_specific_completion_to_disable| option
   7. The |g:ycm_show_diagnostics_ui| option
-  8. The |g:ycm_error_symbol| option
-  9. The |g:ycm_warning_symbol| option
-  10. The |g:ycm_enable_diagnostic_signs| option
-  11. The |g:ycm_enable_diagnostic_highlighting| option
-  12. The |g:ycm_echo_current_diagnostic| option
-  13. The |g:ycm_always_populate_location_list| option
-  14. The |g:ycm_open_loclist_on_ycm_diags| option
-  15. The |g:ycm_allow_changing_updatetime| option
-  16. The |g:ycm_complete_in_comments| option
-  17. The |g:ycm_complete_in_strings| option
-  18. The |g:ycm_collect_identifiers_from_comments_and_strings| option
-  19. The |g:ycm_collect_identifiers_from_tags_files| option
-  20. The |g:ycm_seed_identifiers_with_syntax| option
-  21. The |g:ycm_extra_conf_vim_data| option
-  22. The |g:ycm_path_to_python_interpreter| option
-  23. The |g:ycm_server_use_vim_stdout| option
-  24. The |g:ycm_server_keep_logfiles| option
-  25. The |g:ycm_server_log_level| option
-  26. The |g:ycm_csharp_server_port| option
-  27. The |g:ycm_auto_start_csharp_server| option
-  28. The |g:ycm_auto_stop_csharp_server| option
-  29. The |g:ycm_add_preview_to_completeopt| option
-  30. The |g:ycm_autoclose_preview_window_after_completion| option
-  31. The |g:ycm_autoclose_preview_window_after_insertion| option
-  32. The |g:ycm_max_diagnostics_to_display| option
-  33. The |g:ycm_key_list_select_completion| option
-  34. The |g:ycm_key_list_previous_completion| option
-  35. The |g:ycm_key_invoke_completion| option
-  36. The |g:ycm_key_detailed_diagnostics| option
-  37. The |g:ycm_global_ycm_extra_conf| option
-  38. The |g:ycm_confirm_extra_conf| option
-  39. The |g:ycm_extra_conf_globlist| option
-  40. The |g:ycm_filepath_completion_use_working_dir| option
-  41. The |g:ycm_semantic_triggers| option
-  42. The |g:ycm_cache_omnifunc| option
-  43. The |g:ycm_use_ultisnips_completer| option
+  8. The |g:ycm_diagnostic_ignore_files| option
+  9. The |g:ycm_error_symbol| option
+  10. The |g:ycm_warning_symbol| option
+  11. The |g:ycm_enable_diagnostic_signs| option
+  12. The |g:ycm_enable_diagnostic_highlighting| option
+  13. The |g:ycm_echo_current_diagnostic| option
+  14. The |g:ycm_always_populate_location_list| option
+  15. The |g:ycm_open_loclist_on_ycm_diags| option
+  16. The |g:ycm_allow_changing_updatetime| option
+  17. The |g:ycm_complete_in_comments| option
+  18. The |g:ycm_complete_in_strings| option
+  19. The |g:ycm_collect_identifiers_from_comments_and_strings| option
+  20. The |g:ycm_collect_identifiers_from_tags_files| option
+  21. The |g:ycm_seed_identifiers_with_syntax| option
+  22. The |g:ycm_extra_conf_vim_data| option
+  23. The |g:ycm_path_to_python_interpreter| option
+  24. The |g:ycm_server_use_vim_stdout| option
+  25. The |g:ycm_server_keep_logfiles| option
+  26. The |g:ycm_server_log_level| option
+  27. The |g:ycm_csharp_server_port| option
+  28. The |g:ycm_auto_start_csharp_server| option
+  29. The |g:ycm_auto_stop_csharp_server| option
+  30. The |g:ycm_add_preview_to_completeopt| option
+  31. The |g:ycm_autoclose_preview_window_after_completion| option
+  32. The |g:ycm_autoclose_preview_window_after_insertion| option
+  33. The |g:ycm_max_diagnostics_to_display| option
+  34. The |g:ycm_key_list_select_completion| option
+  35. The |g:ycm_key_list_previous_completion| option
+  36. The |g:ycm_key_invoke_completion| option
+  37. The |g:ycm_key_detailed_diagnostics| option
+  38. The |g:ycm_global_ycm_extra_conf| option
+  39. The |g:ycm_confirm_extra_conf| option
+  40. The |g:ycm_extra_conf_globlist| option
+  41. The |g:ycm_filepath_completion_use_working_dir| option
+  42. The |g:ycm_semantic_triggers| option
+  43. The |g:ycm_cache_omnifunc| option
+  44. The |g:ycm_use_ultisnips_completer| option
  10. FAQ                                                    |youcompleteme-faq|
   1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |import-vim|
   2. On very rare occasions Vim crashes when I tab through the completion menu |youcompleteme-on-very-rare-occasions-vim-crashes-when-i-tab-through-completion-menu|
@@ -998,6 +999,26 @@ GCC Syntastic checkers, unset this option.
 Default: '1'
 >
   let g:ycm_show_diagnostics_ui = 1
+<
+-------------------------------------------------------------------------------
+The *g:ycm_diagnostic_ignore_files* option
+
+Use this option to specify files that do not display diagnostic UI. It's a
+list of |regular-expression| patterns. The full paths of files (see |::p|) are
+matched against these patterns, and the matches are case sensitive. Use |\c|
+to specify case insensitive patterns. For example, if you do not want to
+diagnose the files in '/usr/include' and all the C header files, set this in
+~/.vimrc: >
+
+    let g:ycm_diagnostic_ignore_files = ['\m^/usr/include/',  '\m\c\.h$']
+<
+This option is part of the Syntastic compatibility layer; if the option is not
+set, YCM will fall back to the value of the 'g:syntastic_ignore_files' option
+before using this option's default.
+
+Default: '[]' >
+
+    let g:ycm_diagnostic_ignore_files = []
 <
 -------------------------------------------------------------------------------
 The *g:ycm_error_symbol* option

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -140,6 +140,10 @@ let g:ycm_show_diagnostics_ui =
       \ get( g:, 'ycm_show_diagnostics_ui',
       \ get( g:, 'ycm_register_as_syntastic_checker', 1 ) )
 
+let g:ycm_diagnostic_ignore_files =
+      \ get( g:, 'ycm_diagnostic_ignore_files',
+      \ get( g:, 'syntastic_ignore_files', [] ) )
+
 let g:ycm_enable_diagnostic_signs =
       \ get( g:, 'ycm_enable_diagnostic_signs',
       \ get( g:, 'syntastic_enable_signs', 1 ) )


### PR DESCRIPTION
Use this option to specify files that do not display diagnostic UI. It's
a list of regular-expression patterns. The full paths of files are
matched against these patterns, and the matches are case sensitive.

This option is part of the Syntastic compatibility layer; if the option
is not set, YCM will fall back to the value of the
`g:syntastic_ignore_files` option before using this option's default.

P.S. I've signed the Google CLA before.
