### PR TITLE
[READY] Fix traceback when v:completed_item is empty

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -390,6 +390,9 @@ class YouCompleteMe( object ):
   def _HasCompletionsThatCouldBeCompletedWithMoreText_NewerVim( self,
                                                                 completions ):
     completed_item = vimsupport.GetVariableValue( 'v:completed_item' )
+    if not completed_item:
+      return False
+
     completed_word = completed_item[ 'word' ]
     if not completed_word:
       return False


### PR DESCRIPTION
### Problem

A traceback is raised in Vim when completing in a C♯ file while the ycmd server crashed:
```
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
Traceback (most recent call last):
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
  File "<string>", line 1, in <module>
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\../python\ycm\youcompleteme.py", line 305, in OnCompleteDone
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
    action(self)
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\../python\ycm\youcompleteme.py", line 102, in <lambda>
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
    'cs': lambda( self ): self._OnCompleteDone_Csharp()
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\../python\ycm\youcompleteme.py", line 428, in _OnCompleteDone_Csharp
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:

Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\../python\ycm\youcompleteme.py", line 327, in GetCompletionsUserMayHaveCompleted
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
    if self._HasCompletionsThatCouldBeCompletedWithMoreText( completions ):
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\../python\ycm\youcompleteme.py", line 393, in _HasCompletionsThatCouldBeCompletedWithMoreText
_NewerVim
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
    if not completed_item:
Error detected while processing function <SNR>27_OnCompleteDone:
line    1:
KeyError: 'word'
```
It happens because the Vim variable `v:completed_item` is empty. From Vim documentation on `v:completed_item`:

> Dictionary containing the complete-items for the most 	recently completed word after CompleteDone.  **The Dictionary is empty if the completion failed**.

### Solution

Check if `v:completed_item` is empty before accessing its `word` key.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1860)
<!-- Reviewable:end -->
