### PR TITLE
[READY] Update notifications when ycmd server crashed

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -69,17 +69,13 @@ PatchNoProxy()
 signal.signal( signal.SIGINT, signal.SIG_IGN )
 
 HMAC_SECRET_LENGTH = 16
-NUM_YCMD_STDERR_LINES_ON_CRASH = 30
+SERVER_CRASH_MESSAGE_STDERR_FILE = (
+  'The ycmd server SHUT DOWN (restart with :YcmRestartServer). '
+  'Run :YcmToggleLogs stderr to check the logs.' )
 SERVER_CRASH_MESSAGE_STDERR_FILE_DELETED = (
   'The ycmd server SHUT DOWN (restart with :YcmRestartServer). '
   'Logfile was deleted; set g:ycm_server_keep_logfiles to see errors '
   'in the future.' )
-SERVER_CRASH_MESSAGE_STDERR_FILE = (
-  'The ycmd server SHUT DOWN (restart with :YcmRestartServer). ' +
-  'Stderr (last {0} lines):\n\n'.format( NUM_YCMD_STDERR_LINES_ON_CRASH ) )
-SERVER_CRASH_MESSAGE_SAME_STDERR = (
-  'The ycmd server SHUT DOWN (restart with :YcmRestartServer). '
-  ' check console output for logs!' )
 SERVER_IDLE_SUICIDE_SECONDS = 10800  # 3 hours
 
 
@@ -151,17 +147,11 @@ class YouCompleteMe( object ):
     if self._user_notified_about_crash or self.IsServerAlive():
       return
     self._user_notified_about_crash = True
-    if self._server_stderr:
-      try:
-        with open( self._server_stderr, 'r' ) as server_stderr_file:
-          error_output = ''.join( server_stderr_file.readlines()[
-              : - NUM_YCMD_STDERR_LINES_ON_CRASH ] )
-          vimsupport.PostMultiLineNotice( SERVER_CRASH_MESSAGE_STDERR_FILE +
-                                          error_output )
-      except IOError:
-        vimsupport.PostVimMessage( SERVER_CRASH_MESSAGE_STDERR_FILE_DELETED )
-    else:
-        vimsupport.PostVimMessage( SERVER_CRASH_MESSAGE_SAME_STDERR )
+    try:
+      vimsupport.CheckFilename( self._server_stderr )
+      vimsupport.PostVimMessage( SERVER_CRASH_MESSAGE_STDERR_FILE )
+    except RuntimeError:
+      vimsupport.PostVimMessage( SERVER_CRASH_MESSAGE_STDERR_FILE_DELETED )
 
 
   def ServerPid( self ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -70,12 +70,12 @@ signal.signal( signal.SIGINT, signal.SIG_IGN )
 
 HMAC_SECRET_LENGTH = 16
 SERVER_CRASH_MESSAGE_STDERR_FILE = (
-  'The ycmd server SHUT DOWN (restart with :YcmRestartServer). '
-  'Run :YcmToggleLogs stderr to check the logs.' )
+  "The ycmd server SHUT DOWN (restart with ':YcmRestartServer'). "
+  "Run ':YcmToggleLogs stderr' to check the logs." )
 SERVER_CRASH_MESSAGE_STDERR_FILE_DELETED = (
-  'The ycmd server SHUT DOWN (restart with :YcmRestartServer). '
-  'Logfile was deleted; set g:ycm_server_keep_logfiles to see errors '
-  'in the future.' )
+  "The ycmd server SHUT DOWN (restart with ':YcmRestartServer'). "
+  "Logfile was deleted; set 'g:ycm_server_keep_logfiles' to see errors "
+  "in the future." )
 SERVER_IDLE_SUICIDE_SECONDS = 10800  # 3 hours
 
 


### PR DESCRIPTION
Instead of printing the last 30 lines of the `stderr` logfile if the server crashed, we tell the user to run the `:YcmToggleLogs stderr` command to check the logs.

Remove `SERVER_CRASH_MESSAGE_SAME_STDERR` message because we are always using the `stderr` logfile since PR #1753. Also, console ouput cannot be used to see the logs.

Simplify `_NotifyUserIfServerCrashed` method by using `CheckFilename` function from `vimsupport` module.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1875)
<!-- Reviewable:end -->
