### PR TITLE
Support for C/C++ semantic highlighting.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -37,12 +37,6 @@ let s:diagnostic_ui_filetypes = {
       \ }
 
 
-let s:semantic_highlighting_filetypes = {
-      \ 'cpp': 1,
-      \ 'c': 1,
-      \ }
-
-
 function! youcompleteme#Enable()
   " When vim is in diff mode, don't run
   if &diff
@@ -263,19 +257,6 @@ function! s:SetUpSyntaxHighlighting()
     endif
   endif
 
-  highlight NormalBold gui=bold
-  highlight TypeBold ctermfg=121 guifg=#b58900 gui=bold
-  highlight link Token_cpp_Namespace Function
-  highlight link Token_cpp_Class TypeBold
-  highlight link Token_cpp_Struct TypeBold
-  highlight link Token_cpp_Union TypeBold
-  highlight link Token_cpp_Typedef TypeBold
-  highlight link Token_cpp_Enum TypeBold
-  highlight link Token_cpp_EnumConstant Constant
-  highlight link Token_cpp_Macro Macro
-  highlight link Token_cpp_Function Function
-  highlight link Token_cpp_FunctionParam NormalBold
-
   if !hlexists( 'YcmWarningSection' )
     if hlexists( 'SyntasticWarning' )
       highlight link YcmWarningSection SyntasticWarning
@@ -313,11 +294,6 @@ endfunction
 
 function! s:DiagnosticUiSupportedForCurrentFiletype()
   return get( s:diagnostic_ui_filetypes, &filetype, 0 )
-endfunction
-
-
-function! s:SemanticHighlightingSupportedForCurrentFiletype()
-  return get( s:semantic_highlighting_filetypes, &filetype, 0 )
 endfunction
 
 
@@ -470,7 +446,6 @@ function! s:OnFileReadyToParse()
   " the response would always be pending when we called
   " UpdateDiagnosticNotifications.
   call s:UpdateDiagnosticNotifications()
-  call s:UpdateSemanticHighlightingNotifications()
 
   let buffer_changed = b:changedtick != b:ycm_changedtick.file_ready_to_parse
   if buffer_changed
@@ -631,18 +606,6 @@ function! s:UpdateDiagnosticNotifications()
   endif
 
   py ycm_state.UpdateDiagnosticInterface()
-endfunction
-
-
-function! s:UpdateSemanticHighlightingNotifications()
-  let should_highlight_tokens =
-        \ s:SemanticHighlightingSupportedForCurrentFiletype()
-
-  if !should_highlight_tokens
-    return
-  endif
-
-  py ycm_state.UpdateSemanticHighlights()
 endfunction
 
 
@@ -876,7 +839,7 @@ function! s:ForceCompile()
   py ycm_state.OnFileReadyToParse()
   while 1
     let diagnostics_ready = pyeval(
-          \ 'ycm_state.HandleFileParseResult()' )
+          \ 'ycm_state.DiagnosticsForCurrentFileReady()' )
     if diagnostics_ready
       break
     endif

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -111,6 +111,11 @@ function! youcompleteme#DisableCursorMovedAutocommands()
 endfunction
 
 
+function! youcompleteme#GetSemanticTokens( bufnr, timeout )
+  return pyeval( 'ycm_state.GetSemantics(' . string( a:bufnr ) . ', ' .
+                                           \ string( a:timeout ) . ')' )
+endfunction
+
 function! youcompleteme#GetErrorCount()
   return pyeval( 'ycm_state.GetErrorCount()' )
 endfunction

--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -34,6 +34,7 @@ from mock import call, MagicMock, patch
 DEFAULT_CLIENT_OPTIONS = {
   'server_log_level': 'info',
   'extra_conf_vim_data': [],
+  'show_diagnostics_ui': 1,
 }
 
 def PostVimMessage_Call( message ):
@@ -143,7 +144,7 @@ class EventNotification_test( object ):
 
   @patch( 'vim.command' )
   def FileReadyToParse_NonDiagnostic_Error_test( self, vim_command ):
-    # This test validates the behaviour of YouCompleteMe.ValidateParseRequest in
+    # This test validates the behaviour of YouCompleteMe.HandleFileParseRequest in
     # combination with YouCompleteMe.OnFileReadyToParse when the completer
     # raises an exception handling FileReadyToParse event notification
     ERROR_TEXT = 'Some completer response text'
@@ -154,8 +155,8 @@ class EventNotification_test( object ):
     with MockArbitraryBuffer( 'javascript' ):
       with MockEventNotification( ErrorResponse ):
         self.server_state.OnFileReadyToParse()
-        assert self.server_state.DiagnosticsForCurrentFileReady()
-        self.server_state.ValidateParseRequest()
+        assert self.server_state.FileParseRequestReady()
+        self.server_state.HandleFileParseRequest()
 
         # The first call raises a warning
         vim_command.assert_has_calls( [
@@ -163,15 +164,15 @@ class EventNotification_test( object ):
         ] )
 
         # Subsequent calls don't re-raise the warning
-        self.server_state.ValidateParseRequest()
+        self.server_state.HandleFileParseRequest()
         vim_command.assert_has_calls( [
           PostVimMessage_Call( ERROR_TEXT ),
         ] )
 
         # But it does if a subsequent event raises again
         self.server_state.OnFileReadyToParse()
-        assert self.server_state.DiagnosticsForCurrentFileReady()
-        self.server_state.ValidateParseRequest()
+        assert self.server_state.FileParseRequestReady()
+        self.server_state.HandleFileParseRequest()
         vim_command.assert_has_calls( [
           PostVimMessage_Call( ERROR_TEXT ),
           PostVimMessage_Call( ERROR_TEXT ),
@@ -183,7 +184,7 @@ class EventNotification_test( object ):
     with MockArbitraryBuffer( 'javascript' ):
       with MockEventNotification( None, False ):
         self.server_state.OnFileReadyToParse()
-        self.server_state.ValidateParseRequest()
+        self.server_state.HandleFileParseRequest()
         vim_command.assert_not_called()
 
 
@@ -195,7 +196,7 @@ class EventNotification_test( object ):
       load_extra_conf,
       *args ):
 
-    # This test validates the behaviour of YouCompleteMe.ValidateParseRequest in
+    # This test validates the behaviour of YouCompleteMe.HandleFileParseRequest in
     # combination with YouCompleteMe.OnFileReadyToParse when the completer
     # raises the (special) UnknownExtraConf exception
 
@@ -213,8 +214,8 @@ class EventNotification_test( object ):
         with patch( 'ycm.vimsupport.PresentDialog',
                     return_value = 0 ) as present_dialog:
           self.server_state.OnFileReadyToParse()
-          assert self.server_state.DiagnosticsForCurrentFileReady()
-          self.server_state.ValidateParseRequest()
+          assert self.server_state.FileParseRequestReady()
+          self.server_state.HandleFileParseRequest()
 
           present_dialog.assert_has_calls( [
             PresentDialog_Confirm_Call( MESSAGE ),
@@ -224,7 +225,7 @@ class EventNotification_test( object ):
           ] )
 
           # Subsequent calls don't re-raise the warning
-          self.server_state.ValidateParseRequest()
+          self.server_state.HandleFileParseRequest()
 
           present_dialog.assert_has_calls( [
             PresentDialog_Confirm_Call( MESSAGE )
@@ -235,8 +236,8 @@ class EventNotification_test( object ):
 
           # But it does if a subsequent event raises again
           self.server_state.OnFileReadyToParse()
-          assert self.server_state.DiagnosticsForCurrentFileReady()
-          self.server_state.ValidateParseRequest()
+          assert self.server_state.FileParseRequestReady()
+          self.server_state.HandleFileParseRequest()
 
           present_dialog.assert_has_calls( [
             PresentDialog_Confirm_Call( MESSAGE ),
@@ -251,8 +252,8 @@ class EventNotification_test( object ):
         with patch( 'ycm.vimsupport.PresentDialog',
                     return_value = 1 ) as present_dialog:
           self.server_state.OnFileReadyToParse()
-          assert self.server_state.DiagnosticsForCurrentFileReady()
-          self.server_state.ValidateParseRequest()
+          assert self.server_state.FileParseRequestReady()
+          self.server_state.HandleFileParseRequest()
 
           present_dialog.assert_has_calls( [
             PresentDialog_Confirm_Call( MESSAGE ),
@@ -262,7 +263,7 @@ class EventNotification_test( object ):
           ] )
 
           # Subsequent calls don't re-raise the warning
-          self.server_state.ValidateParseRequest()
+          self.server_state.HandleFileParseRequest()
 
           present_dialog.assert_has_calls( [
             PresentDialog_Confirm_Call( MESSAGE )
@@ -273,8 +274,8 @@ class EventNotification_test( object ):
 
           # But it does if a subsequent event raises again
           self.server_state.OnFileReadyToParse()
-          assert self.server_state.DiagnosticsForCurrentFileReady()
-          self.server_state.ValidateParseRequest()
+          assert self.server_state.FileParseRequestReady()
+          self.server_state.HandleFileParseRequest()
 
           present_dialog.assert_has_calls( [
             PresentDialog_Confirm_Call( MESSAGE ),

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -184,10 +184,10 @@ def UnPlaceDummySign( sign_id, buffer_num ):
     vim.command( 'sign unplace {0} buffer={1}'.format( sign_id, buffer_num ) )
 
 
-def ClearYcmSyntaxMatches():
+def ClearYcmSyntaxMatches( prefix = 'Ycm' ):
   matches = VimExpressionToPythonType( 'getmatches()' )
   for match in matches:
-    if match[ 'group' ].startswith( 'Ycm' ):
+    if match[ 'group' ].startswith( prefix ):
       vim.eval( 'matchdelete({0})'.format( match[ 'id' ] ) )
 
 
@@ -215,6 +215,17 @@ def AddDiagnosticSyntaxMatch( line_num,
       "matchadd('{0}', '\%{1}l\%{2}c\_.\\{{-}}\%{3}l\%{4}c')".format(
         group, line_num, column_num, line_end_num, column_end_num ) )
 
+
+def AddSemanticTokenMatch( token, prefix ):
+  kind = token[ 'kind' ]
+  le = token[ 'location_extent' ]
+  line = le[ 'start' ][ 'line_num' ]
+  column = le[ 'start' ][ 'column_num' ]
+  length = ( int( le[ 'end' ][ 'column_num' ] ) -
+             int( le[ 'start' ][ 'column_num' ] ) )
+  return GetIntValue(
+    "matchaddpos('{0}{1}', [[{2}, {3}, {4}]], {5})".format(
+      prefix, kind, line, column, length, 9 ) )
 
 # Clamps the line and column numbers so that they are not past the contents of
 # the buffer. Numbers are 1-based.

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -184,10 +184,10 @@ def UnPlaceDummySign( sign_id, buffer_num ):
     vim.command( 'sign unplace {0} buffer={1}'.format( sign_id, buffer_num ) )
 
 
-def ClearYcmSyntaxMatches( prefix = 'Ycm' ):
+def ClearYcmSyntaxMatches():
   matches = VimExpressionToPythonType( 'getmatches()' )
   for match in matches:
-    if match[ 'group' ].startswith( prefix ):
+    if match[ 'group' ].startswith( 'Ycm' ):
       vim.eval( 'matchdelete({0})'.format( match[ 'id' ] ) )
 
 
@@ -215,17 +215,6 @@ def AddDiagnosticSyntaxMatch( line_num,
       "matchadd('{0}', '\%{1}l\%{2}c\_.\\{{-}}\%{3}l\%{4}c')".format(
         group, line_num, column_num, line_end_num, column_end_num ) )
 
-
-def AddSemanticTokenMatch( token, prefix ):
-  kind = token[ 'kind' ]
-  le = token[ 'location_extent' ]
-  line = le[ 'start' ][ 'line_num' ]
-  column = le[ 'start' ][ 'column_num' ]
-  length = ( int( le[ 'end' ][ 'column_num' ] ) -
-             int( le[ 'start' ][ 'column_num' ] ) )
-  return GetIntValue(
-    "matchaddpos('{0}{1}', [[{2}, {3}, {4}]], {5})".format(
-      prefix, kind, line, column, length, 9 ) )
 
 # Clamps the line and column numbers so that they are not past the contents of
 # the buffer. Numbers are 1-based.

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -25,6 +25,7 @@ import re
 import signal
 import base64
 from subprocess import PIPE
+from requests.exceptions import Timeout
 from ycm import paths, vimsupport
 from ycmd import utils
 from ycmd.request_wrap import RequestWrap
@@ -523,6 +524,22 @@ class YouCompleteMe( object ):
         vimsupport.EchoText( debug_info[ 'message' ] )
     except ServerError as e:
       vimsupport.PostVimMessage( str( e ) )
+
+
+  def GetSemantics( self, bufnr, timeout ):
+    if not self.IsServerAlive():
+      return []
+    try:
+      buffer = vim.buffers[ bufnr ]
+      request_data = {
+        'filepath': vimsupport.GetBufferFilepath( buffer ),
+        'filetypes': vimsupport.FiletypesForBuffer( buffer ),
+      }
+      return BaseRequest.PostDataToHandler( request_data, 'semantics', timeout )
+    except ServerError as e:
+      return []
+    except Timeout as t:
+      return 'Timeout'
 
 
   def DebugInfo( self ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -24,6 +24,7 @@ import json
 import re
 import signal
 import base64
+from inspect import isfunction
 from subprocess import PIPE
 from requests.exceptions import Timeout
 from ycm import paths, vimsupport
@@ -91,7 +92,9 @@ class YouCompleteMe( object ):
     self._diag_interface = DiagnosticInterface( user_options )
     self._omnicomp = OmniCompleter( user_options )
     self._latest_file_parse_request = None
+    self._latest_file_parse_request_bufnr = None
     self._latest_completion_request = None
+    self._latest_diagnostics = None
     self._server_stdout = None
     self._server_stderr = None
     self._server_popen = None
@@ -102,6 +105,11 @@ class YouCompleteMe( object ):
     self._complete_done_hooks = {
       'cs': lambda( self ): self._OnCompleteDone_Csharp()
     }
+    self._tokens_ready_callback = None
+    self._tokens_ready_vim_callback = None
+    self._tokens_ready_python_callback = None
+    self._diagnostic_ui_filetypes = [ 'cpp', 'cs', 'c', 'objc', 'objcpp' ]
+    self._semantic_token_ui_filetypes = [ 'cpp', 'c' ]
 
   def _SetupServer( self ):
     self._available_completers = {}
@@ -263,6 +271,7 @@ class YouCompleteMe( object ):
     self._latest_file_parse_request = EventNotification( 'FileReadyToParse',
                                                           extra_data )
     self._latest_file_parse_request.Start()
+    self._latest_file_parse_request_bufnr = vim.current.buffer.number
 
 
   def OnBufferUnload( self, deleted_buffer_file ):
@@ -461,50 +470,67 @@ class YouCompleteMe( object ):
   def GetWarningCount( self ):
     return self._diag_interface.GetWarningCount()
 
-  def DiagnosticsForCurrentFileReady( self ):
-    return bool( self._latest_file_parse_request and
-                 self._latest_file_parse_request.Done() )
+  def RegisterSemanticTokensReadyVimCallback( self, callback ):
+    self._tokens_ready_vim_callback = callback
+    return True
 
+  def RegisterSemanticTokensReadyPythonCallback( self, callback ):
+    if not isfunction( callback ):
+      return False
+    self._tokens_ready_python_callback = callback
+    return True
 
-  def GetDiagnosticsFromStoredRequest( self, qflist_format = False ):
-    if self.DiagnosticsForCurrentFileReady():
-      diagnostics = self._latest_file_parse_request.Response()
-      # We set the diagnostics request to None because we want to prevent
-      # repeated refreshing of the buffer with the same diags. Setting this to
-      # None makes DiagnosticsForCurrentFileReady return False until the next
-      # request is created.
-      self._latest_file_parse_request = None
-      if qflist_format:
-        return vimsupport.ConvertDiagnosticsToQfList( diagnostics )
-      else:
-        return diagnostics
+  def NotifySemanticTokensReady( self, bufnr ):
+    if self._tokens_ready_python_callback:
+      self._tokens_ready_python_callback( bufnr )
+    elif self._tokens_ready_vim_callback:
+      #vim.command( 'try | call {0}({1}) | catch | endtry'.format(
+      vim.command( 'call {0}({1})'.format(
+        self._tokens_ready_vim_callback, bufnr ) )
+
+  def DiagnosticUiSupportedForCurrentFiletype( self ):
+    return any( [ x in self._diagnostic_ui_filetypes
+                  for x in vimsupport.CurrentFiletypes() ] )
+
+  def ShouldDisplayDiagnostics( self ):
+    return bool( self._user_options[ 'show_diagnostics_ui' ] and
+                 self.DiagnosticUiSupportedForCurrentFiletype() )
+
+  def GetLatestDiagnosticsQFList( self ):
+    if self._latest_diagnostics:
+      return vimsupport.ConvertDiagnosticsToQfList( self._latest_diagnostics )
     return []
 
 
   def UpdateDiagnosticInterface( self ):
-    if ( self.DiagnosticsForCurrentFileReady() and
-         self.NativeFiletypeCompletionUsable() ):
-      self._diag_interface.UpdateWithNewDiagnostics(
-        self.GetDiagnosticsFromStoredRequest() )
+    self._diag_interface.UpdateWithNewDiagnostics( self._latest_diagnostics )
 
 
-  def ValidateParseRequest( self ):
-    if ( self.DiagnosticsForCurrentFileReady() and
-         self.NativeFiletypeCompletionUsable() ):
+  def FileParseRequestReady( self ):
+    return bool( self._latest_file_parse_request and
+                 self._latest_file_parse_request.Done() )
 
-      # YCM client has a hard-coded list of filetypes which are known to support
-      # diagnostics. These are found in autoload/youcompleteme.vim in
-      # s:diagnostic_ui_filetypes.
-      #
-      # For filetypes which don't support diagnostics, we just want to check the
-      # _latest_file_parse_request for any exception or UnknownExtraConf
-      # response, to allow the server to raise configuration warnings, etc.
-      # to the user. We ignore any other supplied data.
-      self._latest_file_parse_request.Response()
 
-      # We set the diagnostics request to None because we want to prevent
+  def HandleFileParseRequest( self, block = False ):
+    if ( self.NativeFiletypeCompletionUsable() and
+         ( block or self.FileParseRequestReady() ) ):
+
+      if self.ShouldDisplayDiagnostics():
+        self._latest_diagnostics = self._latest_file_parse_request.Response()
+        self.UpdateDiagnosticInterface()
+      else:
+        # YCM client has a hard-coded list of filetypes which are known
+        # to support diagnostics. self.DiagnosticUiSupportedForCurrentFiletype()
+        #
+        # For filetypes which don't support diagnostics, we just want to check
+        # the _latest_file_parse_request for any exception or UnknownExtraConf
+        # response, to allow the server to raise configuration warnings, etc.
+        # to the user. We ignore any other supplied data.
+        self._latest_file_parse_request.Response()
+
+      # We set the file parse request to None because we want to prevent
       # repeated issuing of the same warnings/errors/prompts. Setting this to
-      # None makes DiagnosticsForCurrentFileReady return False until the next
+      # None makes FileParseRequestReady return False until the next
       # request is created.
       #
       # Note: it is the server's responsibility to determine the frequency of
@@ -512,6 +538,9 @@ class YouCompleteMe( object ):
       # it our responsibility to ensure that we only apply the
       # warning/error/prompt received once (for each event).
       self._latest_file_parse_request = None
+
+      self.NotifySemanticTokensReady( self._latest_file_parse_request_bufnr )
+      self._latest_file_parse_request_bufnr = None
 
 
   def ShowDetailedDiagnostic( self ):
@@ -526,7 +555,8 @@ class YouCompleteMe( object ):
       vimsupport.PostVimMessage( str( e ) )
 
 
-  def GetSemantics( self, bufnr, timeout ):
+  def GetSemanticTokens( self, bufnr, start_line, start_column,
+                         end_line, end_column, timeout = 0.01 ):
     if not self.IsServerAlive():
       return []
     try:
@@ -534,11 +564,16 @@ class YouCompleteMe( object ):
       request_data = {
         'filepath': vimsupport.GetBufferFilepath( buffer ),
         'filetypes': vimsupport.FiletypesForBuffer( buffer ),
+        'start_line': start_line,
+        'start_column': start_column,
+        'end_line': end_line,
+        'end_column': end_column,
       }
-      return BaseRequest.PostDataToHandler( request_data, 'semantics', timeout )
-    except ServerError as e:
+      return BaseRequest.PostDataToHandler( request_data, 'semantic_tokens',
+                                            timeout )
+    except ServerError:
       return []
-    except Timeout as t:
+    except Timeout:
       return 'Timeout'
 
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -91,6 +91,9 @@ class YouCompleteMe( object ):
     self._omnicomp = OmniCompleter( user_options )
     self._latest_file_parse_request = None
     self._latest_completion_request = None
+    self._file_parse_result = None
+    self._new_diagnostics = None
+    self._new_semantics = None
     self._server_stdout = None
     self._server_stderr = None
     self._server_popen = None
@@ -460,34 +463,52 @@ class YouCompleteMe( object ):
   def GetWarningCount( self ):
     return self._diag_interface.GetWarningCount()
 
-  def DiagnosticsForCurrentFileReady( self ):
+
+  def FileParseResultReady( self ):
     return bool( self._latest_file_parse_request and
                  self._latest_file_parse_request.Done() )
 
 
+  def HandleFileParseResult( self ):
+    if ( self.FileParseResultReady() and
+         self.NativeFiletypeCompletionUsable() ):
+      parse_result = self._latest_file_parse_request.Response()
+      self._latest_file_parse_request = None
+      if isinstance(parse_result, dict):
+        self._new_diagnostics = parse_result[ 'diagnostics' ]
+        self._new_semantics = parse_result[ 'semantics' ]
+      elif isinstance(parse_result, list):
+        self._new_diagnostics = parse_result
+      return True
+
+    return False
+
+
   def GetDiagnosticsFromStoredRequest( self, qflist_format = False ):
-    if self.DiagnosticsForCurrentFileReady():
-      diagnostics = self._latest_file_parse_request.Response()
-      # We set the diagnostics request to None because we want to prevent
+    self.HandleFileParseResult()
+    if self._new_diagnostics is not None:
+      diagnostics = self._new_diagnostics
+      # We set the diagnostics to None because we want to prevent
       # repeated refreshing of the buffer with the same diags. Setting this to
       # None makes DiagnosticsForCurrentFileReady return False until the next
       # request is created.
-      self._latest_file_parse_request = None
+      self._new_diagnostics = None
       if qflist_format:
         return vimsupport.ConvertDiagnosticsToQfList( diagnostics )
       else:
         return diagnostics
-    return []
+    return [] if qflist_format else None
 
 
   def UpdateDiagnosticInterface( self ):
-    if ( self.DiagnosticsForCurrentFileReady() and
-         self.NativeFiletypeCompletionUsable() ):
-      self._diag_interface.UpdateWithNewDiagnostics(
-        self.GetDiagnosticsFromStoredRequest() )
+    diagnostics = self.GetDiagnosticsFromStoredRequest()
+    if diagnostics is not None:
+      self._diag_interface.UpdateWithNewDiagnostics( diagnostics )
 
 
   def ValidateParseRequest( self ):
+    self.HandleFileParseResult()
+    return
     if ( self.DiagnosticsForCurrentFileReady() and
          self.NativeFiletypeCompletionUsable() ):
 
@@ -523,6 +544,25 @@ class YouCompleteMe( object ):
         vimsupport.EchoText( debug_info[ 'message' ] )
     except ServerError as e:
       vimsupport.PostVimMessage( str( e ) )
+
+
+  def GetTokensFromStoredRequest( self ):
+    self.HandleFileParseResult()
+    if self._new_semantics is not None:
+      semantics = self._new_semantics
+      self._new_semantics = None
+      return semantics
+    return None
+
+
+  def UpdateSemanticHighlights( self ):
+    tokens = self.GetTokensFromStoredRequest()
+    if tokens:
+      filetype = vimsupport.CurrentFiletypes()[ 0 ]
+      prefix = 'Token_' + filetype + '_'
+      vimsupport.ClearYcmSyntaxMatches( prefix )
+      for token in tokens:
+        vimsupport.AddSemanticTokenMatch( token, prefix )
 
 
   def DebugInfo( self ):

--- a/run_tests.py
+++ b/run_tests.py
@@ -61,7 +61,7 @@ def NoseTests( extra_args ):
 def Main():
   ( parsed_args, extra_args ) = ParseArguments()
   RunFlake8()
-  BuildYcmdLibs( parsed_args )
+  #BuildYcmdLibs( parsed_args )
   NoseTests( extra_args )
 
 if __name__ == "__main__":


### PR DESCRIPTION
For testing purposes only.

Continuation of pull request Valloric/ycmd#291

For now, each time when new tokens are received I'm cleaning old matches and adding new ones. This is a quick/dirty solution.
Vim doesn't have effective mechanism for semantic highlighting. The matchaddpos() function I'm using has several "issues":
1. Added matches are staying at their absolute positions, and when user types, it messes up all the highlighting. One should wait for reparse to finish to normalize tokens. This may be frustrating...
2. Vim stores matches in a linked list, so adding/managing all the tokens at once may slow things down in the big files with lots of tokens. (Though I haven't tested this scenario yet)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1873)
<!-- Reviewable:end -->
