### PR TITLE
`set -e` in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 build_file=$SCRIPT_DIR/third_party/ycmd/build.sh


### PR DESCRIPTION
This allows error in `build.sh` to propagate up. Fixes #1197.
