### PR TITLE
Add functionality for disabling and enabling Ycm autocompletion.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -816,14 +816,10 @@ function youcompleteme#EnableCursorMovedAutocommands()
     augroup END
 endfunction
 
-command! YcmUnlock call youcompleteme#EnableCursorMovedAutocommands()
-
 function youcompleteme#DisableCursorMovedAutocommands()
     autocmd! ycmcompletemecursormove CursorMoved *
     autocmd! ycmcompletemecursormove CursorMovedI *
 endfunction
-
-command! YcmLock call youcompleteme#DisableCursorMovedAutocommands()
 
 " This is basic vim plugin boilerplate
 let &cpo = s:save_cpo


### PR DESCRIPTION
This is the better solution for this pull request that i made this morning https://github.com/Valloric/YouCompleteMe/pull/1165

On that PR autocmd was triggering even when Lock command was called. In this PR that is fixed, so now when you call `YcmLock` it disables autocommands for CursorMoved and CursorMovedI.

Fixes #1164
