### PR TITLE
Expose functions to get error and warning counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,30 @@ provides a list of implementations to choose from.
 
 Supported in filetypes: `cs`
 
+Functions
+--------
+
+### The `YcmGetErrorCount` function
+
+Get the number of YCM Diagnostic errors. If no errors are present, this function
+returns 0.
+
+For example:
+```viml
+  call YcmGetErrorCount()
+```
+
+### The `YcmGetWarningCount` function
+
+Get the number of YCM Diagnostic warnings. If no warnings are present, this
+function returns 0.
+
+For example:
+```viml
+  call YcmGetWarningCount()
+```
+
+
 Options
 -------
 

--- a/README.md
+++ b/README.md
@@ -1135,6 +1135,11 @@ For example:
   call youcompleteme#GetErrorCount()
 ```
 
+Both this function and `youcompleteme#GetWarningCount` can be useful when
+integrating YCM with other Vim plugins. For example, a [lightline][] user could
+add a diagnostics section to their statusline which would display the number of
+errors and warnings.
+
 ### The `youcompleteme#GetWarningCount` function
 
 Get the number of YCM Diagnostic warnings. If no warnings are present, this
@@ -2373,6 +2378,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [gpl]: http://www.gnu.org/copyleft/gpl.html
 [vim]: http://www.vim.org/
 [syntastic]: https://github.com/scrooloose/syntastic
+[lightline]: https://github.com/itchyny/lightline.vim
 [flags_example]: https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py
 [compdb]: http://clang.llvm.org/docs/JSONCompilationDatabase.html
 [subsequence]: https://en.wikipedia.org/wiki/Subsequence

--- a/README.md
+++ b/README.md
@@ -1125,24 +1125,24 @@ Supported in filetypes: `cs`
 Functions
 --------
 
-### The `YcmGetErrorCount` function
+### The `youcompleteme#GetErrorCount` function
 
 Get the number of YCM Diagnostic errors. If no errors are present, this function
 returns 0.
 
 For example:
 ```viml
-  call YcmGetErrorCount()
+  call youcompleteme#GetErrorCount()
 ```
 
-### The `YcmGetWarningCount` function
+### The `youcompleteme#GetWarningCount` function
 
 Get the number of YCM Diagnostic warnings. If no warnings are present, this
 function returns 0.
 
 For example:
 ```viml
-  call YcmGetWarningCount()
+  call youcompleteme#GetWarningCount()
 ```
 
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -870,6 +870,16 @@ function! s:ShowDiagnostics()
 endfunction
 
 
+function! g:YcmGetErrorCount()
+  return pyeval( 'ycm_state.GetErrorCount()' )
+endfunction
+
+
+function! g:YcmGetWarningCount()
+  return pyeval( 'ycm_state.GetWarningCount()' )
+endfunction
+
+
 " This is basic vim plugin boilerplate
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -111,6 +111,16 @@ function! youcompleteme#DisableCursorMovedAutocommands()
 endfunction
 
 
+function! youcompleteme#GetErrorCount()
+  return pyeval( 'ycm_state.GetErrorCount()' )
+endfunction
+
+
+function! youcompleteme#GetWarningCount()
+  return pyeval( 'ycm_state.GetWarningCount()' )
+endfunction
+
+
 function! s:SetUpPython() abort
 python << EOF
 import sys
@@ -867,16 +877,6 @@ function! s:ShowDiagnostics()
   else
     echom "No warnings or errors detected"
   endif
-endfunction
-
-
-function! g:YcmGetErrorCount()
-  return pyeval( 'ycm_state.GetErrorCount()' )
-endfunction
-
-
-function! g:YcmGetWarningCount()
-  return pyeval( 'ycm_state.GetWarningCount()' )
 endfunction
 
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1363,6 +1363,11 @@ For example:
 >
   call youcompleteme#GetErrorCount()
 <
+Both this function and |youcompleteme#GetWarningCount| can be useful when
+integrating YCM with other Vim plugins. For example, a lightline [48] user
+could add a diagnostics section to their statusline which would display the
+number of errors and warnings.
+
 -------------------------------------------------------------------------------
 The *youcompleteme#GetWarningCount* function
 
@@ -2627,5 +2632,6 @@ References ~
 [45] http://www.gnu.org/copyleft/gpl.html
 [46] https://bitdeli.com/free
 [47] https://d2weczhvl823v0.cloudfront.net/Valloric/youcompleteme/trend.png
+[48] https://github.com/itchyny/lightline.vim
 
 vim: ft=help

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -55,7 +55,10 @@ Contents ~
   14. The |ReloadSolution| subcommand
   15. The |GoToImplementation| subcommand
   16. The |GoToImplementationElseDeclaration| subcommand
- 8. Options                                             |youcompleteme-options|
+ 8. Functions                                         |youcompleteme-functions|
+  1. The |YcmGetErrorCount| function
+  2. The |YcmGetWarningCount| function
+ 9. Options                                             |youcompleteme-options|
   1. The |g:ycm_min_num_of_chars_for_completion| option
   2. The |g:ycm_min_num_identifier_candidate_chars| option
   3. The |g:ycm_auto_trigger| option
@@ -101,7 +104,7 @@ Contents ~
   43. The |g:ycm_use_ultisnips_completer| option
   44. The |g:ycm_goto_buffer_command| option
   45. The |g:ycm_disable_for_files_larger_than_kb| option
- 9. FAQ                                                     |youcompleteme-faq|
+ 10. FAQ                                                    |youcompleteme-faq|
   1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |import-vim|
   2. On very rare occasions Vim crashes when I tab through the completion menu |youcompleteme-on-very-rare-occasions-vim-crashes-when-i-tab-through-completion-menu|
   3. I get a linker warning regarding |libpython| on Mac when compiling YCM
@@ -1346,6 +1349,30 @@ provides a list of implementations to choose from.
 
 Supported in filetypes: 'cs'
 
+===============================================================================
+                                                      *youcompleteme-functions*
+Functions ~
+
+-------------------------------------------------------------------------------
+The *YcmGetErrorCount* function
+
+Get the number of YCM Diagnostic errors. If no errors are present, this function
+returns 0.
+
+For example:
+>
+  call YcmGetErrorCount()
+<
+-------------------------------------------------------------------------------
+The *YcmGetWarningCount* function
+
+Get the number of YCM Diagnostic warnings. If no warnings are present, this
+function returns 0.
+
+For example:
+>
+  call YcmGetWarningCount()
+<
 ===============================================================================
                                                         *youcompleteme-options*
 Options ~

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -30,6 +30,7 @@ Contents ~
   8. Diagnostic display                      |youcompleteme-diagnostic-display|
    1. C# Diagnostic Support                |youcompleteme-c-diagnostic-support|
    2. Diagnostic highlighting groups |youcompleteme-diagnostic-highlighting-groups|
+
  6. Commands                                           |youcompleteme-commands|
   1. The |:YcmRestartServer| command
   2. The |:YcmForceCompileAndDiagnostics| command
@@ -1231,9 +1232,9 @@ For example:
   class C {
       void f();
   };
-  
+
   void C::f() {
-  
+
   }
 <
 In the out-of-line definition of 'C::f', the semantic parent is the class 'C',
@@ -1354,24 +1355,24 @@ Supported in filetypes: 'cs'
 Functions ~
 
 -------------------------------------------------------------------------------
-The *YcmGetErrorCount* function
+The *youcompleteme#GetErrorCount* function
 
 Get the number of YCM Diagnostic errors. If no errors are present, this function
 returns 0.
 
 For example:
 >
-  call YcmGetErrorCount()
+  call youcompleteme#GetErrorCount()
 <
 -------------------------------------------------------------------------------
-The *YcmGetWarningCount* function
+The *youcompleteme#GetWarningCount* function
 
 Get the number of YCM Diagnostic warnings. If no warnings are present, this
 function returns 0.
 
 For example:
 >
-  call YcmGetWarningCount()
+  call youcompleteme#GetWarningCount()
 <
 ===============================================================================
                                                         *youcompleteme-options*

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -30,7 +30,6 @@ Contents ~
   8. Diagnostic display                      |youcompleteme-diagnostic-display|
    1. C# Diagnostic Support                |youcompleteme-c-diagnostic-support|
    2. Diagnostic highlighting groups |youcompleteme-diagnostic-highlighting-groups|
-
  6. Commands                                           |youcompleteme-commands|
   1. The |:YcmRestartServer| command
   2. The |:YcmForceCompileAndDiagnostics| command
@@ -57,8 +56,8 @@ Contents ~
   15. The |GoToImplementation| subcommand
   16. The |GoToImplementationElseDeclaration| subcommand
  8. Functions                                         |youcompleteme-functions|
-  1. The |YcmGetErrorCount| function
-  2. The |YcmGetWarningCount| function
+  1. The |youcompleteme#GetErrorCount| function
+  2. The |youcompleteme#GetWarningCount| function
  9. Options                                             |youcompleteme-options|
   1. The |g:ycm_min_num_of_chars_for_completion| option
   2. The |g:ycm_min_num_identifier_candidate_chars| option
@@ -1357,8 +1356,8 @@ Functions ~
 -------------------------------------------------------------------------------
 The *youcompleteme#GetErrorCount* function
 
-Get the number of YCM Diagnostic errors. If no errors are present, this function
-returns 0.
+Get the number of YCM Diagnostic errors. If no errors are present, this
+function returns 0.
 
 For example:
 >

--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -45,27 +45,11 @@ class DiagnosticInterface( object ):
 
 
   def GetErrorCount( self ):
-    errors = 0
-    line_to_diags = self._buffer_number_to_line_to_diags[
-      vim.current.buffer.number ]
-
-    for diags in line_to_diags.itervalues():
-      for diag in diags:
-        if _DiagnosticIsError( diag ):
-          errors += 1
-    return errors
+    return len( self._FilterDiagnostics( _DiagnosticIsError ) )
 
 
   def GetWarningCount( self ):
-    warnings = 0
-    line_to_diags = self._buffer_number_to_line_to_diags[
-      vim.current.buffer.number ]
-
-    for diags in line_to_diags.itervalues():
-      for diag in diags:
-        if _DiagnosticIsWarning( diag ):
-          warnings += 1
-    return warnings
+    return len( self._FilterDiagnostics( _DiagnosticIsWarning ) )
 
 
   def UpdateWithNewDiagnostics( self, diags ):
@@ -102,6 +86,16 @@ class DiagnosticInterface( object ):
 
     vimsupport.EchoTextVimWidth( text )
     self._diag_message_needs_clearing = True
+
+
+  def _FilterDiagnostics( self, predicate ):
+    matched_diags = []
+    line_to_diags = self._buffer_number_to_line_to_diags[
+      vim.current.buffer.number ]
+
+    for diags in line_to_diags.itervalues():
+      matched_diags.extend( filter( predicate, diags ) )
+    return matched_diags
 
 
 def _UpdateSquiggles( buffer_number_to_line_to_diags ):

--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -43,6 +43,31 @@ class DiagnosticInterface( object ):
       if self._user_options[ 'echo_current_diagnostic' ]:
         self._EchoDiagnosticForLine( line )
 
+
+  def GetErrorCount( self ):
+    errors = 0
+    line_to_diags = self._buffer_number_to_line_to_diags[
+      vim.current.buffer.number ]
+
+    for diags in line_to_diags.itervalues():
+      for diag in diags:
+        if _DiagnosticIsError( diag ):
+          errors += 1
+    return errors
+
+
+  def GetWarningCount( self ):
+    warnings = 0
+    line_to_diags = self._buffer_number_to_line_to_diags[
+      vim.current.buffer.number ]
+
+    for diags in line_to_diags.itervalues():
+      for diag in diags:
+        if _DiagnosticIsWarning( diag ):
+          warnings += 1
+    return warnings
+
+
   def UpdateWithNewDiagnostics( self, diags ):
     normalized_diags = [ _NormalizeDiagnostic( x ) for x in diags ]
     self._buffer_number_to_line_to_diags = _ConvertDiagListToDict(
@@ -207,6 +232,10 @@ def _ConvertDiagListToDict( diag_list ):
 
 def _DiagnosticIsError( diag ):
   return diag[ 'kind' ] == 'ERROR'
+
+
+def _DiagnosticIsWarning( diag ):
+  return diag[ 'kind' ] == 'WARNING'
 
 
 def _NormalizeDiagnostic( diag ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -451,6 +451,11 @@ class YouCompleteMe( object ):
       return None
     return completion[ "extra_data" ][ "required_namespace_import" ]
 
+  def GetErrorCount( self ):
+    return self._diag_interface.GetErrorCount()
+
+  def GetWarningCount( self ):
+    return self._diag_interface.GetWarningCount()
 
   def DiagnosticsForCurrentFileReady( self ):
     return bool( self._latest_file_parse_request and


### PR DESCRIPTION
@Valloric I've implemented two functions which resolve #1011 

The interface exposed to Vim is:

```viml
youcompleteme#GetErrorCount()
youcompleteme#GetWarningCount()
```

Below is a rough example of how these methods can be used to integrate with other plugins. In this case Lightline has been extended to show the error and warning count as red and yellow sections on the end of the status line, respectively.

![animation](https://cloud.githubusercontent.com/assets/3267574/11604073/078cb98e-9a9d-11e5-9fa3-c9b4bb6a6e82.gif)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1814)
<!-- Reviewable:end -->
