### PR TITLE
Adds YcmLock and YcmUnlock commands to temporarily prevent autocompletio...

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -268,7 +268,8 @@ endfunction
 function! s:AllowedToCompleteInCurrentFile()
   if empty( &filetype ) ||
         \ getbufvar( winbufnr( winnr() ), "&buftype" ) ==# 'nofile' ||
-        \ &filetype ==# 'qf'
+        \ &filetype ==# 'qf' ||
+        \ s:lock
     return 0
   endif
 
@@ -408,7 +409,7 @@ endfunction
 
 
 function! s:OnCursorMovedInsertMode()
-  if !s:AllowedToCompleteInCurrentFile() || s:lock
+  if !s:AllowedToCompleteInCurrentFile()
     return
   endif
 
@@ -445,7 +446,7 @@ endfunction
 
 
 function! s:OnCursorMovedNormalMode()
-  if !s:AllowedToCompleteInCurrentFile() || s:lock
+  if !s:AllowedToCompleteInCurrentFile()
     return
   endif
 


### PR DESCRIPTION
Added Vim commands for temorarily locking(disabling) and unlocking(enabling) autocomplete trigger as you type (on cursor move).
To lock it, just use command:

```
:YcmLock
```

And to unlock it:

```
:YcmUnlock
```

YCM generall works fine with https://github.com/kristijanhusak/vim-multiple-cursors, but it slows it a bit. Adding this to vimrc can be small improvement (https://github.com/kristijanhusak/vim-multiple-cursors/issues/4):

```
" Disable autocomplete before multiple cursors to avoid conflict
function! Multiple_cursors_before()
    exe 'YcmLock'
endfunction

" Enable autocomplete after multiple cursors
function! Multiple_cursors_after()
    exe 'YcmUnlock'
endfunction

```
