### PR TITLE
fix <c-y> causing strange popup menu and solve <tab> conflict with ultisnips

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -656,7 +656,8 @@ def GetCompletionsInner(baseText):
     if bool( int( vim.eval( 'complete_check()' ) ) ):
       return { 'words' : [], 'refresh' : 'always'}
 
-  results = base.AdjustCandidateInsertionText( request.Response(),baseText )
+  results = base.AdjustCandidateInsertionText( request.Response() )
+  results = filter(lambda a:a.get('abbr', a['word'])!=baseText or a.get('menu'), results)
   return { 'words' : results, 'refresh' : 'always' }
 EOF
 

--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -89,7 +89,7 @@ def LastEnteredCharIsIdentifierChar():
         line, current_column, filetype ) != current_column )
 
 
-def AdjustCandidateInsertionText( candidates, baseText ):
+def AdjustCandidateInsertionText( candidates ):
   """This function adjusts the candidate insertion text to take into account the
   text that's currently in front of the cursor.
 
@@ -111,11 +111,6 @@ def AdjustCandidateInsertionText( candidates, baseText ):
     if overlap_len:
       return to_insert[ :-overlap_len ]
     return to_insert
-
-  """This filter delete the excatly same candidate, we check 'menu' field to
-        preserve the ultisnips' result
-  """
-  candidates = filter(lambda a:a['word']!=baseText or a.get('menu'), candidates);
 
   text_after_cursor = vimsupport.TextAfterCursor()
   if not text_after_cursor:


### PR DESCRIPTION
Use CONTROL-Y to accept the current candidate will cause a second popup menu. Because after ycm insterts the candidate, cursor position has changed and ycm will find a new candidate again. I delete the candidate exactly same as the text to match. Thus, no second popup menu will occur.

By this enhancement, I can use vim script to use TAB key for both cycling through ycm candidates and ultisnips placeholders. Also I can use ENTER key for both accepting ycm candidate and expand ultisnips. I add the solution to README.md.
