### PR TITLE
Add support for commands returning text to echo in vim

### DIFF
--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -37,12 +37,14 @@ Contents ~
   3. The |GoTo| subcommand
   4. The |GoToImprecise| subcommand
   5. The |ClearCompilationFlagCache| subcommand
-  6. The |StartServer| subcommand
-  7. The |StopServer| subcommand
-  8. The |RestartServer| subcommand
-  9. The |ReloadSolution| subcommand
-  10. The |GoToImplementation| subcommand
-  11. The |GoToImplementationElseDeclaration| subcommand
+  6. The |GetType| subcommand
+  7. The |GetParent| subcommand
+  8. The |StartServer| subcommand
+  9. The |StopServer| subcommand
+  10. The |RestartServer| subcommand
+  11. The |ReloadSolution| subcommand
+  12. The |GoToImplementation| subcommand
+  13. The |GoToImplementationElseDeclaration| subcommand
  7. Options                                             |youcompleteme-options|
   1. The |g:ycm_min_num_of_chars_for_completion| option
   2. The |g:ycm_min_num_identifier_candidate_chars| option
@@ -947,6 +949,41 @@ Vim of course).
 
 This command clears that cache entirely. YCM will then re-query your
 'FlagsForFile' function as needed in the future.
+
+Supported in filetypes: 'c, cpp, objc, objcpp'
+
+-------------------------------------------------------------------------------
+The *GetType* subcommand
+
+Echos the type of the variable or method under the cursor.
+
+Supported in filetypes: 'c, cpp, objc, objcpp'
+
+-------------------------------------------------------------------------------
+The *GetParent* subcommand
+
+Echos the semantic parent of the point under the cursor.
+
+The semantic parent is the item that semantically contains the given position.
+
+For example:
+>
+    class C {
+        void f();
+    };
+
+    void C::f() { 
+    
+    }
+<
+In the out-of-line definition of C::f, the semantic parent is the class C, 
+of which this function is a member.
+
+In the example above, both declarations of C::f have C as their semantic 
+context, while the lexical context of the first C::f is C and the lexical 
+context of the second C::f is the translation unit.
+
+For global declarations, the semantic parent is the translation unit.
 
 Supported in filetypes: 'c, cpp, objc, objcpp'
 

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -57,17 +57,20 @@ class CommandRequest( BaseRequest ):
 
 
   def RunPostCommandActionsIfNeeded( self ):
-    if not self._is_goto_command or not self.Done() or not self._response:
+    if not self.Done() or not self._response:
       return
 
-    if isinstance( self._response, list ):
-      defs = [ _BuildQfListItem( x ) for x in self._response ]
-      vim.eval( 'setqflist( %s )' % repr( defs ) )
-      vim.eval( 'youcompleteme#OpenGoToList()' )
-    else:
-      vimsupport.JumpToLocation( self._response[ 'filepath' ],
-                                 self._response[ 'line_num' ],
-                                 self._response[ 'column_num' ] )
+    if self._is_goto_command: 
+      if isinstance( self._response, list ):
+        defs = [ _BuildQfListItem( x ) for x in self._response ]
+        vim.eval( 'setqflist( %s )' % repr( defs ) )
+        vim.eval( 'youcompleteme#OpenGoToList()' )
+      else:
+        vimsupport.JumpToLocation( self._response[ 'filepath' ],
+                                    self._response[ 'line_num' ],
+                                    self._response[ 'column_num' ] )
+    elif 'message' in self._response:
+        vimsupport.EchoText( self._response['message'] )
 
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,9 +4,28 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-"${SCRIPT_DIR}/third_party/ycmd/build.py"
+function usage {
+  echo "Usage: $0 [--skip-build]"
+  exit 0
+}
 
 flake8 --select=F,C9 --max-complexity=10 "${SCRIPT_DIR}/python"
+skip_build=false
+
+for flag in $@; do
+  case "$flag" in
+    --skip-build)
+      skip_build=true
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if ! $skip_build; then
+    "${SCRIPT_DIR}/third_party/ycmd/build.py"
+fi
 
 for directory in "${SCRIPT_DIR}"/third_party/*; do
   if [ -d "${directory}" ]; then


### PR DESCRIPTION
This change allows completer subcommands to return text which is echo'd in vim.

This is used by the clang completer subcommands GetType and GetParent which return the type and semantic parent of the word under the cursor respectively.