### PR TITLE
Add apt-vim installation recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ YouCompleteMe: a code-completion engine for Vim
 
 - [Intro](#intro)
 - [Installation](#installation)
+    - [apt-vim](#apt-vim-installation)
     - [Mac OS X](#mac-os-x-super-quick-installation)
     - [Ubuntu](#ubuntu-linux-x64-super-quick-installation)
     - [Windows](#windows-installation)
@@ -103,6 +104,13 @@ and a completer that integrates with [UltiSnips][].
 
 Installation
 ------------
+
+### apt-vim installation
+Install [apt-vim][] and then run the following in terminal:
+
+    apt-vim install -y https://github.com/Valloric/YouCompleteMe
+
+And you're done! The apt-vim method works on Mac OS X as well as Linux (Ubuntu/Debian).
 
 ### Mac OS X super-quick installation
 
@@ -2013,3 +2021,4 @@ This software is licensed under the [GPL v3 license][gpl].
 [ygen]: https://github.com/rdnetto/YCM-Generator
 [Gocode]: https://github.com/nsf/gocode
 [NeoBundle]: https://github.com/Shougo/neobundle.vim
+[apt-vim]: https://github.com/egalpin/apt-vim

--- a/vim_config.json
+++ b/vim_config.json
@@ -1,0 +1,33 @@
+@vimpkg
+{
+    "depends-on": [
+        {
+            "name": "cmake",
+            "recipe": {
+                "darwin": [
+                    "brew install cmake"
+                ],
+                "linux": [
+                    "sudo apt-get install -y cmake"
+                ]
+            }
+        },
+        {
+            "name": "python-dev",
+            "recipe": {
+                "darwin": [],
+                "linux": [
+                    "sudo apt-get install -y python-dev"
+                ]
+            }
+        }
+    ],
+    "name": "YouCompleteMe",
+    "pkg-url": "https://github.com/Valloric/YouCompleteMe.git",
+    "recipe": {
+        "all": [
+            "git submodule update --init --recursive",
+            "./install.sh --clang-completer"
+        ]
+    }
+}

--- a/vim_config.json
+++ b/vim_config.json
@@ -20,6 +20,15 @@
                     "sudo apt-get install -y python-dev"
                 ]
             }
+        },
+        {
+            "name": "build-essential",
+            "recipe": {
+                "darwin": [],
+                "linux": [
+                    "sudo apt-get install -y build-essential"
+                ]
+            }
         }
     ],
     "name": "YouCompleteMe",

--- a/vim_config.json
+++ b/vim_config.json
@@ -2,6 +2,15 @@
 {
     "depends-on": [
         {
+            "name": "brew",
+            "recipe": {
+                "all": [],
+                "darwin": [
+                    "ruby -e \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""
+                ]
+            }
+        },
+        {
             "name": "cmake",
             "recipe": {
                 "darwin": [


### PR DESCRIPTION
Added `vim_config.json` and updated the README to include instructions for how to install YCM using [apt-vim](https://github.com/egalpin/apt-vim). This will allow for a fully-automated install of YCM and all dependencies on Mac and Linux.