### PR TITLE
Add option to enable semantic based completion without trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,18 @@ Default: `1`
 
     let g:ycm_auto_trigger = 1
 
+### The `g:ycm_prefer_semantic` option
+
+When set to `1`, the identifier-based completion engine will be ignored if a
+semantic completion engine is available.
+
+YCM will always use the semantic completion engine when available, 
+even without semantic triggers.
+
+Default: `0`
+
+    let g:ycm_prefer_semantic = 0
+
 ### The `g:ycm_filetype_whitelist` option
 
 This option controls for which Vim filetypes (see `:h filetype`) should YCM be

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -691,7 +691,11 @@ function! youcompleteme#Complete( findstart, base )
     if !pyeval( 'ycm_state.IsServerAlive()' )
       return -2
     endif
-    py ycm_state.CreateCompletionRequest()
+    if g:ycm_prefer_semantic == 1
+	    py ycm_state.CreateCompletionRequest( force_semantic = True )
+	else
+	    py ycm_state.CreateCompletionRequest( )
+	endifM
     return pyeval( 'base.CompletionStartColumn()' )
   else
     return s:GetCompletions()

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -692,10 +692,10 @@ function! youcompleteme#Complete( findstart, base )
       return -2
     endif
     if g:ycm_prefer_semantic
-	    py ycm_state.CreateCompletionRequest( force_semantic = True )
-	else
-	    py ycm_state.CreateCompletionRequest( )
-	endif
+        py ycm_state.CreateCompletionRequest( force_semantic = True )
+    else
+        py ycm_state.CreateCompletionRequest( )
+    endif
     return pyeval( 'base.CompletionStartColumn()' )
   else
     return s:GetCompletions()

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -691,11 +691,11 @@ function! youcompleteme#Complete( findstart, base )
     if !pyeval( 'ycm_state.IsServerAlive()' )
       return -2
     endif
-    if g:ycm_prefer_semantic == 1
+    if g:ycm_prefer_semantic
 	    py ycm_state.CreateCompletionRequest( force_semantic = True )
 	else
 	    py ycm_state.CreateCompletionRequest( )
-	endifM
+	endif
     return pyeval( 'base.CompletionStartColumn()' )
   else
     return s:GetCompletions()

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -170,6 +170,9 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
+let g:ycm_prefer_semantic =
+      \ get( g:, 'ycm_prefer_semantic', '0' )
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart


### PR DESCRIPTION
This patch adds a new option `g:ycm_prefer_semantic`. 

When set to `1`, the as-you-type completion will use the semantic completion engine, instead of the default identifier based one.

Although it might cause problems or confusions in certain large project, I think this feature should still be useful for many people (especially when writing programs in languages like C). Having this as an option seems reasonable to me.

Tested on my side. CLA signed.