### PR TITLE
Move information about using system libclang

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,10 @@ process.
     NOTE: This _only_ works with a _downloaded_ LLVM binary package, not a
     custom-built LLVM! See docs below for `EXTERNAL_LIBCLANG_PATH` when using a
     custom LLVM build.
+    
+    For those who want to use the system version of libclang, you would pass
+    `-DUSE_SYSTEM_LIBCLANG=ON` to cmake _instead of_ the
+    `-DPATH_TO_LLVM_ROOT=...` flag.
 
     With that in mind, run the following command in the `ycm_build` directory:
 
@@ -366,10 +370,6 @@ process.
     Now that makefiles have been generated, simply run:
 
         make ycm_support_libs
-
-    For those who want to use the system version of libclang, you would pass
-    `-DUSE_SYSTEM_LIBCLANG=ON` to cmake _instead of_ the
-    `-DPATH_TO_LLVM_ROOT=...` flag.
 
     NOTE: We **STRONGLY recommend AGAINST use** of the system libclang instead
     of the upstream compiled binaries. Random things may break. Save yourself


### PR DESCRIPTION
I suggest to move the information about how to use system libclang before the cmake example line. As a new user I actually run the cmake command with PATH_TO_LLVM_ROOT=/ before reading the information about system libclang.

I think place this information before the cmake example is more relevant for new users.

I did sign Google CLA