### PR TITLE
Fix spurious warning about missing newline at EOF

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -100,7 +100,8 @@ def GetUnsavedAndCurrentBufferData():
       continue
 
     buffers_data[ GetBufferFilepath( buffer_object ) ] = {
-      'contents': '\n'.join( buffer_object ),
+      # Add a newline to match what gets saved to disk. See #1455 for details.
+      'contents': '\n'.join( buffer_object ) + '\n',
       'filetypes': FiletypesForBuffer( buffer_object )
     }
 


### PR DESCRIPTION
C requires a newline at the end of any file, Vim always includes one. With -Weverything, YCM warns that it's missing, because joining the lines of the buffer doesn't reflect the implicit newline. Adding a newline makes the buffer text match what will be saved, and makes the warning go away. This impacts any C source file compiled with sufficient warnings (e.g. -Weverything).

I've signed the Google CLA.