### PR TITLE
Updated paths to the build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,11 +458,11 @@ process.
     following:
 
         cd ~
-        mkdir ycm_build
-        cd ycm_build
+        mkdir ycm_temp
+        cd ycm_temp
 
     Now we need to generate the makefiles. If you DON'T care about semantic
-    support for C-family languages, run the following command in the `ycm_build`
+    support for C-family languages, run the following command in the `ycm_temp`
     directory:
 
         cmake -G "<generator>" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
@@ -496,7 +496,7 @@ process.
     custom-built LLVM! See docs below for `EXTERNAL_LIBCLANG_PATH` when using a
     custom LLVM build.
 
-    With that in mind, run the following command in the `ycm_build` directory:
+    With that in mind, run the following command in the `ycm_temp` directory:
 
         cmake -G "<generator>" -DPATH_TO_LLVM_ROOT=~/ycm_temp/llvm_root_dir . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
 


### PR DESCRIPTION
Curenntly causes the following error if you follow the complete guide:

CompletionData.h:23:10: fatal error: 'clang-c/Index.h' file not found
   #include <clang-c/Index.h>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1843)
<!-- Reviewable:end -->
