### PR TITLE
Don't cache invalid completer check results

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -229,7 +229,6 @@ class YouCompleteMe( object ):
     if exists_completer is None:
       return False
 
-    exists_completer = bool ( exists_completer )
     self._available_completers[ filetype ] = exists_completer
     return exists_completer
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -222,8 +222,14 @@ class YouCompleteMe( object ):
     except KeyError:
       pass
 
-    exists_completer = ( self.IsServerAlive() and
-                         bool( SendCompleterAvailableRequest( filetype ) ) )
+    if not self.IsServerAlive():
+      return False
+
+    exists_completer = SendCompleterAvailableRequest( filetype )
+    if exists_completer is None:
+      return False
+
+    exists_completer = bool ( exists_completer )
     self._available_completers[ filetype ] = exists_completer
     return exists_completer
 


### PR DESCRIPTION
[Lets try this again](https://github.com/Valloric/YouCompleteMe/pull/1897#issuecomment-170978003)

If the check for available completers isn't run because the server isn't
alive, or the check request erred or times out, don't cache the result. Only
cache valid returns.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1898)
<!-- Reviewable:end -->
