### PR TITLE
Add option to set custom tag file list for collecting identifiers from

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,6 +1239,16 @@ Default: `0`
 
     let g:ycm_collect_identifiers_from_tags_files = 0
 
+### The `g:ycm_tags` option
+
+Defines a custom tag file list to autocomplete from. Useful when you want to
+keep the autocomplete dataset small, while still having all the tags at your disposal
+for navigation.
+
+Default: `tagfiles()`
+
+    let g:ycm_tags = ["/path/to/my/tags"]
+
 ### The `g:ycm_seed_identifiers_with_syntax` option
 
 When this option is set to `1`, YCM's identifier completer will seed its

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -170,6 +170,8 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
+let g:ycm_tags = tagfiles()
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -374,7 +374,7 @@ class YouCompleteMe( object ):
 
   def _AddTagsFilesIfNeeded( self, extra_data ):
     def GetTagFiles():
-      tag_files = vim.eval( 'tagfiles()' )
+      tag_files = vim.eval( 'g:ycm_tags' )
       # getcwd() throws an exception when the CWD has been deleted.
       try:
         current_working_directory = os.getcwd()


### PR DESCRIPTION
somehow related to https://github.com/Valloric/YouCompleteMe/issues/595

### Context

I am working on a Ruby on Rails project with a lot of dependencies, I have `gem-ctags` which generates a tag file for each of the project deps, and I have `vim-bundler` which takes all those tag files and adds them to vim.

Since my current project has about 200 deps, about 200 tag files are available in Vim and everything is fine. Except when I set `g:ycm_collect_identifiers_from_tag_files`. After that memory usage of the daemon goes to about ~700 megs. (I am aware that ycm speed is due to its algorithm that is a bit consuming on the memory)

### Solution

Since I use per-project `.vimrc` anyways, and I generate a tag file in project folder as well, the correct approach for me would be to only collect identifiers from project tagfile, not from all dependencies. The naive solution would be to just ignore all tag files from dependencies and call it a day. However, I'd still want Vim to know about all those tag files so that I can search symbols and go to definition.

So the solution is simple, add a overridable variable to that defaults to `tagfiles()`, which will tell ycm from which files to autocomplete. That way, Vim remains aware of all the tag files, yet ycm autocompletes only project identifiers and has a small memory footprint

Note: this pull-request will not fix any memory issues for users who have a single, large tag file