### PR TITLE
Support showing a completer command output in balloonexpr

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -144,17 +144,24 @@ class BaseRequest( object ):
   hmac_secret = ''
 
 
-def BuildRequestData( include_buffer_data = True ):
-  line, column = vimsupport.CurrentLineAndColumn()
-  filepath = vimsupport.GetCurrentBufferFilepath()
-  request_data = {
-    'line_num': line + 1,
-    'column_num': column + 1,
-    'filepath': filepath
-  }
+def BuildRequestData( include_buffer_data = True, buffer_info = None ):
+  if buffer_info is None:
+    line, column = vimsupport.CurrentLineAndColumn()
+    filepath = vimsupport.GetCurrentBufferFilepath()
+    buffer_info = {
+      'line_num': line + 1,
+      'column_num': column + 1,
+      'filepath': filepath,
+      'buffer_num': None
+    }
 
+  request_data = {
+    'line_num': buffer_info['line_num'],
+    'column_num': buffer_info['column_num'],
+    'filepath': buffer_info['filepath']
+  }
   if include_buffer_data:
-    request_data[ 'file_data' ] = vimsupport.GetUnsavedAndCurrentBufferData()
+    request_data[ 'file_data' ] = vimsupport.GetUnsavedAndCurrentBufferData( buffer_info[ 'buffer_num' ] )
 
   return request_data
 

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -39,8 +39,9 @@ class CommandRequest( BaseRequest ):
     self._response = None
 
 
-  def Start( self ):
-    request_data = BuildRequestData()
+  def Start( self, request_data = None ):
+    if request_data is None:
+      request_data = BuildRequestData()
     request_data.update( {
       'completer_target': self._completer_target,
       'command_arguments': self._arguments
@@ -75,11 +76,12 @@ class CommandRequest( BaseRequest ):
 
 
 
-def SendCommandRequest( arguments, completer ):
+def SendCommandRequest( arguments, completer, request_data = None, run_post_actions = True ):
   request = CommandRequest( arguments, completer )
   # This is a blocking call.
-  request.Start()
-  request.RunPostCommandActionsIfNeeded()
+  request.Start( request_data )
+  if run_post_actions:
+    request.RunPostCommandActionsIfNeeded()
   return request.Response()
 
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -92,11 +92,14 @@ def BufferModified( buffer_object ):
   return bool( int( GetBufferOption( buffer_object, 'mod' ) ) )
 
 
-def GetUnsavedAndCurrentBufferData():
+def GetUnsavedAndCurrentBufferData( current_buffer_number = None ):
+  if current_buffer_number is None:
+    current_buffer_number = vim.current.buffer.number
+
   buffers_data = {}
   for buffer_object in vim.buffers:
     if not ( BufferModified( buffer_object ) or
-             buffer_object == vim.current.buffer ):
+             buffer_object.number == current_buffer_number ):
       continue
 
     buffers_data[ GetBufferFilepath( buffer_object ) ] = {


### PR DESCRIPTION
Support showing a completer command output in balloonexpr.
This requires two things:
1) The balloonexpr does not run on the current cursor or window, but can run
anywhere visible. So commands need to be able to run at custom column, line,
and file.
2) We don't want to see the message echoed, so we need to be able to
suppress the post actions.

I'm not sure how to write tests for this

Here's what I'm trying to achieve: 
![image](https://cloud.githubusercontent.com/assets/1434266/7614601/1f5764b8-f955-11e4-928e-f9d5c7681631.png)

I'm testing this feature with the following balloonexpr:
```
function! CsBalloonExpr() 
	python << ENDPYTHON
import vim
from ycm.client.base_request import BuildRequestData
from ycm.client.command_request import SendCommandRequest
from ycm import vimsupport
buffer_num = vimsupport.GetIntValue('v:beval_bufnr')
buffer_object = vim.buffers[ buffer_num ]
request_data = BuildRequestData( buffer_info = {
	'filepath': vimsupport.GetBufferFilepath( buffer_object ),
	'line_num': vimsupport.GetIntValue('v:beval_lnum'),
	'column_num': vimsupport.GetIntValue('v:beval_col'),
	'buffer_num': buffer_num
})
typeLookupResponse = SendCommandRequest( ['TypeLookup'], '', request_data, run_post_actions = False ) or dict()
ENDPYTHON
	return pyeval('typeLookupResponse.get("message", "") or ""')
endfunction
setlocal balloonexpr=CsBalloonExpr()
setlocal ballooneval
```

I've already signed the CLA.