### PR TITLE
Defer omnifunc only the first time; testing vimscript through vimrunner-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   matrix:
     - YCMD_PYTHON_VERSION=2.7
     - YCMD_PYTHON_VERSION=2.6
+    - VIMSCRIPT=true
 addons:
   apt:
     sources:
@@ -23,6 +24,8 @@ addons:
      - python2.7
      - python2.7-dev
      - python-virtualenv
+     - xterm
 cache:
   directories:
     - $HOME/.cache/pip
+    - /tmp/vim

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -22,6 +22,7 @@ set cpo&vim
 " This needs to be called outside of a function
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
 let s:omnifunc_mode = 0
+let s:have_deferred_omnifunc = 0
 
 let s:old_cursor_position = []
 let s:cursor_moved = 0
@@ -87,6 +88,20 @@ function! youcompleteme#Enable()
     autocmd VimLeave * call s:OnVimLeave()
     autocmd CompleteDone * call s:OnCompleteDone()
   augroup END
+
+  " Setting the omnifunc require us to ask the server if it has a Native
+  " Semantic Completer for the current buffer's filetype. When vim first start
+  " this mean that we have to wait for the server to be up and running which
+  " would block vim. So we defer setting the omnifunc the first time to when
+  " we enter Insert mode and then update it on every BufferVisit.
+  if !s:have_deferred_omnifunc
+    augroup ycm_defer_omnifunc
+      autocmd!
+      autocmd InsertEnter * call s:SetOmnicompleteFunc()
+                        \| let s:have_deferred_omnifunc = 1
+                        \| autocmd! ycm_defer_omnifunc
+    augroup END
+  endif
 
   " Calling these once solves the problem of BufReadPre/BufRead/BufEnter not
   " triggering for the first loaded file. This should be the last commands
@@ -400,6 +415,13 @@ function! s:OnBufferVisit()
 
   call s:SetUpCompleteopt()
   call s:SetCompleteFunc()
+
+  " If we already have deferred setting the omnifunc one time then we can
+  " update it on BufferVisit without the user experience any waiting
+  if s:have_deferred_omnifunc
+    call s:SetOmnicompleteFunc()
+  endif
+
   py ycm_state.OnBufferVisit()
   call s:OnFileReadyToParse()
 endfunction
@@ -530,11 +552,6 @@ function! s:OnInsertEnter()
 
   if !s:AllowedToCompleteInCurrentFile()
     return
-  endif
-
-  if !get( b:, 'ycm_omnicomplete', 0 )
-    let b:ycm_omnicomplete = 1
-    call s:SetOmnicompleteFunc()
   endif
 
   let s:old_cursor_position = []

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -1,4 +1,6 @@
 flake8>=2.0
 mock>=1.0.1
 nose>=1.3.0
+nose-exclude>=0.4.1
 PyHamcrest>=1.8.0
+vimrunner>=1.0.3

--- a/python/ycm/tests/vimscript/defer_omnifunc_test.py
+++ b/python/ycm/tests/vimscript/defer_omnifunc_test.py
@@ -37,6 +37,16 @@ class OmnifuncTest( TestCase ):
     assert_that( vim.eval( '&omnifunc' ), equal_to( 'youcompleteme#OmniComplete' ) )
 
 
+  def omnifunc_is_set_after_re_edit_file_test( self ):
+    vim = self.prepare_editor()
+    vim.edit( 'python/ycm/base.py' )
+    vim.command( 'autocmd FileType python :setlocal omnifunc=noycm' )
+    vim.normal( 'i' )
+    vim.feedkeys( '\<Esc>' )
+    vim.command( 'e!' )
+    assert_that( vim.eval( '&omnifunc' ), equal_to( 'youcompleteme#OmniComplete' ) )
+
+
   def prepare_editor( self ):
     self.vim = self._get_proper_editor()
     self.vim.prepend_runtimepath( DIR_OF_YCM )

--- a/python/ycm/tests/vimscript/defer_omnifunc_test.py
+++ b/python/ycm/tests/vimscript/defer_omnifunc_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+import vimrunner
+from os import path
+from ycmd.utils import OnMac
+from unittest import TestCase
+from hamcrest import assert_that
+from hamcrest.core.core.isequal import equal_to
+
+DIR_OF_YCM = path.abspath( path.join( path.dirname( path.abspath( __file__ ) ),
+                                      '..', '..', '..', '..' ) )
+
+
+class OmnifuncTest( TestCase ):
+
+  def omnifunc_is_set_as_soon_as_we_enter_insert_mode_test( self ):
+    vim = self.prepare_editor()
+    vim.edit( 'python/ycm/base.py' )
+    vim.normal( 'i' )
+    assert_that( vim.eval( '&omnifunc' ), equal_to( 'youcompleteme#OmniComplete' ) )
+
+
+  def prepare_editor( self ):
+    self.vim = self._get_proper_editor()
+    self.vim.prepend_runtimepath( DIR_OF_YCM )
+    self.vim.command( 'runtime! plugin/youcompleteme.vim' )
+    self.vim.command( 'call youcompleteme#Enable()' )
+    return self.vim
+
+
+  def _get_proper_editor( self ):
+    if OnMac():
+      return self.server.start_gvim()
+    else:
+      return self.server.start_in_other_terminal()
+
+
+  def setUp( self ):
+    self.server = vimrunner.Server()
+
+
+  def tearDown( self ):
+    self.vim.feedkeys( '\<Esc>' )
+    self.vim.quit()
+    self.server.kill()

--- a/run_tests.py
+++ b/run_tests.py
@@ -37,6 +37,8 @@ def ParseArguments():
   parser = argparse.ArgumentParser()
   parser.add_argument( '--skip-build', action = 'store_true',
                        help = 'Do not build ycmd before testing.' )
+  parser.add_argument( '--run-all', action = 'store_true',
+                       help = 'Run all tests.' )
 
   return parser.parse_args()
 
@@ -49,11 +51,24 @@ def BuildYcmdLibs( args ):
     ] )
 
 
+def TestingVimscript():
+  return os.environ.get( 'VIMSCRIPT' )
+
+
 def NoseTests():
   subprocess.check_call( [
     'nosetests',
     '-v',
-    p.join( DIR_OF_THIS_SCRIPT, 'python' )
+    p.join( DIR_OF_THIS_SCRIPT, 'python' ),
+    '--exclude-dir={0}'.format( p.join( 'python', 'ycm', 'tests', 'vimscript' ) )
+  ] )
+
+
+def NoseVimscriptTests():
+  subprocess.check_call( [
+    'nosetests',
+    '-v',
+    p.join( DIR_OF_THIS_SCRIPT, 'python', 'ycm', 'tests', 'vimscript' )
   ] )
 
 
@@ -61,7 +76,14 @@ def Main():
   parsed_args = ParseArguments()
   RunFlake8()
   BuildYcmdLibs( parsed_args )
-  NoseTests()
+
+  if parsed_args.run_all:
+    NoseTests()
+    NoseVimscriptTests()
+  elif TestingVimscript():
+    NoseVimscriptTests()
+  else:
+    NoseTests()
 
 if __name__ == "__main__":
   Main()

--- a/travis/travis_install.linux.sh
+++ b/travis/travis_install.linux.sh
@@ -1,3 +1,31 @@
 # Linux installation
 
 virtualenv -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}
+
+if [[ ${VIMSCRIPT} ]]; then
+  if [[ -d /tmp/vim/.git ]]; then
+    pushd /tmp/vim
+    git fetch
+    if ! git diff --exit-code --quiet ..origin/master; then
+      git reset --hard origin/master
+      git clean -dfx
+      need_build=1
+    fi
+    popd
+  else
+    git clone --depth 1 --single-branch https://github.com/vim/vim /tmp/vim
+    need_build=1
+  fi
+  if [[ -n "${need_build}" ]]; then
+    pushd /tmp/vim
+    ./configure --prefix="/tmp/vim/build" --with-features=huge \
+      --with-x --enable-pythoninterp --enable-fail-if-missing
+    make -j2
+    make install
+    popd
+  fi
+
+  export PATH=/tmp/vim/build/bin:$PATH
+  export DISPLAY=:99.0
+  sh -e /etc/init.d/xvfb start
+fi

--- a/travis/travis_install.linux.sh
+++ b/travis/travis_install.linux.sh
@@ -4,7 +4,7 @@ virtualenv -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}
 
 if [[ ${VIMSCRIPT} ]]; then
   if [[ ! -d /tmp/vim/.git ]]; then
-    git clone --depth 1 --single-branch --branch v7.3.598 https://github.com/vim/vim /tmp/vim
+    git clone --depth 1 --single-branch --branch v7.3.599 https://github.com/vim/vim /tmp/vim
     pushd /tmp/vim
     ./configure --prefix="/tmp/vim/build" --with-features=huge \
       --with-x --enable-pythoninterp --enable-fail-if-missing

--- a/travis/travis_install.linux.sh
+++ b/travis/travis_install.linux.sh
@@ -3,20 +3,8 @@
 virtualenv -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}
 
 if [[ ${VIMSCRIPT} ]]; then
-  if [[ -d /tmp/vim/.git ]]; then
-    pushd /tmp/vim
-    git fetch
-    if ! git diff --exit-code --quiet ..origin/master; then
-      git reset --hard origin/master
-      git clean -dfx
-      need_build=1
-    fi
-    popd
-  else
-    git clone --depth 1 --single-branch https://github.com/vim/vim /tmp/vim
-    need_build=1
-  fi
-  if [[ -n "${need_build}" ]]; then
+  if [[ ! -d /tmp/vim/.git ]]; then
+    git clone --depth 1 --single-branch --branch v7.3.598 https://github.com/vim/vim /tmp/vim
     pushd /tmp/vim
     ./configure --prefix="/tmp/vim/build" --with-features=huge \
       --with-x --enable-pythoninterp --enable-fail-if-missing

--- a/travis/travis_install.osx.sh
+++ b/travis/travis_install.osx.sh
@@ -1,5 +1,9 @@
 # OS X installation
 
+function brew() {
+  command brew "$@" || command brew "$@"
+}
+
 # OS X comes with 2 versions of python by default, and a neat system
 # (versioner) to switch between them:
 #   /usr/bin/python2.7 - python 2.7
@@ -17,3 +21,6 @@ VENV_VERSION=13.1.2
 curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${VENV_VERSION}.tar.gz
 tar xvfz virtualenv-${VENV_VERSION}.tar.gz
 python virtualenv-${VENV_VERSION}/virtualenv.py -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}
+
+brew update
+brew install --ignore-dependencies macvim --with-python --with-override-system-vim

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -2,6 +2,10 @@
 
 set -ev
 
+# In the case of VIMSCRIPT testing we still need to define this variable and we
+# also need to run under 2.7 since vimrunner-python don't support python2.6
+YCMD_PYTHON_VERSION=${YCMD_PYTHON_VERSION:-2.7}
+
 YCMD_VENV_DIR=${HOME}/venvs/ycmd_test
 
 # Requirements of OS-specific install:


### PR DESCRIPTION
I wanted to get it out and get some real feedback about it. This PR supersedes #1770 since it enables testing the vimscript that handle this deferring through [vimrunner-python](/andri-ch/vimrunner-python). The cons of this:

- No Windows at the moment.
- No python 2.6

The cons are actually limitation of `vimrunner-python`. @micbou do you have news about this? I know you were working on it, just checking ;)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1811)
<!-- Reviewable:end -->
