### PR TITLE
Fix #814

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -793,7 +793,7 @@ function! s:ForceCompile()
   endif
 
   echom "Forcing compilation, this will block Vim until done."
-  py ycm_state.OnFileReadyToParse()
+  py ycm_state.OnFileReadyToParse( is_forced=True )
   while 1
     let diagnostics_ready = pyeval(
           \ 'ycm_state.DiagnosticsForCurrentFileReady()' )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -227,13 +227,17 @@ class YouCompleteMe( object ):
              self.NativeFiletypeCompletionAvailable() )
 
 
-  def OnFileReadyToParse( self ):
+  def OnFileReadyToParse( self, is_forced=False ):
     self._omnicomp.OnFileReadyToParse( None )
 
     if not self.IsServerAlive():
       self._NotifyUserIfServerCrashed()
 
     extra_data = {}
+
+    if is_forced:
+      extra_data['is_forced'] = True
+
     self._AddTagsFilesIfNeeded( extra_data )
     self._AddSyntaxDataIfNeeded( extra_data )
     self._AddExtraConfDataIfNeeded( extra_data )


### PR DESCRIPTION
Set request_data['is_forced'] to True to indicate that OnFileReadyToParse was triggered by YcmForceCompileAndDiagnostics.
The code completion server (Valloric/ycmd) can now ignore  the 'file too short' exception when is_forced is not set to True (or the key does not the exist).
