### PR TITLE
Clear available completers cache on restart

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -171,6 +171,7 @@ class YouCompleteMe( object ):
 
 
   def _ServerCleanup( self ):
+    self._available_completers = {}
     if self.IsServerAlive():
       self._server_popen.terminate()
 


### PR DESCRIPTION
Clear the cache of which completers are available on ycmd restart.
Without this, you must restart vim, or fiddle with ycm internals, to get
it to recheck completers, which impedes completer development.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1897)
<!-- Reviewable:end -->
