### PR TITLE
Remove all bashisms.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-build_file=$SCRIPT_DIR/third_party/ycmd/build.sh
+build_file="$SCRIPT_DIR/third_party/ycmd/build.sh"
 
-if [[ ! -f "$build_file" ]]; then
+if [ ! -f "$build_file" ]; then
   echo "File $build_file doesn't exist; you probably forgot to run:"
   printf "\n\tgit submodule update --init --recursive\n\n"
   exit 1
@@ -15,6 +15,6 @@ fi
 "$build_file" "$@"
 
 # Remove old YCM libs if present so that YCM can start.
-rm -f python/*ycm_core.* &> /dev/null
-rm -f python/*ycm_client_support.* &> /dev/null
-rm -f python/*clang*.* &> /dev/null
+rm -f python/*ycm_core.* >/dev/null 2>&1
+rm -f python/*ycm_client_support.* >/dev/null 2>&1
+rm -f python/*clang*.* >/dev/null 2>&1


### PR DESCRIPTION
fixes #1290
This makes it possible to run install.sh under a POSIX sh, instead of
depending on bash.

Note that this PR includes a submodule update to ycmd, which requires [my PR to YCMD](ttps://github.com/Valloric/ycmd/pull/69) to be merged first.

I signed the CLA.