### PR TITLE
Remove g:ycm_server_use_vim_stdout option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,15 +47,13 @@ Here are the things you should do when creating an issue:
 2. Put the following options in your vimrc:
 
    ```viml
-   let g:ycm_server_use_vim_stdout = 1
+   let g:ycm_server_keep_logfiles = 1
    let g:ycm_server_log_level = 'debug'
    ```
 
-   Then, if possible, start gvim/macvim (not console vim) from the console.
-   As you use Vim, you'll see the `ycmd` debug output stream in the console.
-   If you can not use gvim/macvim, run `:YcmDebugInfo` in vim to see what
-   temporary files (listed under "Server logfiles") the debug output streams
-   are written to. Attach the debug output stream to your issue.
+   Run `:YcmDebugInfo` in vim to see what temporary files (listed under "Server
+   logfiles") the debug output streams are written to. Attach the debug output
+   stream to your issue.
 3. **Create a test case for your issue**. This is critical. Don't talk about how
    "when I have X in my file" or similar, _create a file with X in it_ and put
    the contents inside code blocks in your issue description. Try to make this

--- a/README.md
+++ b/README.md
@@ -1547,18 +1547,6 @@ Default: `''`
 let g:ycm_path_to_python_interpreter = ''
 ```
 
-### The `g:ycm_server_use_vim_stdout` option
-
-By default, the `ycmd` completion server writes logs to logfiles. When this
-option is set to `1`, the server writes logs to Vim's stdout (so you'll see them
-in the console).
-
-Default: `0`
-
-```viml
-let g:ycm_server_use_vim_stdout = 0
-```
-
 ### The `g:ycm_server_keep_logfiles` option
 
 When this option is set to `1`, the `ycmd` completion server will keep the

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -77,30 +77,29 @@ Contents ~
   20. The |g:ycm_seed_identifiers_with_syntax| option
   21. The |g:ycm_extra_conf_vim_data| option
   22. The |g:ycm_path_to_python_interpreter| option
-  23. The |g:ycm_server_use_vim_stdout| option
-  24. The |g:ycm_server_keep_logfiles| option
-  25. The |g:ycm_server_log_level| option
-  26. The |g:ycm_auto_start_csharp_server| option
-  27. The |g:ycm_auto_stop_csharp_server| option
-  28. The |g:ycm_csharp_server_port| option
-  29. The |g:ycm_csharp_insert_namespace_expr| option
-  30. The |g:ycm_add_preview_to_completeopt| option
-  31. The |g:ycm_autoclose_preview_window_after_completion| option
-  32. The |g:ycm_autoclose_preview_window_after_insertion| option
-  33. The |g:ycm_max_diagnostics_to_display| option
-  34. The |g:ycm_key_list_select_completion| option
-  35. The |g:ycm_key_list_previous_completion| option
-  36. The |g:ycm_key_invoke_completion| option
-  37. The |g:ycm_key_detailed_diagnostics| option
-  38. The |g:ycm_global_ycm_extra_conf| option
-  39. The |g:ycm_confirm_extra_conf| option
-  40. The |g:ycm_extra_conf_globlist| option
-  41. The |g:ycm_filepath_completion_use_working_dir| option
-  42. The |g:ycm_semantic_triggers| option
-  43. The |g:ycm_cache_omnifunc| option
-  44. The |g:ycm_use_ultisnips_completer| option
-  45. The |g:ycm_goto_buffer_command| option
-  46. The |g:ycm_disable_for_files_larger_than_kb| option
+  23. The |g:ycm_server_keep_logfiles| option
+  24. The |g:ycm_server_log_level| option
+  25. The |g:ycm_auto_start_csharp_server| option
+  26. The |g:ycm_auto_stop_csharp_server| option
+  27. The |g:ycm_csharp_server_port| option
+  28. The |g:ycm_csharp_insert_namespace_expr| option
+  29. The |g:ycm_add_preview_to_completeopt| option
+  30. The |g:ycm_autoclose_preview_window_after_completion| option
+  31. The |g:ycm_autoclose_preview_window_after_insertion| option
+  32. The |g:ycm_max_diagnostics_to_display| option
+  33. The |g:ycm_key_list_select_completion| option
+  34. The |g:ycm_key_list_previous_completion| option
+  35. The |g:ycm_key_invoke_completion| option
+  36. The |g:ycm_key_detailed_diagnostics| option
+  37. The |g:ycm_global_ycm_extra_conf| option
+  38. The |g:ycm_confirm_extra_conf| option
+  39. The |g:ycm_extra_conf_globlist| option
+  40. The |g:ycm_filepath_completion_use_working_dir| option
+  41. The |g:ycm_semantic_triggers| option
+  42. The |g:ycm_cache_omnifunc| option
+  43. The |g:ycm_use_ultisnips_completer| option
+  44. The |g:ycm_goto_buffer_command| option
+  45. The |g:ycm_disable_for_files_larger_than_kb| option
  9. FAQ                                                     |youcompleteme-faq|
   1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |import-vim|
   2. On very rare occasions Vim crashes when I tab through the completion menu |youcompleteme-on-very-rare-occasions-vim-crashes-when-i-tab-through-completion-menu|
@@ -1741,17 +1740,6 @@ Vim.
 Default: "''"
 >
   let g:ycm_path_to_python_interpreter = ''
-<
--------------------------------------------------------------------------------
-The *g:ycm_server_use_vim_stdout* option
-
-By default, the 'ycmd' completion server writes logs to logfiles. When this
-option is set to '1', the server writes logs to Vim's stdout (so you'll see
-them in the console).
-
-Default: '0'
->
-  let g:ycm_server_use_vim_stdout = 0
 <
 -------------------------------------------------------------------------------
 The *g:ycm_server_keep_logfiles* option

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -121,9 +121,6 @@ let g:ycm_key_detailed_diagnostics =
 let g:ycm_cache_omnifunc =
       \ get( g:, 'ycm_cache_omnifunc', 1 )
 
-let g:ycm_server_use_vim_stdout =
-      \ get( g:, 'ycm_server_use_vim_stdout', 0 )
-
 let g:ycm_server_log_level =
       \ get( g:, 'ycm_server_log_level', 'info' )
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -121,19 +121,18 @@ class YouCompleteMe( object ):
                '--idle_suicide_seconds={0}'.format(
                   SERVER_IDLE_SUICIDE_SECONDS )]
 
-      if not self._user_options[ 'server_use_vim_stdout' ]:
-        filename_format = os.path.join( utils.PathToTempDir(),
-                                        'server_{port}_{std}.log' )
+      filename_format = os.path.join( utils.PathToTempDir(),
+                                      'server_{port}_{std}.log' )
 
-        self._server_stdout = filename_format.format( port = server_port,
-                                                      std = 'stdout' )
-        self._server_stderr = filename_format.format( port = server_port,
-                                                      std = 'stderr' )
-        args.append('--stdout={0}'.format( self._server_stdout ))
-        args.append('--stderr={0}'.format( self._server_stderr ))
+      self._server_stdout = filename_format.format( port = server_port,
+                                                    std = 'stdout' )
+      self._server_stderr = filename_format.format( port = server_port,
+                                                    std = 'stderr' )
+      args.append( '--stdout={0}'.format( self._server_stdout ) )
+      args.append( '--stderr={0}'.format( self._server_stderr ) )
 
-        if self._user_options[ 'server_keep_logfiles' ]:
-          args.append('--keep_logfiles')
+      if self._user_options[ 'server_keep_logfiles' ]:
+        args.append( '--keep_logfiles' )
 
       self._server_popen = utils.SafePopen( args, stdin_windows = PIPE,
                                             stdout = PIPE, stderr = PIPE)


### PR DESCRIPTION
The `g:ycm_server_use_vim_stdout` option is not working like expected. ycmd logs are not written to the console when using the gui client with this option enabled. This is the case on Windows and I think @puremourning can confirm this on other platforms. Worse, it also makes the ycmd server unresponsive on Windows.

It's a big issue because we recommend to use this option in [CONTRIBUTING.md](https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md).

This PR removes the option and updates the contribution guidelines by asking the user to put the `let g:ycm_server_keep_logfiles = 1` option instead.

To further improve the debugging process, I would like to add a new command `:YcmToggleLogs` (thanks to @puremourning for the idea) that automatically open or close the ycmd stdout and stderr logs as windows in Vim. If you agree, I'll send another PR adding the command.

Note: if you are wondering why the ycmd stdout logs are always empty while you are adding print statements in the ycmd code, this is because the output needs to be flushed: `sys.stdout.flush()`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1753)
<!-- Reviewable:end -->
