### PR TITLE
Disable completion if any of current filetypes is disable

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -341,7 +341,7 @@ class YouCompleteMe( object ):
     if '*' in filetype_to_disable:
       return False
     else:
-      return not all([ x in filetype_to_disable for x in filetypes ])
+      return not any([ x in filetype_to_disable for x in filetypes ])
 
 
   def _AddSyntaxDataIfNeeded( self, extra_data ):


### PR DESCRIPTION
#1531 seems sensible: if one disable `javascript` I guess that `javascript.jasmine` should be disable as well.

Fixes #1531