### PR TITLE
Use check_call to capture error from build process

### DIFF
--- a/install.py
+++ b/install.py
@@ -18,7 +18,7 @@ def Main():
               'to run:\n\tgit submodule update --init --recursive\n\n' )
 
   python_binary = sys.executable
-  subprocess.call( [ python_binary, build_file ] + sys.argv[1:] )
+  subprocess.check_call( [ python_binary, build_file ] + sys.argv[1:] )
 
   # Remove old YCM libs if present so that YCM can start.
   old_libs = (


### PR DESCRIPTION
Without this install.py always exits 0 and no way to tell vim-plug its installation actually failed.

Before:

```
$ ./install.py
...

-- Configuring incomplete, errors occurred!
See also "/tmp/ycm_build.Vu_ej5/CMakeFiles/CMakeOutput.log".
See also "/tmp/ycm_build.Vu_ej5/CMakeFiles/CMakeError.log".
Traceback (most recent call last):
  File "/root/.vim/plugged/YouCompleteMe/third_party/ycmd/build.py", line 312, in <module>
    Main()
  File "/root/.vim/plugged/YouCompleteMe/third_party/ycmd/build.py", line 303, in Main
    BuildYcmdLibs( args )
  File "/root/.vim/plugged/YouCompleteMe/third_party/ycmd/build.py", line 248, in BuildYcmdLibs
    subprocess.check_call( [ 'cmake' ] + full_cmake_args )
  File "/usr/lib64/python2.6/subprocess.py", line 505, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '-G', 'Unix Makefiles', '/root/.vim/plugged/YouCompleteMe/third_party/ycmd/cpp']' returned non-zero exit status 1

$ echo $?
0
```

After:

```
$ ./install.py
...

-- Configuring incomplete, errors occurred!
See also "/tmp/ycm_build.p6F7yK/CMakeFiles/CMakeOutput.log".
See also "/tmp/ycm_build.p6F7yK/CMakeFiles/CMakeError.log".
Traceback (most recent call last):
  File "/root/.vim/plugged/YouCompleteMe/third_party/ycmd/build.py", line 312, in <module>
    Main()
  File "/root/.vim/plugged/YouCompleteMe/third_party/ycmd/build.py", line 303, in Main
    BuildYcmdLibs( args )
  File "/root/.vim/plugged/YouCompleteMe/third_party/ycmd/build.py", line 248, in BuildYcmdLibs
    subprocess.check_call( [ 'cmake' ] + full_cmake_args )
  File "/usr/lib64/python2.6/subprocess.py", line 505, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '-G', 'Unix Makefiles', '/root/.vim/plugged/YouCompleteMe/third_party/ycmd/cpp']' returned non-zero exit status 1
Traceback (most recent call last):
  File "./install.py", line 32, in <module>
    Main()
  File "./install.py", line 21, in Main
    subprocess.check_call( [ python_binary, build_file ] + sys.argv[1:] )
  File "/usr/lib64/python2.6/subprocess.py", line 505, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/usr/bin/python', '/root/.vim/plugged/YouCompleteMe/third_party/ycmd/build.py']' returned non-zero exit status 1

$ echo $?
1
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1855)
<!-- Reviewable:end -->
