### PR TITLE
Fix : Close Preview Window after insertion.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -21,7 +21,6 @@ set cpo&vim
 
 " This needs to be called outside of a function
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
-let s:searched_and_results_found = 0
 let s:omnifunc_mode = 0
 
 let s:old_cursor_position = []
@@ -518,11 +517,9 @@ function! s:ClosePreviewWindowIfNeeded()
     return
   endif
 
-  if s:searched_and_results_found
-    " This command does the actual closing of the preview window. If no preview
-    " window is shown, nothing happens.
-    pclose
-  endif
+  " This command does the actual closing of the preview window. If no preview
+  " window is shown, nothing happens.
+  pclose
 endfunction
 
 
@@ -633,7 +630,6 @@ EOF
 function! s:GetCompletions()
   py results = GetCompletionsInner()
   let results = pyeval( 'results' )
-  let s:searched_and_results_found = len( results.words ) != 0
   return results
 endfunction
 


### PR DESCRIPTION
Fixes #524

**I signed the CLA.**

After doing a bit of history research, I came to the conclusion that `s:searched_and_results_found` was actually used to prevent an infinite loop.
Although, the de8f45c2021814529928c5025ce08ffb6b47cb6f commit changed this. The only purpose of the `s:searched_and_results_found` variable now was to avoid calling `pclose` if there were no results.

Now, this condition is only causing trouble. Calling `pclose` whether there are results or not is not a problem.

So in the end, I've found no reason anymore for this condition, unless @Valloric says otherwise, so we can simply remove it, and the `s:searched_and_results_found` variable too.
