### PR TITLE
Fixed systemcall, we need a shell to run the command

### DIFF
--- a/install.py
+++ b/install.py
@@ -19,7 +19,7 @@ def Main():
 
   python_binary = sys.executable
   args = ' '.join( sys.argv[1:] )
-  subprocess.call( ' '.join( [ python_binary, build_file, args ] ) )
+  subprocess.call( ' '.join( [ python_binary, build_file, args ] ), shell=True )
 
   # Remove old YCM libs if present so that YCM can start.
   old_libs = (


### PR DESCRIPTION
I was trying to use the install.py script to compile YCM but I got an error that a file was not found. This occured in Ubuntu (64bit, older version) as well as in CentOS 6.2

Once I fixed this line, it worked well on both systems. 