### PR TITLE
Disable on large file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,15 @@ Default: `'same-buffer'`
 
     let g:ycm_goto_buffer_command = 'same-buffer'
 
+### The `g:ycm_disable_for_files_larger_than_kb` option
+
+Defines the max size (in Kb) for a file to be considered for completion. If this
+option is set to 0 then no check is made on the size of the file you're opening
+
+Default: 1000
+
+    let g:ycm_disable_for_files_larger_than_kb = 1000
+
 FAQ
 ---
 

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -167,6 +167,9 @@ let g:ycm_warning_symbol =
 let g:ycm_goto_buffer_command =
       \ get( g:, 'ycm_goto_buffer_command', 'same-buffer' )
 
+let g:ycm_disable_for_files_larger_than_kb =
+      \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart


### PR DESCRIPTION
An attempt to resolve #1238. I did it on the client side because did't seem right to send a large file from the client to the server just to be discarded.

I signed the CLA
