### PR TITLE
[READY] Update CMake generators for MSVC in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,9 +537,9 @@ process.
     where `<generator>` is `Unix Makefiles` on Unix systems and one of the
     following Visual Studio generators on Windows:
 
-    - `Visual Studio 11 2012 Win64`
-    - `Visual Studio 12 2013 Win64`
-    - `Visual Studio 14 2015 Win64`
+    - `Visual Studio 11 Win64`
+    - `Visual Studio 12 Win64`
+    - `Visual Studio 14 Win64`
 
     Remove the `Win64` part in these generators if your Vim architecture is
     32-bit.

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -732,9 +732,9 @@ process.
    where '<generator>' is 'Unix Makefiles' on Unix systems and one of the
    following Visual Studio generators on Windows:
 
-   - 'Visual Studio 11 2012 Win64'
-   - 'Visual Studio 12 2013 Win64'
-   - 'Visual Studio 14 2015 Win64'
+   - 'Visual Studio 11 Win64'
+   - 'Visual Studio 12 Win64'
+   - 'Visual Studio 14 Win64'
 
    Remove the 'Win64' part in these generators if your Vim architecture is
    32-bit.


### PR DESCRIPTION
Following PR Valloric/ycmd#285, older versions of CMake (< 3.0) don't support the MSVC generator names with the year component but newer versions accept both formats. So, replace the generator names in README.md by the old ones.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1893)
<!-- Reviewable:end -->
