### PR TITLE
[RFC] Add support for accepting a completion

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -27,6 +27,7 @@ let s:old_cursor_position = []
 let s:cursor_moved = 0
 let s:moved_vertically_in_insert_mode = 0
 let s:previous_num_chars_on_current_line = -1
+let s:completion_accepted = 0
 
 let s:diagnostic_ui_filetypes = {
       \ 'cpp': 1,
@@ -109,6 +110,19 @@ function! youcompleteme#DisableCursorMovedAutocommands()
 endfunction
 
 
+function! youcompleteme#Accept()
+  " Will suppress completion menu until cursor moved, or other suitable autocmd
+  " fires. The value of 2 here is a signal that the cursor will actually need to
+  " move twice before we re-enable completion, because our `<C-y>` here will
+  " actually cause the CursorMovedI autocmd to fire immediately, and we want to
+  " ignore that first move.
+  let s:completion_accepted = 2
+  set completeopt-=menuone
+  set completeopt-=menu
+  return "\<C-y>"
+endfunction
+
+
 function! s:SetUpPython() abort
   py import sys
   py import vim
@@ -171,6 +185,11 @@ function! s:SetUpKeyMappings()
     " This selects the previous candidate for shift-tab (default)
     exe 'inoremap <expr>' . key .
           \ ' pumvisible() ? "\<C-p>" : "\' . key .'"'
+  endfor
+
+  for key in g:ycm_key_list_accept_completion
+    exe 'inoremap <expr> ' . key .
+          \ ' pumvisible() ? youcompleteme#Accept() : "\' . key . '"'
   endfor
 
   if !empty( g:ycm_key_invoke_completion )
@@ -281,6 +300,10 @@ endfunction
 
 
 function! s:AllowedToCompleteInCurrentFile()
+  if s:completion_accepted
+    return 0
+  endif
+
   if empty( &filetype ) ||
         \ getbufvar( winbufnr( winnr() ), "&buftype" ) ==# 'nofile' ||
         \ &filetype ==# 'qf'
@@ -318,10 +341,15 @@ function! s:SetUpCompleteopt()
   " There's no two ways about this: if you want to use YCM then you have to
   " have these completeopt settings, otherwise YCM won't work at all.
 
-  " We need menuone in completeopt, otherwise when there's only one candidate
-  " for completion, the menu doesn't show up.
-  set completeopt-=menu
-  set completeopt+=menuone
+  if s:completion_accepted
+    set completeopt-=menu
+    set completeopt-=menuone
+  else
+    " We need menuone in completeopt, otherwise when there's only one candidate
+    " for completion, the menu doesn't show up.
+    set completeopt-=menu
+    set completeopt+=menuone
+  endif
 
   " This is unnecessary with our features. People use this option to insert
   " the common prefix of all the matches and then add more differentiating chars
@@ -439,6 +467,14 @@ endfunction
 
 
 function! s:OnCursorMovedInsertMode()
+  if s:completion_accepted == 2
+    " Ignore first move.
+    let s:completion_accepted -= 1
+    return
+  elseif s:completion_accepted
+    call s:ResetCompletionAccepted()
+  endif
+
   if !s:AllowedToCompleteInCurrentFile()
     return
   endif
@@ -501,11 +537,21 @@ endfunction
 
 
 function! s:OnInsertEnter()
+  call s:ResetCompletionAccepted()
+
   if !s:AllowedToCompleteInCurrentFile()
     return
   endif
 
   let s:old_cursor_position = []
+endfunction
+
+
+function! s:ResetCompletionAccepted()
+  if s:completion_accepted
+    let s:completion_accepted = 0
+    call s:SetUpCompleteopt()
+  endif
 endfunction
 
 

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -112,6 +112,9 @@ let g:ycm_key_list_select_completion =
 let g:ycm_key_list_previous_completion =
       \ get( g:, 'ycm_key_list_previous_completion', ['<S-TAB>', '<Up>'] )
 
+let g:ycm_key_list_accept_completion =
+      \ get( g:, 'ycm_key_list_accept_completion', ['<C-Y>'] )
+
 let g:ycm_key_invoke_completion =
       \ get( g:, 'ycm_key_invoke_completion', '<C-Space>' )
 


### PR DESCRIPTION
This has come up before in a somewhat polemical thread here:

https://github.com/Valloric/YouCompleteMe/issues/232

The argument against adding this feature was basically:

> The keys can be remapped, but this is how it works. There is no accept
> key because it is unnecessary. I am not willing to change YCM to force
> the user to add unnecessary key presses just because "that's how other
> editors work".

(https://github.com/Valloric/YouCompleteMe/issues/232#issuecomment-15934327)

However, I have a use case for the ability to force acceptance of a
completion, which is pretty compelling for me personally, and I'll
detail below and see if others agree.

As implemented here, the change shouldn't "force the user to add
unnecessary key presses", but it does enable the user to optionally make
use of the ability to declare a completion as accepted in a way that
makes working with UltiSnips considerably more pleasant.

As explained in great detail here:

https://github.com/SirVer/ultisnips/pull/514#issuecomment-111775399

I've a long-running grievance with the way YCM and UltiSnips interact
within one another when trying to use `<TAB>` for everything (cycling
through YCM completions, expanding snippets, and jumping among snippet
placeholders). When inside a snippet placeholder and a YCM completion is
available, it's fundamentally ambiguous what you want to do with `<TAB>`
at that point: do you mean to choose a YCM completion, or jump to the
next placeholder?

Prior to that pull request, UltiSnips always ended up winning (ie.
`<TAB>` would always mean "jump to next placeholder" instead of "pick
next YCM completion), which was counterintuitive, because the visibility
of the completion menu of YCM suggests that it is the "active" element
and should be the "focus" of the `<TAB>` action. The workaround was to
define different mappings for YCM and UltiSnips, thus shattering the
unthinkingly-mash-`<TAB>`-for-everything dream.

What that pull request does is add autocommands to UltiSnips that allow
people who want to invert the prioritization to do so by overriding the
"inner" mappings that UltiSnips sets up only for the duration of snippet
expansion. In this way, you can make YCM completion win inside of
placeholders whenever it has completions available (ie. when
`pumvisible()`).

But there is one small problem. What do you do when you've finished
cycling through your YCM completion options with `<TAB>` and you then
_do_ want to jump to the next placeholder? Once again, we don't want to
have to define a non-`<TAB>` mapping for jumping between placeholders
because of @jordwalke's point:

> ... the popular mental model of snippets, which usually use `<Tab>`
> for not only expansion, but also jumping between snippet placeholders
> (which has been ingrained in users' muscle memory for thirty years of
> keyboard form filling).

(https://github.com/Valloric/YouCompleteMe/issues/232#issuecomment-36497678)

Ideally, you should be able to accept the YCM completion (either with
the Vim default of `<CTRL-Y>`, or with something else that you deem more
comfortable, like `<CR>` or any other mapping of your choosing), which
should dismiss the menu, keep the completion, and free you to hit
`<TAB>` to jump to the next placeholder. If you ever forget about how
the dual role of `<TAB>` works here and end up mashing it one time to
many, correction can be a simple `<S-TAB>` (or repeat `<TAB>`) followed
by `<CR>` (away).

This commit implements that behavior in a rough way (no tests, just an
RFC at this stage). This is my first incursion into the YCM codebase, so
hopefully I haven't done anything stomach-churningly hacky here. What it
does is allow the chosen "accept completion" binding to set some
internal state that hides the completion menu, and then forwards the
native `<CTRL-Y>` to Vim to "accept" the completion. Switching buffers
or moving the cursor resets this internal state, effectively unhiding
the menu again.

Obviously I'd be happy to include docs, switch defaults, or make other
requested changes in order to see this or equivalent functionality land
in upstream.

For an example of this option in use, see this commit in my dotfiles
repo:

https://github.com/wincent/wincent/commit/bc6ed079ab148e74b74cb0e7e6c67

And for more context on how it all first together, go back to that
UltiSnips PR that I linked to further up.