### PR TITLE
Check the server end point for available completer

### DIFF
--- a/python/ycm/client/completer_available_request.py
+++ b/python/ycm/client/completer_available_request.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2013  Google Inc.
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from ycm.client.base_request import ( BaseRequest, BuildRequestData,
+                                      HandleServerException )
+
+class CompleterAvailableRequest( BaseRequest ):
+  def __init__( self, filetypes ):
+    super( CompleterAvailableRequest, self ).__init__()
+    self.filetypes = filetypes
+    self._response = None
+
+
+  def Start( self ):
+    request_data = BuildRequestData()
+    request_data.update( { 'filetypes': self.filetypes } )
+    try:
+      self._response = self.PostDataToHandler( request_data,
+                                               'semantic_completion_available' )
+    except Exception as e:
+      HandleServerException( e )
+
+
+  def Response( self ):
+    return self._response
+
+
+def SendCompleterAvailableRequest( filetypes ):
+  request = CompleterAvailableRequest( filetypes )
+  # This is a blocking call.
+  request.Start()
+  return request.Response()

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -30,9 +30,9 @@ from ycmd.request_wrap import RequestWrap
 from ycm.diagnostic_interface import DiagnosticInterface
 from ycm.omni_completer import OmniCompleter
 from ycm import syntax_parse
-from ycmd.completers.completer_utils import FiletypeCompleterExistsForFiletype
 from ycm.client.ycmd_keepalive import YcmdKeepalive
 from ycm.client.base_request import BaseRequest, BuildRequestData
+from ycm.client.completer_available_request import SendCompleterAvailableRequest
 from ycm.client.command_request import SendCommandRequest
 from ycm.client.completion_request import CompletionRequest
 from ycm.client.omni_completion_request import OmniCompletionRequest
@@ -98,6 +98,7 @@ class YouCompleteMe( object ):
     self._ycmd_keepalive.Start()
 
   def _SetupServer( self ):
+    self._available_completers = {}
     server_port = utils.GetUnusedLocalhostPort()
     # The temp options file is deleted by ycmd during startup
     with tempfile.NamedTemporaryFile( delete = False ) as options_file:
@@ -217,8 +218,20 @@ class YouCompleteMe( object ):
     return self._omnicomp
 
 
+  def FiletypeCompleterExistsForFiletype( self, filetype ):
+    try:
+      return self._available_completers[ filetype ]
+    except KeyError:
+      pass
+
+    exists_completer = ( self.IsServerAlive() and
+                         bool( SendCompleterAvailableRequest( filetype ) ) )
+    self._available_completers[ filetype ] = exists_completer
+    return exists_completer
+
+
   def NativeFiletypeCompletionAvailable( self ):
-    return any( [ FiletypeCompleterExistsForFiletype( x ) for x in
+    return any( [ self.FiletypeCompleterExistsForFiletype( x ) for x in
                   vimsupport.CurrentFiletypes() ] )
 
 


### PR DESCRIPTION
Previously we were checking if the `hook.py` file existed for the given
filetype. ycmd has an endpoint for checking if given a filetype a
semantic completer is available. Should fix #1284.


I've signed the CLA
