### PR TITLE
Set buffer filetypes for UltiSnips

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -602,7 +602,14 @@ def _AddUltiSnipsDataIfNeeded( extra_data ):
     return
 
   try:
-    rawsnips = UltiSnips_Manager._snips( '', 1 )
+    # Since UltiSnips may run in a different python interpreter (python 3) than
+    # YCM, UltiSnips_Manager singleton is not necessary the same as the one
+    # used by YCM. In particular, it means that we cannot rely on UltiSnips to
+    # set the current filetypes to the singleton. We need to do it ourself.
+    UltiSnips_Manager.reset_buffer_filetypes()
+    UltiSnips_Manager.add_buffer_filetypes(
+      vimsupport.GetVariableValue( '&filetype' ) )
+    rawsnips = UltiSnips_Manager._snips( '', True )
   except:
     return
 


### PR DESCRIPTION
Currently, only `all` snippets are displayed by YCM because UltiSnips is called without setting the buffer filetypes. See issue #1818.

This is fixed by using UltiSnips methods `reset_buffer_filetypes` and `add_buffer_filetypes`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1821)
<!-- Reviewable:end -->
