### PR TITLE
Ignore whitespace after triggers for semantic completion.

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -134,7 +134,7 @@ class BaseRequest( object ):
 
 
 def BuildRequestData( include_buffer_data = True ):
-  line, column = vimsupport.CurrentLineAndColumn()
+  line, column = vimsupport.LastTriggerLineAndColumn()
   filepath = vimsupport.GetCurrentBufferFilepath()
   request_data = {
     'line_num': line + 1,

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -85,7 +85,7 @@ def VimVersionAtLeast( version_string ):
   # For Vim 7.4.301, v:version is '704'
   actual_major_and_minor = GetIntValue( 'v:version' )
   if actual_major_and_minor != major * 100 + minor:
-    return False
+    return actual_major_and_minor > major * 100 + minor
 
   return GetBoolValue( 'has("patch{0}")'.format( patch ) )
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -23,6 +23,7 @@ import tempfile
 import json
 from ycmd.utils import ToUtf8IfNeeded
 from ycmd import user_options_store
+from ycmd import identifier_utils
 
 BUFFER_COMMAND_MAP = { 'same-buffer'      : 'edit',
                        'horizontal-split' : 'split',
@@ -35,6 +36,23 @@ def CurrentLineAndColumn():
   # column number
   line, column = vim.current.window.cursor
   line -= 1
+  return line, column
+
+
+def LastTriggerLineAndColumn():
+  line, column = CurrentLineAndColumn()
+  line_value = vim.current.line[ :column ].rstrip()
+  while not line_value:
+    line = line - 1
+    if line == -1:
+      return CurrentLineAndColumn()
+    line_value = vim.current.buffer[ line ].rstrip()
+  column = len( line_value )
+  filetypes =  CurrentFiletypes()
+  filetype = filetypes[ 0 ] if filetypes else None
+  if identifier_utils.IsIdentifier( vim.current.buffer[ line ][ column - 1 ],
+                                    filetype ):
+    return CurrentLineAndColumn()
   return line, column
 
 


### PR DESCRIPTION
This makes semantic completion to work irrespective of the whitespaces that may come after triggers by fooling the server that the completion is happening just after the trigger.

I've signed the CLA.