### PR TITLE
Fix unicode-character filename bug.

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -103,7 +103,7 @@ def GetUnsavedAndCurrentBufferData():
 
 
 def GetBufferNumberForFilename( filename, open_file_if_needed = True ):
-  return GetIntValue( "bufnr('{0}', {1})".format(
+  return GetIntValue( u"bufnr('{0}', {1})".format(
       os.path.realpath( filename ),
       int( open_file_if_needed ) ) )
 


### PR DESCRIPTION
Issued here https://github.com/Valloric/YouCompleteMe/issues/1069
To reproduce:
1. Create any file with unicode character on its filename, e.g `Ω.c`
2. Open the file and start adding codes until >5 lines (i.e ycm start compiling)
3. YCM will crash due to unicode encoding error. See issue referenced above for complete log.

I have signed the Google CLA.
