### PR TITLE
Update README.md with proper clang flag for install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Install dependencies and CMake: `sudo pkg_add llvm boost cmake`
 Compiling YCM **with** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
-    ./install.sh --clang-completer --system-clang --system-boost
+    ./install.sh --clang-completer --system-libclang --system-boost
 
 Compiling YCM **without** semantic support for C-family languages:
 


### PR DESCRIPTION
Following the instruction in the README for OS X revealed a minor documentation error.

```
➜  YouCompleteMe git:(master) ✗ ./install.sh --clang-completer --system-clang --system-boost
Usage: /Users/jwomack/.vim/bundle/YouCompleteMe/third_party/ycmd/build.sh [--clang-completer [--system-libclang]] [--system-boost] [--omnisharp-completer]

➜  YouCompleteMe git:(master) ✗ ./install.sh --clang-completer --system-libclang --system-boost
/var/folders/b3/2bw5vyb14s32ktj5glp_r1ydcc9ghq/T/ycm_build.XXXXXX.X7SooY2d ~/.vim/bundle/YouCompleteMe
```
