### PR TITLE
Use python2 in install.sh if it exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,9 @@ if [[ ! -f "$build_file" ]]; then
   exit 1
 fi
 
-"$build_file" "$@"
+PYTHON2=python
+command -v python2 >/dev/null && PYTHON2=python2
+$PYTHON2 "$build_file" "$@"
 
 # Remove old YCM libs if present so that YCM can start.
 rm -f python/*ycm_core.* &> /dev/null


### PR DESCRIPTION
This checks if there exists a python2 in $PATH and uses this instead of python to call the build script. This fixes the build for archlinux where python is python2 and also works on systems that don't have a python2 binary (in which case python is python2). This check should work in all POSIX shells.

I signed the CLA.