### PR TITLE
Fix completer available

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -423,7 +423,10 @@ endfunction
 function! s:SetCompleteFunc()
   let &completefunc = 'youcompleteme#Complete'
   let &l:completefunc = 'youcompleteme#Complete'
+endfunction
 
+
+function! s:SetOmnicompleteFunc()
   if pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
     let &omnifunc = 'youcompleteme#OmniComplete'
     let &l:omnifunc = 'youcompleteme#OmniComplete'
@@ -504,6 +507,8 @@ function! s:OnInsertEnter()
   if !s:AllowedToCompleteInCurrentFile()
     return
   endif
+
+  call s:SetOmnicompleteFunc()
 
   let s:old_cursor_position = []
 endfunction

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -564,8 +564,7 @@ endfunction
 
 function! s:UpdateDiagnosticNotifications()
   let should_display_diagnostics = g:ycm_show_diagnostics_ui &&
-        \ s:DiagnosticUiSupportedForCurrentFiletype() &&
-        \ pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
+        \ s:DiagnosticUiSupportedForCurrentFiletype()
 
   if !should_display_diagnostics
     return

--- a/python/ycm/client/completer_available_request.py
+++ b/python/ycm/client/completer_available_request.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2013  Google Inc.
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from ycm.client.base_request import ( BaseRequest, BuildRequestData,
+                                      HandleServerException )
+
+class CompleterAvailableRequest( BaseRequest ):
+  def __init__( self, filetypes ):
+    super( CompleterAvailableRequest, self ).__init__()
+    self.filetypes = filetypes
+    self._response = None
+
+
+  def Start( self ):
+    request_data = BuildRequestData()
+    request_data.update( { 'filetypes': self.filetypes } )
+    try:
+      self._response = self.PostDataToHandler( request_data,
+                                               'semantic_completion_available' )
+    except Exception as e:
+      HandleServerException( e )
+
+
+  def Response( self ):
+    return self._response
+
+
+def SendCompleterAvailableRequest( filetypes ):
+  request = CompleterAvailableRequest( filetypes )
+  # This is a blocking call.
+  request.Start()
+  return request.Response()

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -299,7 +299,8 @@ class YouCompleteMe( object ):
 
 
   def UpdateDiagnosticInterface( self ):
-    if not self.DiagnosticsForCurrentFileReady():
+    if ( not self.DiagnosticsForCurrentFileReady() or
+         not self.NativeFiletypeCompletionUsable() ):
       return
     self._diag_interface.UpdateWithNewDiagnostics(
       self.GetDiagnosticsFromStoredRequest() )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -30,9 +30,9 @@ from ycmd.request_wrap import RequestWrap
 from ycm.diagnostic_interface import DiagnosticInterface
 from ycm.omni_completer import OmniCompleter
 from ycm import syntax_parse
-from ycmd.completers.completer_utils import FiletypeCompleterExistsForFiletype
 from ycm.client.ycmd_keepalive import YcmdKeepalive
 from ycm.client.base_request import BaseRequest, BuildRequestData
+from ycm.client.completer_available_request import SendCompleterAvailableRequest
 from ycm.client.command_request import SendCommandRequest
 from ycm.client.completion_request import CompletionRequest
 from ycm.client.omni_completion_request import OmniCompletionRequest
@@ -98,6 +98,7 @@ class YouCompleteMe( object ):
     self._ycmd_keepalive.Start()
 
   def _SetupServer( self ):
+    self._available_completers = {}
     server_port = utils.GetUnusedLocalhostPort()
     # The temp options file is deleted by ycmd during startup
     with tempfile.NamedTemporaryFile( delete = False ) as options_file:
@@ -217,8 +218,20 @@ class YouCompleteMe( object ):
     return self._omnicomp
 
 
+  def FiletypeCompleterExistsForFiletype( self, filetype ):
+    try:
+      return self._available_completers[ filetype ]
+    except KeyError:
+      pass
+
+    exists_completer = ( self.IsServerAlive() and
+                         bool( SendCompleterAvailableRequest( filetype ) ) )
+    self._available_completers[ filetype ] = exists_completer
+    return exists_completer
+
+
   def NativeFiletypeCompletionAvailable( self ):
-    return any( [ FiletypeCompleterExistsForFiletype( x ) for x in
+    return any( [ self.FiletypeCompleterExistsForFiletype( x ) for x in
                   vimsupport.CurrentFiletypes() ] )
 
 


### PR DESCRIPTION
This is a follow up of #1524 and #1529. The thing that made #1524 slow down the startup was that when we setup the `omnifunc` we have to check if a native completer is available; set up the `omnifunc` at startup translate in waiting that the server is up and running before do anything. The `omnifunc` is actually only required if we require a semantic completion, so after a semantic trigger or if we hit `<C-Space>` which are both done in Insert mode. So the first thing I do is defer the set up of the `omnifunc` at `InsertEnter`. The other place where we checked if a native completer exists for the current filetype is when we check for diagnostic update. From what I understood (I was not familiar with that part of the code) we get the diagnostics from the response to a previous issued FileReadyToParse event. So before we:

- check if the settings allow us to display diagnostic
- check if a native completer exists for the current filetype which could gives us diagnostics
- check if the response is available:
  - if not ready: do nothing
  - if ready get the diagnostic and display them to the user

The original behaviour for the diagnostics already do nothing if the server is not yet available. So I thought of checking for the native completer available after the response from the server is ready; this way the behaviour is the same.

@Valloric What do you think of this approach? I did the `Revert "Revert "commit""` thing, if you prefer a cleaner history and want me to change it just tell me.