### PR TITLE
Handle boolean responses from ycmd subcommands

### DIFF
--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -60,17 +60,23 @@ class CommandRequest( BaseRequest ):
 
 
   def RunPostCommandActionsIfNeeded( self ):
-    if not self.Done() or not self._response:
+    if not self.Done() or self._response is None:
       return
 
+    if isinstance( self._response, bool ):
+      return self._HandleBooleanResponse()
+
     if self._is_goto_command:
-      self._HandleGotoResponse()
-    elif self._is_fixit_command:
-      self._HandleFixitResponse()
-    elif 'message' in self._response:
-      self._HandleMessageResponse()
-    elif 'detailed_info' in self._response:
-      self._HandleDetailedInfoResponse()
+      return self._HandleGotoResponse()
+
+    if self._is_fixit_command:
+      return self._HandleFixitResponse()
+
+    if 'message' in self._response:
+      return self._HandleMessageResponse()
+
+    if 'detailed_info' in self._response:
+      return self._HandleDetailedInfoResponse()
 
 
   def _HandleGotoResponse( self ):
@@ -95,6 +101,12 @@ class CommandRequest( BaseRequest ):
       vimsupport.EchoTextVimWidth( "FixIt applied "
                                    + str( len( chunks ) )
                                    + " changes" )
+
+
+  def _HandleBooleanResponse( self ):
+    if self._response:
+      return vimsupport.EchoText( 'Yes' )
+    vimsupport.EchoText( 'No' )
 
 
   def _HandleMessageResponse( self ):


### PR DESCRIPTION
`ServerReady`, `ServerRunning`, and `ServerTerminated` C♯ subcommands could return a traceback or nothing in Vim because ycmd returns a boolean as the response of these commands.
Fix this by echoing `Yes` when the response is `True`, `No` otherwise.

Refactor the `RunPostCommandActionsIfNeeded` function to improve readability.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1805)
<!-- Reviewable:end -->
