### PR TITLE
Add super-quick feature summary by completer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ YouCompleteMe: a code-completion engine for Vim
     - [Windows](#windows-installation)
     - [FreeBSD/OpenBSD](#freebsdopenbsd-installation)
     - [Full Installation Guide](#full-installation-guide)
+- [Quick Feature Summary](#quick-feature-summary)
 - [User Guide](#user-guide)
     - [General Usage](#general-usage)
     - [Client-server architecture](#client-server-architecture)
@@ -102,7 +103,6 @@ engines in the future.
 
 You'll also find that YCM has filepath completers (try typing `./` in a file)
 and a completer that integrates with [UltiSnips][].
-
 
 Installation
 ------------
@@ -400,6 +400,50 @@ in the User Guide.
 YCM comes with sane defaults for its options, but you still may want to take a
 look at what's available for configuration. There are a few interesting options
 that are conservatively turned off by default that you may want to turn on.
+
+Quick Feature Summary
+-----
+
+### General (all languages)
+
+* Super-fast identifier completer including tags files and syntax elements
+* Intelligent suggestion ranking and filtering
+* File and path suggestions
+* Suggestions from Vim's OmniFunc
+* UltiSnips snippet suggestions
+
+### C-family languages (C, C++, Objective C, Objective C++)
+
+* Semantic auto-completion
+* Real-time diagnostic display
+* Go to declaration/definition (`GoTo`, etc.)
+* Semantic type information for identifiers (`GetType`)
+* Automatically fix certain errors (`FixIt`)
+
+### C♯
+
+* Semantic auto-completion
+* Real-time diagnostic display
+* Go to declaration/definition (`GoTo`, etc.)
+* Semantic type information for identifiers (`GetType`)
+* Automatically fix certain errors (`FixIt`)
+* Management of OmniSharp server instance
+
+### Python 2
+
+* Intelligent auto-completion
+* Go to declaration/definition (`GoTo`, etc.)
+
+### Go
+
+* Semantic auto-completion
+* Management of `gocode` server instance
+
+### TypeScript
+
+* Semantic auto-completion
+* Go to definition (`GoToDefinition`)
+* Semantic type information for identifiers (`GetType`)
 
 User Guide
 ----------

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -11,7 +11,14 @@ Contents ~
   3. Windows Installation                  |youcompleteme-windows-installation|
   4. FreeBSD/OpenBSD Installation  |youcompleteme-freebsd-openbsd-installation|
   5. Full Installation Guide            |youcompleteme-full-installation-guide|
- 4. User Guide                                       |youcompleteme-user-guide|
+ 4. Quick Feature Summary                 |youcompleteme-quick-feature-summary|
+  1. General (all languages)                            |youcompleteme-general|
+  2. C-family languages (C, C++, Objective C, Objective C++) |youcompleteme-c-family-languages|
+  3. C♯                                                       |youcompleteme-c|
+  4. Python 2                                          |youcompleteme-python-2|
+  5. Go                                                      |youcompleteme-go|
+  6. TypeScript                                      |youcompleteme-typescript|
+ 5. User Guide                                       |youcompleteme-user-guide|
   1. General Usage                                |youcompleteme-general-usage|
   2. Client-server architecture      |youcompleteme-client-server-architecture|
   3. Completion string ranking        |youcompleteme-completion-string-ranking|
@@ -22,14 +29,14 @@ Contents ~
   8. Diagnostic display                      |youcompleteme-diagnostic-display|
    1. C# Diagnostic Support                |youcompleteme-c-diagnostic-support|
    2. Diagnostic highlighting groups |youcompleteme-diagnostic-highlighting-groups|
- 5. Commands                                           |youcompleteme-commands|
+ 6. Commands                                           |youcompleteme-commands|
   1. The |:YcmRestartServer| command
   2. The |:YcmForceCompileAndDiagnostics| command
   3. The |:YcmDiags| command
   4. The |:YcmShowDetailedDiagnostic| command
   5. The |:YcmDebugInfo| command
   6. The |:YcmCompleter| command
- 6. YcmCompleter subcommands           |youcompleteme-ycmcompleter-subcommands|
+ 7. YcmCompleter subcommands           |youcompleteme-ycmcompleter-subcommands|
   1. The |GoToDeclaration| subcommand
   2. The |GoToDefinition| subcommand
   3. The |GoTo| subcommand
@@ -44,7 +51,7 @@ Contents ~
   12. The |ReloadSolution| subcommand
   13. The |GoToImplementation| subcommand
   14. The |GoToImplementationElseDeclaration| subcommand
- 7. Options                                             |youcompleteme-options|
+ 8. Options                                             |youcompleteme-options|
   1. The |g:ycm_min_num_of_chars_for_completion| option
   2. The |g:ycm_min_num_identifier_candidate_chars| option
   3. The |g:ycm_auto_trigger| option
@@ -91,7 +98,7 @@ Contents ~
   44. The |g:ycm_use_ultisnips_completer| option
   45. The |g:ycm_goto_buffer_command| option
   46. The |g:ycm_disable_for_files_larger_than_kb| option
- 8. FAQ                                                     |youcompleteme-faq|
+ 9. FAQ                                                     |youcompleteme-faq|
   1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |import-vim|
   2. On very rare occasions Vim crashes when I tab through the completion menu |youcompleteme-on-very-rare-occasions-vim-crashes-when-i-tab-through-completion-menu|
   3. I get a linker warning regarding |libpython| on Mac when compiling YCM
@@ -120,9 +127,9 @@ Contents ~
   26. Why did YCM stop using Syntastic for diagnostics display? |youcompleteme-why-did-ycm-stop-using-syntastic-for-diagnostics-display|
   27. Completion doesn't work with the C++ standard library headers |youcompleteme-completion-doesnt-work-with-c-standard-library-headers|
   28. Install YCM with NeoBundle [37] |youcompleteme-install-ycm-with-neobundle-37|
- 9. Contact                                             |youcompleteme-contact|
- 10. License                                            |youcompleteme-license|
- 11. References                                      |youcompleteme-references|
+ 10. Contact                                            |youcompleteme-contact|
+ 11. License                                            |youcompleteme-license|
+ 12. References                                      |youcompleteme-references|
 
 ===============================================================================
                                                    *youcompleteme-introduction*
@@ -139,6 +146,7 @@ Introduction ~
   - FreeBSD/OpenBSD
   - Full Installation Guide
 
+- Quick Feature Summary
 - User Guide
 
   - General Usage
@@ -554,6 +562,63 @@ all in the User Guide.
 YCM comes with sane defaults for its options, but you still may want to take a
 look at what's available for configuration. There are a few interesting options
 that are conservatively turned off by default that you may want to turn on.
+
+===============================================================================
+                                          *youcompleteme-quick-feature-summary*
+Quick Feature Summary ~
+
+-------------------------------------------------------------------------------
+                                                        *youcompleteme-general*
+General (all languages) ~
+
+- Super-fast identifier completer including tags files and syntax elements
+- Intelligent suggestion ranking and filtering
+- File and path suggestions
+- Suggestions from Vim's OmniFunc
+- UltiSnips snippet suggestions
+
+-------------------------------------------------------------------------------
+                                             *youcompleteme-c-family-languages*
+C-family languages (C, C++, Objective C, Objective C++) ~
+
+- Semantic auto-completion
+- Real-time diagnostic display
+- Go to declaration/definition (|GoTo|, etc.)
+- Semantic type information for identifiers (|GetType|)
+- Automatically fix certain errors (|FixIt|)
+
+-------------------------------------------------------------------------------
+                                                              *youcompleteme-c*
+C♯ ~
+
+- Semantic auto-completion
+- Real-time diagnostic display
+- Go to declaration/definition (|GoTo|, etc.)
+- Semantic type information for identifiers (|GetType|)
+- Automatically fix certain errors (|FixIt|)
+- Management of OmniSharp server instance
+
+-------------------------------------------------------------------------------
+                                                       *youcompleteme-python-2*
+Python 2 ~
+
+- Intelligent auto-completion
+- Go to declaration/definition (|GoTo|, etc.)
+
+-------------------------------------------------------------------------------
+                                                             *youcompleteme-go*
+Go ~
+
+- Semantic auto-completion
+- Management of 'gocode' server instance
+
+-------------------------------------------------------------------------------
+                                                     *youcompleteme-typescript*
+TypeScript ~
+
+- Semantic auto-completion
+- Go to definition (|GoToDefinition|)
+- Semantic type information for identifiers (|GetType|)
 
 ===============================================================================
                                                      *youcompleteme-user-guide*


### PR DESCRIPTION
I never got time to do the larger revamp of the README.md, but I thought a super-quick summary would be useful, as I'm about to add yet-another subcommand to a bunch of completers.