### PR TITLE
Redraw the screen before displaying a message

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -358,11 +358,13 @@ def NumLinesInBuffer( buffer_object ):
   return len( buffer_object )
 
 
-# Calling this function from the non-GUI thread will sometimes crash Vim. At the
-# time of writing, YCM only uses the GUI thread inside Vim (this used to not be
-# the case).
+# Calling this function from the non-GUI thread will sometimes crash Vim. At
+# the time of writing, YCM only uses the GUI thread inside Vim (this used to
+# not be the case).
+# We redraw the screen before displaying the message to avoid the "Press ENTER
+# or type command to continue" prompt when editing a new C-family file.
 def PostVimMessage( message ):
-  vim.command( "echohl WarningMsg | echom '{0}' | echohl None"
+  vim.command( "redraw | echohl WarningMsg | echom '{0}' | echohl None"
                .format( EscapeForVim( str( message ) ) ) )
 
 


### PR DESCRIPTION
There has been several complaints about the message "ValueError: File is less than 5 lines long; not compiling". See issues #814, #1364, #1544. In fact, I believe the issue is not the message itself but the infamous "Press ENTER or type command to continue" prompt when editing a new C-family file.

For example, if I create the file `foo.c`, Vim will display the line `"foo.c" [New file]` and then YouCompleteMe will display `ValueError: File is less than 5 lines long; not compiling`. Since there are now two lines, the hit-enter message is prompted. By redrawing the screen just before displaying the message from YouCompleteMe, only one line appears and we avoid this behavior.

Tested on Linux and Windows.

CLA signed.