### PR TITLE
Show docs from clang completer in preview window

### DIFF
--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -21,6 +21,7 @@ from ycmd.utils import ToUtf8IfNeeded
 from ycm.client.base_request import ( BaseRequest, JsonFromFuture,
                                       HandleServerException,
                                       MakeServerException )
+import os
 
 TIMEOUT_SECONDS = 0.5
 
@@ -64,6 +65,13 @@ def _ConvertCompletionDataToVimData( completion_data ):
     'dup'  : 1,
   }
 
+  if ( 'extra_data' in completion_data and
+       'doc_string' in completion_data[ 'extra_data' ] ):
+    doc_string = ToUtf8IfNeeded(
+                              completion_data[ 'extra_data' ][ 'doc_string' ] )
+  else:
+    doc_string = ""
+
   if 'menu_text' in completion_data:
     vim_data[ 'abbr' ] = ToUtf8IfNeeded( completion_data[ 'menu_text' ] )
   if 'extra_menu_info' in completion_data:
@@ -73,6 +81,10 @@ def _ConvertCompletionDataToVimData( completion_data ):
         completion_data[ 'kind' ] )[ 0 ].lower()
   if 'detailed_info' in completion_data:
     vim_data[ 'info' ] = ToUtf8IfNeeded( completion_data[ 'detailed_info' ] )
+    if doc_string:
+      vim_data[ 'info' ] += os.linesep + doc_string
+  elif doc_string:
+    vim_data[ 'info' ] = doc_string
 
   return vim_data
 

--- a/python/ycm/client/tests/completion_request_test.py
+++ b/python/ycm/client/tests/completion_request_test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015 YouCompleteMe Contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from nose.tools import eq_
+from ycm.test_utils import MockVimModule
+vim_mock = MockVimModule()
+import os
+
+from .. import completion_request
+
+class ConvertCompletionResponseToVimDatas_test:
+  """ This class tests the
+      completion_request._ConvertCompletionResponseToVimDatas method """
+
+  def _Check( self, completion_data, expected_vim_data ):
+    vim_data = completion_request._ConvertCompletionDataToVimData(
+        completion_data )
+
+    try:
+      eq_( expected_vim_data, vim_data )
+    except:
+      print "Expected:\n'{0}'\nwhen parsing:\n'{1}'\nBut found:\n'{2}'".format(
+          expected_vim_data,
+          completion_data,
+          vim_data )
+      raise
+
+
+  def All_Fields_test( self ):
+    self._Check( {
+      'insertion_text':  'INSERTION TEXT',
+      'menu_text':       'MENU TEXT',
+      'extra_menu_info': 'EXTRA MENU INFO',
+      'kind':            'K',
+      'detailed_info':   'DETAILED INFO',
+      'extra_data': {
+        'doc_string':    'DOC STRING',
+      },
+    }, {
+      'word': 'INSERTION TEXT',
+      'abbr': 'MENU TEXT',
+      'menu': 'EXTRA MENU INFO',
+      'kind': 'k',
+      'info': 'DETAILED INFO' + os.linesep + 'DOC STRING',
+      'dup' : 1,
+    } )
+
+
+  def Just_Detailed_Info_test( self ):
+    self._Check( {
+      'insertion_text':  'INSERTION TEXT',
+      'menu_text':       'MENU TEXT',
+      'extra_menu_info': 'EXTRA MENU INFO',
+      'kind':            'K',
+      'detailed_info':   'DETAILED INFO',
+    }, {
+      'word': 'INSERTION TEXT',
+      'abbr': 'MENU TEXT',
+      'menu': 'EXTRA MENU INFO',
+      'kind': 'k',
+      'info': 'DETAILED INFO',
+      'dup' : 1,
+    } )
+
+
+  def Just_Doc_String_test( self ):
+    self._Check( {
+      'insertion_text':  'INSERTION TEXT',
+      'menu_text':       'MENU TEXT',
+      'extra_menu_info': 'EXTRA MENU INFO',
+      'kind':            'K',
+      'extra_data': {
+        'doc_string':    'DOC STRING',
+      },
+    }, {
+      'word': 'INSERTION TEXT',
+      'abbr': 'MENU TEXT',
+      'menu': 'EXTRA MENU INFO',
+      'kind': 'k',
+      'info': 'DOC STRING',
+      'dup' : 1,
+    } )
+
+
+  def Extra_Info_No_Doc_String_test( self ):
+    self._Check( {
+      'insertion_text':  'INSERTION TEXT',
+      'menu_text':       'MENU TEXT',
+      'extra_menu_info': 'EXTRA MENU INFO',
+      'kind':            'K',
+      'extra_data': {
+      },
+    }, {
+      'word': 'INSERTION TEXT',
+      'abbr': 'MENU TEXT',
+      'menu': 'EXTRA MENU INFO',
+      'kind': 'k',
+      'dup' : 1,
+    } )
+
+
+  def Extra_Info_No_Doc_String_With_Detailed_Info_test( self ):
+    self._Check( {
+      'insertion_text':  'INSERTION TEXT',
+      'menu_text':       'MENU TEXT',
+      'extra_menu_info': 'EXTRA MENU INFO',
+      'kind':            'K',
+      'detailed_info':   'DETAILED INFO',
+      'extra_data': {
+      },
+    }, {
+      'word': 'INSERTION TEXT',
+      'abbr': 'MENU TEXT',
+      'menu': 'EXTRA MENU INFO',
+      'kind': 'k',
+      'info': 'DETAILED INFO',
+      'dup' : 1,
+    } )


### PR DESCRIPTION
Fixes https://github.com/Valloric/YouCompleteMe/issues/106

We add the detailed_info (which is the function definiton) followed by the brief comment if supplied.

I added a test for the method, which is now reasonably complex.