### PR TITLE
Removed the bash dependency that install.sh had

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,11 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -e
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR=$(dirname $0 || exit $?)
+cd $SCRIPT_DIR || exit $?
 
 build_file=$SCRIPT_DIR/third_party/ycmd/build.py
 
-if [[ ! -f "$build_file" ]]; then
+if [ ! -f "$build_file" ]; then
   echo "File $build_file doesn't exist; you probably forgot to run:"
   printf "\n\tgit submodule update --init --recursive\n\n"
   exit 1
@@ -21,7 +20,7 @@ if command_exists python2; then
   PYTHON_BINARY=python2
 fi
 
-$PYTHON_BINARY "$build_file" "$@"
+$PYTHON_BINARY "$build_file" "$@" || exit $?
 
 # Remove old YCM libs if present so that YCM can start.
 rm -f python/*ycm_core.* &> /dev/null


### PR DESCRIPTION
People like me use YCM on machines that don't have bash, and it's nice to not have to add it unnecessarily. This removes the bash dependency for installation.