### PR TITLE
Set stdin to PIPE on Windows only when necessary

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -130,7 +130,8 @@ class YouCompleteMe( object ):
         if self._user_options[ 'server_keep_logfiles' ]:
           args.append('--keep_logfiles')
 
-      self._server_popen = utils.SafePopen( args, stdout = PIPE, stderr = PIPE)
+      self._server_popen = utils.SafePopen( args, stdin_windows = PIPE,
+                                            stdout = PIPE, stderr = PIPE)
       BaseRequest.server_location = 'http://127.0.0.1:' + str( server_port )
       BaseRequest.hmac_secret = hmac_secret
 


### PR DESCRIPTION
Commit 98d687a5e02548fafc05397aaab38e8735078ff4 causes a Python crash in Vim on Windows. This is due to the `SafePopen` call in `s:SetUpPython` function which sets `stdin` to `PIPE` on Windows. 

Since the `stdin` option is only necessary when starting the `ycmd` server (in `python/ycm/youcompleteme.py`), this PR and PR Valloric/ycmd#173 introduce a new option `stdin_windows` to `SafePopen` that sets `stdin` to `PIPE` on Windows. This option is only used when starting the `ycmd` server. 

CLA signed.