### PR TITLE
Support completer commands that return text

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,68 @@ This command clears that cache entirely. YCM will then re-query your
 
 Supported in filetypes: `c, cpp, objc, objcpp`
 
+### The `GetType` subcommand
+
+Echos the type of the variable or method under the cursor, and where it differs,
+the derived type. 
+
+For example:
+
+```c++
+    std::string s;
+```
+
+Invoking this command on `s` returns `std::string => std::basic_string<char>`
+
+NOTE: Due to limitations of `libclang`, invoking this command on the word
+`auto` typically returns `auto`. However, invoking it on a usage of the variable
+with inferred type returns the correct type, but typically it is repeated due to
+`libclang` returning that the types differ. 
+
+For example:
+
+```c++
+const char *s = "String";
+auto x = &s; // invoking on x or auto returns "auto";
+             // invoking on s returns "const char *"
+std::cout << *x; // invoking on x returns "const char ** => const char **"
+```
+
+NOTE: Causes reparsing of the current translation unit.
+
+Supported in filetypes: `c, cpp, objc, objcpp`
+
+### The `GetParent` subcommand
+
+Echos the semantic parent of the point under the cursor.
+
+The semantic parent is the item that semantically contains the given position.
+
+For example:
+
+```c++
+class C {
+    void f();
+};
+
+void C::f() { 
+
+}
+```
+
+In the out-of-line definition of `C::f`, the semantic parent is the class `C`, 
+of which this function is a member.
+
+In the example above, both declarations of `C::f` have `C` as their semantic 
+context, while the lexical context of the first `C::f` is `C` and the lexical 
+context of the second `C::f` is the translation unit.
+
+For global declarations, the semantic parent is the translation unit.
+
+NOTE: Causes reparsing of the current translation unit.
+
+Supported in filetypes: `c, cpp, objc, objcpp`
+
 ### The `StartServer` subcommand
 
 Starts the semantic-engine-as-localhost-server for those semantic engines that

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -57,17 +57,20 @@ class CommandRequest( BaseRequest ):
 
 
   def RunPostCommandActionsIfNeeded( self ):
-    if not self._is_goto_command or not self.Done() or not self._response:
+    if not self.Done() or not self._response:
       return
 
-    if isinstance( self._response, list ):
-      defs = [ _BuildQfListItem( x ) for x in self._response ]
-      vim.eval( 'setqflist( %s )' % repr( defs ) )
-      vim.eval( 'youcompleteme#OpenGoToList()' )
-    else:
-      vimsupport.JumpToLocation( self._response[ 'filepath' ],
-                                 self._response[ 'line_num' ],
-                                 self._response[ 'column_num' ] )
+    if self._is_goto_command: 
+      if isinstance( self._response, list ):
+        defs = [ _BuildQfListItem( x ) for x in self._response ]
+        vim.eval( 'setqflist( %s )' % repr( defs ) )
+        vim.eval( 'youcompleteme#OpenGoToList()' )
+      else:
+        vimsupport.JumpToLocation( self._response[ 'filepath' ],
+                                    self._response[ 'line_num' ],
+                                    self._response[ 'column_num' ] )
+    elif 'message' in self._response:
+        vimsupport.EchoText( self._response['message'] )
 
 
 


### PR DESCRIPTION
This is required to allow the ycmd GetType and GetParent subcommands to echo
their reults in vim. The apporach is to display any text returned from a
subcommand in the 'message' property assuming that the command is not a known
'GoTo' command.