### PR TITLE
Run tests on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,28 @@
-language: python
-python:
-  - "2.6"
-  - "2.7"
+language: generic
+os:
+  - linux
+  - osx
+sudo: false
 before_install:
   - git submodule update --init --recursive
 install:
-  - pip install -r python/test_requirements.txt
+  # source because it sets up env vars on some platforms
+  - source travis/travis_install.sh
 script: ./run_tests.py
+env:
+  matrix:
+    - YCMD_PYTHON_VERSION=2.7
+    - YCMD_PYTHON_VERSION=2.6
+addons:
+  apt:
+    sources:
+     - deadsnakes
+    packages:
+     - python2.6
+     - python2.6-dev
+     - python2.7
+     - python2.7-dev
+     - python-virtualenv
+cache:
+  directories:
+    - $HOME/.cache/pip

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -2,4 +2,3 @@ flake8>=2.0
 mock>=1.0.1
 nose>=1.3.0
 PyHamcrest>=1.8.0
-argparse>=1.4.0

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -2,4 +2,4 @@ flake8>=2.0
 mock>=1.0.1
 nose>=1.3.0
 PyHamcrest>=1.8.0
-
+argparse>=1.4.0

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import os.path as p
 import sys
-import argparse
 
 DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )
 DIR_OF_THIRD_PARTY = p.join( DIR_OF_THIS_SCRIPT, 'third_party' )
@@ -19,8 +18,10 @@ if os.environ.get( 'PYTHONPATH' ):
   python_path.append( os.environ[ 'PYTHONPATH' ] )
 os.environ[ 'PYTHONPATH' ] = os.pathsep.join( python_path )
 
-sys.path.insert( 1, p.abspath( p.join( DIR_OF_THIRD_PARTY, 'argparse' ) ) )
+sys.path.insert( 1, p.abspath( p.join( DIR_OF_YCMD_THIRD_PARTY,
+                                       'argparse' ) ) )
 
+import argparse
 
 def RunFlake8():
   print( 'Running flake8' )

--- a/travis/travis_install.linux.sh
+++ b/travis/travis_install.linux.sh
@@ -1,0 +1,3 @@
+# Linux installation
+
+virtualenv -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}

--- a/travis/travis_install.osx.sh
+++ b/travis/travis_install.osx.sh
@@ -1,0 +1,19 @@
+# OS X installation
+
+# OS X comes with 2 versions of python by default, and a neat system
+# (versioner) to switch between them:
+#   /usr/bin/python2.7 - python 2.7
+#   /usr/bin/python2.6 - python 2.6
+#
+# We just set the system default to match it
+# http://stackoverflow.com/q/6998545
+defaults write com.apple.versioner.python Version ${YCMD_PYTHON_VERSION}
+
+# virtualenv is not installed by default on OS X under python2.6, and we don't
+# have sudo, so we install it manually. There is no "latest" link, so we have
+# to install a specific version.
+VENV_VERSION=13.1.2
+
+curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${VENV_VERSION}.tar.gz
+tar xvfz virtualenv-${VENV_VERSION}.tar.gz
+python virtualenv-${VENV_VERSION}/virtualenv.py -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ev
+
+YCMD_VENV_DIR=${HOME}/venvs/ycmd_test
+
+# Requirements of OS-specific install:
+#  - install any software which is not installed by Travis configuration
+#  - create (but don't activate) a virtualenv for the python version
+#    ${YCMD_PYTHON_VERSION} in the directory ${YCMD_VENV_DIR}, e.g.
+#    virtualenv -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}
+source travis/travis_install.${TRAVIS_OS_NAME}.sh
+
+# virtualenv doesn't copy python-config https://github.com/pypa/virtualenv/issues/169
+# but our build system uses it
+cp /usr/bin/python${YCMD_PYTHON_VERSION}-config ${YCMD_VENV_DIR}/bin/python-config
+
+# virtualenv script is noisy, so don't print every command
+set +v
+source ${YCMD_VENV_DIR}/bin/activate
+set -v
+
+# It is quite easy to get the above series of steps wrong. Verify that the
+# version of python actually in the path and used is the version that was
+# requested, and fail the build if we broke the travis setup
+python_version=$(python -c 'import sys; print "{0}.{1}".format( sys.version_info[0], sys.version_info[1] )')
+echo "Checking python version (actual ${python_version} vs expected ${YCMD_PYTHON_VERSION})"
+test ${python_version} == ${YCMD_PYTHON_VERSION}
+
+pip install -U pip wheel setuptools
+pip install -r python/test_requirements.txt
+
+# The build infrastructure prints a lot of spam after this script runs, so make
+# sure to disable printing, and failing on non-zero exit code after this script
+# finishes
+set +ev


### PR DESCRIPTION
There should be no difference between the behaviour on OS X and the behaviour on other platforms as all of the tests are python. However, running them is cheap and proves that there are no differences.

The approach is to import the scripts from `ycmd` with a couple of modifications:
     - don't set `YCM_CORES=1` as we didn't before, and this makes the build a lot faster
     - don't install `gcc-4.8` as we didn't before
     - install `argparse` for the tests as it is not available in python2.6

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1762)
<!-- Reviewable:end -->
