### PR TITLE
Update subcommmands supported for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ the definition of the symbol is in the current translation unit. A translation
 unit consists of the file you are editing and all the files you are including
 with `#include` directives (directly or indirectly) in that file.
 
-Supported in filetypes: `c, cpp, objc, objcpp, python, cs`
+Supported in filetypes: `c, cpp, objc, objcpp, python, cs, typescript`
 
 ### The `GoTo` subcommand
 
@@ -799,7 +799,7 @@ std::cout << *x; // invoking on x returns "const char ** => const char **"
 
 NOTE: Causes reparsing of the current translation unit.
 
-Supported in filetypes: `c, cpp, objc, objcpp`
+Supported in filetypes: `c, cpp, objc, objcpp, typescript`
 
 ### The `GetParent` subcommand
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -922,7 +922,7 @@ when the definition of the symbol is in the current translation unit. A
 translation unit consists of the file you are editing and all the files you are
 including with '#include' directives (directly or indirectly) in that file.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, python, cs'
+Supported in filetypes: 'c, cpp, objc, objcpp, python, cs, typescript'
 
 -------------------------------------------------------------------------------
 The *GoTo* subcommand
@@ -988,7 +988,7 @@ For example:
 <
 NOTE: Causes reparsing of the current translation unit.
 
-Supported in filetypes: 'c, cpp, objc, objcpp'
+Supported in filetypes: 'c, cpp, objc, objcpp, typescript'
 
 -------------------------------------------------------------------------------
 The *GetParent* subcommand


### PR DESCRIPTION
Noticed that the subcommands supported by typescript are not listed. Updated the docs and ran

```
vim-tools/html2vimdoc.py -f youcompleteme README.md > doc/youcompleteme.txt
```