### PR TITLE
Remove deprecated --use-mirrors argument from pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
 before_install:
   - git submodule update --init --recursive
 install:
-  - pip install -r python/test_requirements.txt --use-mirrors
+  - pip install -r python/test_requirements.txt
 script: ./run_tests.sh


### PR DESCRIPTION
Pip no longer supports --use-mirrors since version 1.5. See https://github.com/pypa/pip/pull/1098.

CLA signed.