### PR TITLE
Fix running scripts from a directory whose name contains space

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ if [[ ! -f "$build_file" ]]; then
   exit 1
 fi
 
-$build_file "$@"
+"$build_file" "$@"
 
 # Remove old YCM libs if present so that YCM can start.
 rm -f python/*ycm_core.* &> /dev/null

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,21 +4,21 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$SCRIPT_DIR/third_party/ycmd/build.sh
+"${SCRIPT_DIR}/third_party/ycmd/build.sh"
 
-flake8 --select=F,C9 --max-complexity=10 $SCRIPT_DIR/python
+flake8 --select=F,C9 --max-complexity=10 "${SCRIPT_DIR}/python"
 
-for directory in $SCRIPT_DIR/third_party/*; do
+for directory in "${SCRIPT_DIR}"/third_party/*; do
   if [ -d "${directory}" ]; then
     export PYTHONPATH=${directory}:$PYTHONPATH
   fi
 done
 
 
-for directory in $SCRIPT_DIR/third_party/ycmd/third_party/*; do
+for directory in "${SCRIPT_DIR}"/third_party/ycmd/third_party/*; do
   if [ -d "${directory}" ]; then
     export PYTHONPATH=${directory}:$PYTHONPATH
   fi
 done
 
-nosetests -v $SCRIPT_DIR/python
+nosetests -v "${SCRIPT_DIR}/python"


### PR DESCRIPTION
Match Valloric/ycmd#13.

This will allow user to run `~/.vim/bundle/YouCompleteMe/install.sh` directly without cd into the directory.
## 

CLA signed.
