### PR TITLE
If errors are returned in addition to completion suggestions, print them

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -163,7 +163,7 @@ def JsonFromFuture( future ):
   response = future.result()
   _ValidateResponseObject( response )
   if response.status_code == requests.codes.server_error:
-    _RaiseExceptionForData( response.json() )
+    raise MakeServerException( response.json() )
 
   # We let Requests handle the other status types, we only handle the 500
   # error code.
@@ -218,10 +218,9 @@ def _CheckServerIsHealthyWithCache():
   except:
     return False
 
-
-def _RaiseExceptionForData( data ):
+def MakeServerException( data ):
   if data[ 'exception' ][ 'TYPE' ] == UnknownExtraConf.__name__:
-    raise UnknownExtraConf( data[ 'exception' ][ 'extra_conf_file' ] )
+    return UnknownExtraConf( data[ 'exception' ][ 'extra_conf_file' ] )
 
-  raise ServerError( '{0}: {1}'.format( data[ 'exception' ][ 'TYPE' ],
-                                        data[ 'message' ] ) )
+  return ServerError( '{0}: {1}'.format( data[ 'exception' ][ 'TYPE' ],
+                                         data[ 'message' ] ) )

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -19,7 +19,8 @@
 
 from ycmd.utils import ToUtf8IfNeeded
 from ycm.client.base_request import ( BaseRequest, JsonFromFuture,
-                                      HandleServerException )
+                                      HandleServerException,
+                                      MakeServerException )
 
 TIMEOUT_SECONDS = 0.5
 
@@ -43,10 +44,16 @@ class CompletionRequest( BaseRequest ):
     if not self._response_future:
       return []
     try:
-      return _ConvertCompletionResponseToVimDatas(
-          JsonFromFuture( self._response_future ) )
+      response = JsonFromFuture( self._response_future )
+
+      errors = response['errors'] if 'errors' in response else []
+      for e in errors:
+        HandleServerException( MakeServerException( e ) )
+
+      return _ConvertCompletionResponseToVimDatas( response )
     except Exception as e:
       HandleServerException( e )
+
     return []
 
 


### PR DESCRIPTION
Needed for https://github.com/Valloric/ycmd/pull/198

This maintains the previous client behaviour when the semantic completer throws an exception.