### PR TITLE
Revert commit 0fd842a29e1826e85bf495b5a88960a9e58eb9a5

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -134,8 +134,7 @@ class YouCompleteMe( object ):
       if self._user_options[ 'server_keep_logfiles' ]:
         args.append( '--keep_logfiles' )
 
-      self._server_popen = utils.SafePopen( args, stdin_windows = PIPE,
-                                            stdout = PIPE, stderr = PIPE)
+      self._server_popen = utils.SafePopen( args, stdout = PIPE, stderr = PIPE)
       BaseRequest.server_location = 'http://127.0.0.1:' + str( server_port )
       BaseRequest.hmac_secret = hmac_secret
 


### PR DESCRIPTION
this commit breaks things on ubuntu 14.04 with python 2.7.6,
since kwargs for popen does not support the key stdin_windows

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1787)
<!-- Reviewable:end -->
