### PR TITLE
Handle canonical response from subcommands

### DIFF
--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -63,14 +63,17 @@ class CommandRequest( BaseRequest ):
     if not self.Done() or self._response is None:
       return
 
-    if isinstance( self._response, bool ):
-      return self._HandleBooleanResponse()
-
     if self._is_goto_command:
       return self._HandleGotoResponse()
 
     if self._is_fixit_command:
       return self._HandleFixitResponse()
+
+    # If not a dictionary or a list, the response is necessarily a
+    # scalar: boolean, number, string, etc. In this case, we print
+    # it to the user.
+    if not isinstance( self._response, ( dict, list ) ):
+      return self._HandleBasicResponse()
 
     if 'message' in self._response:
       return self._HandleMessageResponse()
@@ -103,10 +106,8 @@ class CommandRequest( BaseRequest ):
                                    + " changes" )
 
 
-  def _HandleBooleanResponse( self ):
-    if self._response:
-      return vimsupport.EchoText( 'Yes' )
-    vimsupport.EchoText( 'No' )
+  def _HandleBasicResponse( self ):
+    vimsupport.EchoText( self._response )
 
 
   def _HandleMessageResponse( self ):


### PR DESCRIPTION
In continuation to PR #1805, when the ycmd server returns a canonical type (boolean, number, string, etc.), we should print it to the user.

For example, this applies to the `SolutionFile` C♯ subcommand which only returns a string (actually, this could be improved in the completer).

This also fixes a thrown exception when the response is not iterable (a number for example).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1807)
<!-- Reviewable:end -->
