### PR TITLE
Fix AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ install:
   - python C:\get-pip.py
   - pip install -r python\test_requirements.txt
 build_script:
-  - run_tests.py
+  - python run_tests.py
 # Disable automatic tests
 test: off


### PR DESCRIPTION
AppVeyor certainly made some changes to their infrastructures because the `run_tests.py` script is not properly executed anymore. We now need to specifically call it with python.

This is already done in the `ycmd` repository so no changes needed there.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1761)
<!-- Reviewable:end -->
