### PR TITLE
Ignore dirty submodules in status

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "third_party/requests-futures"]
 	path = third_party/requests-futures
 	url = https://github.com/ross/requests-futures
+	ignore = dirty
 [submodule "third_party/requests"]
 	path = third_party/requests
 	url = https://github.com/kennethreitz/requests
+	ignore = dirty
 [submodule "third_party/ycmd"]
 	path = third_party/ycmd
 	url = https://github.com/Valloric/ycmd
+	ignore = dirty


### PR DESCRIPTION
Added flag to remove dirty submodules to come up in git status lines.
This allows automated tools, such as ansible, which rely on git status
output, to correctly identify whether YCM needs to be recompiled or not.
Otherwise, the status after compilation is always "modified" for the
submodules, leading to incorrect understanding by said tools of the
status of the repository. CLA was signed by author.