### PR TITLE
Test suite: allow skipping of build step

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,9 +4,28 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-"${SCRIPT_DIR}/third_party/ycmd/build.py"
+function usage {
+  echo "Usage: $0 [--skip-build]"
+  exit 0
+}
 
 flake8 --select=F,C9 --max-complexity=10 "${SCRIPT_DIR}/python"
+skip_build=false
+
+for flag in $@; do
+  case "$flag" in
+    --skip-build)
+      skip_build=true
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if ! $skip_build; then
+    "${SCRIPT_DIR}/third_party/ycmd/build.py"
+fi
 
 for directory in "${SCRIPT_DIR}"/third_party/*; do
   if [ -d "${directory}" ]; then


### PR DESCRIPTION
Allow user to skip build when running tests.

This is required if you have to pass custom parameters to the build.