### PR TITLE
[READY] Bumps required Vim to 7.4.143 and adopts TextChangedI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2680,7 +2680,7 @@ fixed, Vim trunk landed the `pyeval()` function which improved YCM performance
 even more since less time was spent serializing and deserializing data between
 Vim and the embedded Python interpreter. A few critical bugfixes for `pyeval()`
 landed in Vim 7.3.584 (and a few commits before that), and given the current
-availability of Vim 7.4.143, which packs improved events for text change
+availability of Vim 7.4.143, which features improved events for text change
 detection, it has been chosen.
 
 ### I get annoying messages in Vim's status area when I type

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ that are conservatively turned off by default that you may want to turn on.
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.3.598 with python2 or python3 support. Ubuntu 14.04 and
+Make sure you have Vim 7.4 with python2 or python3 support. Ubuntu 14.04 and
 later have a Vim that's recent enough. You can see the version of Vim installed
 by running `vim --version`. If the version is too old, you may need to [compile
 Vim from source][vim-build] (don't worry, it's easy).
@@ -272,7 +272,7 @@ that are conservatively turned off by default that you may want to turn on.
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.3.598 with Python 2 or Python 3 support. Fedora 21 and
+Make sure you have Vim 7.4 with Python 2 or Python 3 support. Fedora 21 and
 later have a Vim that's recent enough. You can see the version of Vim installed
 by running `vim --version`. If the version is too old, you may need to [compile
 Vim from source][vim-build] (don't worry, it's easy).
@@ -337,7 +337,7 @@ provided on a best-effort basis and may not work for you.
 **Important:** we assume that you are using the `cmd.exe` command prompt and
 that you know how to add an executable to the PATH environment variable.
 
-Make sure you have at least Vim 7.3.598 with Python 2 or Python 3 support. You
+Make sure you have at least Vim 7.4 with Python 2 or Python 3 support. You
 can check the version and which Python is supported by typing `:version` inside
 Vim. Look at the features included: `+python/dyn` for Python 2 and
 `+python3/dyn` for Python 3. Take note of the Vim architecture, i.e. 32 or
@@ -414,7 +414,7 @@ Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you. OpenBSD / FreeBSD are
 not officially supported platforms by YCM.
 
-Make sure you have Vim 7.3.598 with Python 2 or Python 3 support.
+Make sure you have Vim 7.4 with Python 2 or Python 3 support.
 
 OpenBSD 5.5 and later have a Vim that's recent enough. You can see the version of
 Vim installed by running `vim --version`.
@@ -491,19 +491,17 @@ process.
 
 **Please follow the instructions carefully. Read EVERY WORD.**
 
-1.  **Ensure that your version of Vim is _at least_ 7.3.598 _and_ that it has
+1.  **Ensure that your version of Vim is _at least_ 7.4 _and_ that it has
     support for Python 2 or Python 3 scripting**.
 
     Inside Vim, type `:version`. Look at the first two to three lines of output;
     it should say `Vi IMproved X.Y`, where X.Y is the major version of vim. If
-    your version is greater than 7.3, then you're all set. If your version is
-    7.3 then look below that where it says, `Included patches: 1-Z`, where Z
-    will be some number. That number needs to be 598 or higher.
+    your version is greater than or equal 7.4, then you're all set.
 
     If your version of Vim is not recent enough, you may need to [compile Vim
     from source][vim-build] (don't worry, it's easy).
 
-    After you have made sure that you have Vim 7.3.598+, type the following in
+    After you have made sure that you have Vim 7.4+, type the following in
     Vim: `:echo has('python') || has('python3')`. The output should be 1. If
     it's 0, then get a version of Vim with Python support.
 
@@ -2679,7 +2677,9 @@ Those needed to be fixed upstream (and were). A few months after those bugs were
 fixed, Vim trunk landed the `pyeval()` function which improved YCM performance
 even more since less time was spent serializing and deserializing data between
 Vim and the embedded Python interpreter. A few critical bugfixes for `pyeval()`
-landed in Vim 7.3.584 (and a few commits before that).
+landed in Vim 7.3.584 (and a few commits before that), and given the current
+availability of Vim 7.4, which packs improved events for text change detection,
+it has been chosen.
 
 ### I get annoying messages in Vim's status area when I type
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ that are conservatively turned off by default that you may want to turn on.
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.4 with python2 or python3 support. Ubuntu 14.04 and
+Make sure you have Vim 7.4.143 with python2 or python3 support. Ubuntu 14.04 and
 later have a Vim that's recent enough. You can see the version of Vim installed
 by running `vim --version`. If the version is too old, you may need to [compile
 Vim from source][vim-build] (don't worry, it's easy).
@@ -272,7 +272,7 @@ that are conservatively turned off by default that you may want to turn on.
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.4 with Python 2 or Python 3 support. Fedora 21 and
+Make sure you have Vim 7.4.143 with Python 2 or Python 3 support. Fedora 21 and
 later have a Vim that's recent enough. You can see the version of Vim installed
 by running `vim --version`. If the version is too old, you may need to [compile
 Vim from source][vim-build] (don't worry, it's easy).
@@ -337,7 +337,7 @@ provided on a best-effort basis and may not work for you.
 **Important:** we assume that you are using the `cmd.exe` command prompt and
 that you know how to add an executable to the PATH environment variable.
 
-Make sure you have at least Vim 7.4 with Python 2 or Python 3 support. You
+Make sure you have at least Vim 7.4.143 with Python 2 or Python 3 support. You
 can check the version and which Python is supported by typing `:version` inside
 Vim. Look at the features included: `+python/dyn` for Python 2 and
 `+python3/dyn` for Python 3. Take note of the Vim architecture, i.e. 32 or
@@ -414,7 +414,7 @@ Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you. OpenBSD / FreeBSD are
 not officially supported platforms by YCM.
 
-Make sure you have Vim 7.4 with Python 2 or Python 3 support.
+Make sure you have Vim 7.4.143 with Python 2 or Python 3 support.
 
 OpenBSD 5.5 and later have a Vim that's recent enough. You can see the version of
 Vim installed by running `vim --version`.
@@ -491,17 +491,19 @@ process.
 
 **Please follow the instructions carefully. Read EVERY WORD.**
 
-1.  **Ensure that your version of Vim is _at least_ 7.4 _and_ that it has
+1.  **Ensure that your version of Vim is _at least_ 7.4.143 _and_ that it has
     support for Python 2 or Python 3 scripting**.
 
     Inside Vim, type `:version`. Look at the first two to three lines of output;
     it should say `Vi IMproved X.Y`, where X.Y is the major version of vim. If
-    your version is greater than or equal 7.4, then you're all set.
+    your version is greater than 7.4, then you're all set. If your version is
+    7.4 then look below that where it says, `Included patches: 1-Z`, where Z
+    will be some number. That number needs to be 143 or higher.
 
     If your version of Vim is not recent enough, you may need to [compile Vim
     from source][vim-build] (don't worry, it's easy).
 
-    After you have made sure that you have Vim 7.4+, type the following in
+    After you have made sure that you have Vim 7.4.143+, type the following in
     Vim: `:echo has('python') || has('python3')`. The output should be 1. If
     it's 0, then get a version of Vim with Python support.
 
@@ -2678,8 +2680,8 @@ fixed, Vim trunk landed the `pyeval()` function which improved YCM performance
 even more since less time was spent serializing and deserializing data between
 Vim and the embedded Python interpreter. A few critical bugfixes for `pyeval()`
 landed in Vim 7.3.584 (and a few commits before that), and given the current
-availability of Vim 7.4, which packs improved events for text change detection,
-it has been chosen.
+availability of Vim 7.4.143, which packs improved events for text change
+detection, it has been chosen.
 
 ### I get annoying messages in Vim's status area when I type
 

--- a/README.md
+++ b/README.md
@@ -2507,11 +2507,6 @@ fixes that should make YCM work with such a configuration. Also rebuild Macvim
 then. If you still get problems with this, see [issue #18][issue18] for
 suggestions.
 
-### Vim segfaults when I use the semantic completer in Ruby files
-
-This was caused by a Vim bug. Update your version of Vim (Vim 7.3.874 is known
-to work, earlier versions may also fix this issue).
-
 ### I get `LONG_BIT definition appears wrong for platform` when compiling
 
 Look at the output of your CMake call. There should be a line in it like the

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -26,7 +26,6 @@ let s:defer_omnifunc = 1
 
 let s:old_cursor_position = []
 let s:cursor_moved = 0
-let s:moved_vertically_in_insert_mode = 0
 let s:previous_allowed_buffer_number = 0
 
 
@@ -595,10 +594,6 @@ endfunction
 function! s:UpdateCursorMoved()
   let current_position = getpos('.')
   let s:cursor_moved = current_position != s:old_cursor_position
-
-  let s:moved_vertically_in_insert_mode = s:old_cursor_position != [] &&
-        \ current_position[ 1 ] != s:old_cursor_position[ 1 ]
-
   let s:old_cursor_position = current_position
 endfunction
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -136,33 +136,32 @@ Contents ~
   10. I get "'GLIBC_2.XX' not found (required by libclang.so)" when starting Vim |GLIBC_2.XX-not-found()|
   11. I'm trying to use a Homebrew Vim with YCM and I'm getting segfaults |youcompleteme-im-trying-to-use-homebrew-vim-with-ycm-im-getting-segfaults|
   12. I have a Homebrew Python and/or MacVim; can't compile/SIGABRT when starting |youcompleteme-i-have-homebrew-python-and-or-macvim-cant-compile-sigabrt-when-starting|
-  13. Vim segfaults when I use the semantic completer in Ruby files |youcompleteme-vim-segfaults-when-i-use-semantic-completer-in-ruby-files|
-  14. I get 'LONG_BIT definition appears wrong for platform' when compiling |LONG_BIT-definition-appears-wrong-for-platform|
-  15. I get 'libpython2.7.a [...] relocation R_X86_64_32' when compiling |libpython2.7.a-...-relocation-R_X86_64_32|
-  16. I get 'Vim: Caught deadly signal SEGV' on Vim startup |Vim:-Caught-deadly-signal-SEGV|
-  17. I get 'Fatal Python error: PyThreadState_Get: no current thread' on startup |Fatal-Python-error:-PyThreadState_Get:-no-current-thread|
-  18. |install.py| says python must be compiled with '--enable-framework'. Wat?
-  19. YCM does not read identifiers from my tags files |youcompleteme-ycm-does-not-read-identifiers-from-my-tags-files|
-  20. 'CTRL-U' in insert mode does not work                        |CTRL-sub-U|
-  21. YCM conflicts with UltiSnips TAB key usage |youcompleteme-ycm-conflicts-with-ultisnips-tab-key-usage|
-  22. Snippets added with |:UltiSnipsAddFiletypes| do not appear in the popup menu
-  23. Why isn't YCM just written in plain VimScript, FFS? |youcompleteme-why-isnt-ycm-just-written-in-plain-vimscript-ffs|
-  24. Why does YCM demand such a recent version of Vim? |youcompleteme-why-does-ycm-demand-such-recent-version-of-vim|
-  25. I get annoying messages in Vim's status area when I type |youcompleteme-i-get-annoying-messages-in-vims-status-area-when-i-type|
-  26. Nasty bugs happen if I have the 'vim-autoclose' plugin installed |vim-sub-autoclose|
-  27. Is there some sort of YCM mailing list? I have questions |youcompleteme-is-there-sort-of-ycm-mailing-list-i-have-questions|
-  28. I get an internal compiler error when installing |youcompleteme-i-get-an-internal-compiler-error-when-installing|
-  29. I get weird errors when I press 'Ctrl-C' in Vim              |Ctrl-sub-C|
-  30. Why did YCM stop using Syntastic for diagnostics display? |youcompleteme-why-did-ycm-stop-using-syntastic-for-diagnostics-display|
-  31. Completion doesn't work with the C++ standard library headers |youcompleteme-completion-doesnt-work-with-c-standard-library-headers|
-  32. When I open a JavaScript file, I get an annoying warning about '.tern-project'
+  13. I get 'LONG_BIT definition appears wrong for platform' when compiling |LONG_BIT-definition-appears-wrong-for-platform|
+  14. I get 'libpython2.7.a [...] relocation R_X86_64_32' when compiling |libpython2.7.a-...-relocation-R_X86_64_32|
+  15. I get 'Vim: Caught deadly signal SEGV' on Vim startup |Vim:-Caught-deadly-signal-SEGV|
+  16. I get 'Fatal Python error: PyThreadState_Get: no current thread' on startup |Fatal-Python-error:-PyThreadState_Get:-no-current-thread|
+  17. |install.py| says python must be compiled with '--enable-framework'. Wat?
+  18. YCM does not read identifiers from my tags files |youcompleteme-ycm-does-not-read-identifiers-from-my-tags-files|
+  19. 'CTRL-U' in insert mode does not work                        |CTRL-sub-U|
+  20. YCM conflicts with UltiSnips TAB key usage |youcompleteme-ycm-conflicts-with-ultisnips-tab-key-usage|
+  21. Snippets added with |:UltiSnipsAddFiletypes| do not appear in the popup menu
+  22. Why isn't YCM just written in plain VimScript, FFS? |youcompleteme-why-isnt-ycm-just-written-in-plain-vimscript-ffs|
+  23. Why does YCM demand such a recent version of Vim? |youcompleteme-why-does-ycm-demand-such-recent-version-of-vim|
+  24. I get annoying messages in Vim's status area when I type |youcompleteme-i-get-annoying-messages-in-vims-status-area-when-i-type|
+  25. Nasty bugs happen if I have the 'vim-autoclose' plugin installed |vim-sub-autoclose|
+  26. Is there some sort of YCM mailing list? I have questions |youcompleteme-is-there-sort-of-ycm-mailing-list-i-have-questions|
+  27. I get an internal compiler error when installing |youcompleteme-i-get-an-internal-compiler-error-when-installing|
+  28. I get weird errors when I press 'Ctrl-C' in Vim              |Ctrl-sub-C|
+  29. Why did YCM stop using Syntastic for diagnostics display? |youcompleteme-why-did-ycm-stop-using-syntastic-for-diagnostics-display|
+  30. Completion doesn't work with the C++ standard library headers |youcompleteme-completion-doesnt-work-with-c-standard-library-headers|
+  31. When I open a JavaScript file, I get an annoying warning about '.tern-project'
 file |.tern-sub-project|
-  33. When I start vim I get a runtime error saying 'R6034 An application has made an
+  32. When I start vim I get a runtime error saying 'R6034 An application has made an
 attempt to load the C runtime library incorrectly.' |R6034-An-application-has-made-an-attempt-to-load-the-C-runtime-library-incorrectly.|
-  34. I hear that YCM only supports Python 2, is that true? |youcompleteme-i-hear-that-ycm-only-supports-python-2-is-that-true|
-  35. On Windows I get "E887: Sorry, this command is disabled, the Python's site
+  33. I hear that YCM only supports Python 2, is that true? |youcompleteme-i-hear-that-ycm-only-supports-python-2-is-that-true|
+  34. On Windows I get "E887: Sorry, this command is disabled, the Python's site
 module could not be loaded" |E887:-Sorry-this-command-is-disabled-the-Python-s-site-module-could-not-be-loaded|
-  36. I can't complete python packages in a virtual environment. |youcompleteme-i-cant-complete-python-packages-in-virtual-environment.|
+  35. I can't complete python packages in a virtual environment. |youcompleteme-i-cant-complete-python-packages-in-virtual-environment.|
  12. Contributor Code of Conduct    |youcompleteme-contributor-code-of-conduct|
  13. Contact                                            |youcompleteme-contact|
  14. License                                            |youcompleteme-license|
@@ -2760,13 +2759,6 @@ I have a Homebrew Python and/or MacVim; can't compile/SIGABRT when starting ~
 You should probably run 'brew rm python; brew install python' to get the latest
 fixes that should make YCM work with such a configuration. Also rebuild Macvim
 then. If you still get problems with this, see issue #18 [54] for suggestions.
-
--------------------------------------------------------------------------------
-      *youcompleteme-vim-segfaults-when-i-use-semantic-completer-in-ruby-files*
-Vim segfaults when I use the semantic completer in Ruby files ~
-
-This was caused by a Vim bug. Update your version of Vim (Vim 7.3.874 is known
-to work, earlier versions may also fix this issue).
 
 -------------------------------------------------------------------------------
                                *LONG_BIT-definition-appears-wrong-for-platform*

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -405,7 +405,7 @@ Ubuntu Linux x64 ~
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.4 with python2 or python3 support. Ubuntu 14.04
+Make sure you have Vim 7.4.143 with python2 or python3 support. Ubuntu 14.04
 and later have a Vim that's recent enough. You can see the version of Vim
 installed by running 'vim --version'. If the version is too old, you may need
 to compile Vim from source [26] (don't worry, it's easy).
@@ -473,7 +473,7 @@ Fedora Linux x64 ~
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.4 with Python 2 or Python 3 support. Fedora 21 and
+Make sure you have Vim 7.4.143 with Python 2 or Python 3 support. Fedora 21 and
 later have a Vim that's recent enough. You can see the version of Vim installed
 by running 'vim --version'. If the version is too old, you may need to compile
 Vim from source [26] (don't worry, it's easy).
@@ -544,7 +544,7 @@ provided on a best-effort basis and may not work for you.
 **Important:** we assume that you are using the 'cmd.exe' command prompt and
 that you know how to add an executable to the PATH environment variable.
 
-Make sure you have at least Vim 7.4 with Python 2 or Python 3 support. You
+Make sure you have at least Vim 7.4.143 with Python 2 or Python 3 support. You
 can check the version and which Python is supported by typing ':version' inside
 Vim. Look at the features included: '+python/dyn' for Python 2 and
 '+python3/dyn' for Python 3. Take note of the Vim architecture, i.e. 32 or
@@ -627,7 +627,7 @@ Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you. OpenBSD / FreeBSD are
 not officially supported platforms by YCM.
 
-Make sure you have Vim 7.4 with Python 2 or Python 3 support.
+Make sure you have Vim 7.4.143 with Python 2 or Python 3 support.
 
 OpenBSD 5.5 and later have a Vim that's recent enough. You can see the version
 of Vim installed by running 'vim --version'.
@@ -708,17 +708,19 @@ will notify you to recompile it. You should then rerun the install process.
 
 **Please follow the instructions carefully. Read EVERY WORD.**
 
-1. **Ensure that your version of Vim is _at least_ 7.4 _and_ that it has
+1. **Ensure that your version of Vim is _at least_ 7.4.143 _and_ that it has
    support for Python 2 or Python 3 scripting**.
 
    Inside Vim, type ':version'. Look at the first two to three lines of
    output; it should say 'Vi IMproved X.Y', where X.Y is the major version
-   of vim. If your version is greater than 7.4, then you're all set.
+   of vim. If your version is greater than 7.4, then you're all set. If your
+   version is 7.4 then look below that where it says, 'Included patches:
+   1-Z', where Z will be some number. That number needs to be 143 or higher.
 
    If your version of Vim is not recent enough, you may need to compile Vim
    from source [26] (don't worry, it's easy).
 
-   After you have made sure that you have Vim 7.4+, type the following
+   After you have made sure that you have Vim 7.4.143+, type the following
    in Vim: ":echo has('python') || has('python3')". The output should be 1.
    If it's 0, then get a version of Vim with Python support.
 
@@ -2938,7 +2940,7 @@ were fixed, Vim trunk landed the 'pyeval()' function which improved YCM
 performance even more since less time was spent serializing and deserializing
 data between Vim and the embedded Python interpreter. A few critical bugfixes
 for 'pyeval()' landed in Vim 7.3.584 (and a few commits before that), and given
-the current availability of Vim 7.4, which packs improved events for text
+the current availability of Vim 7.4.143, which packs improved events for text
 change detection, it has been chosen.
 
 -------------------------------------------------------------------------------

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2940,8 +2940,8 @@ were fixed, Vim trunk landed the 'pyeval()' function which improved YCM
 performance even more since less time was spent serializing and deserializing
 data between Vim and the embedded Python interpreter. A few critical bugfixes
 for 'pyeval()' landed in Vim 7.3.584 (and a few commits before that), and given
-the current availability of Vim 7.4.143, which packs improved events for text
-change detection, it has been chosen.
+the current availability of Vim 7.4.143, which features improved events for
+text change detection, it has been chosen.
 
 -------------------------------------------------------------------------------
         *youcompleteme-i-get-annoying-messages-in-vims-status-area-when-i-type*

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -405,7 +405,7 @@ Ubuntu Linux x64 ~
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.3.598 with python2 or python3 support. Ubuntu 14.04
+Make sure you have Vim 7.4 with python2 or python3 support. Ubuntu 14.04
 and later have a Vim that's recent enough. You can see the version of Vim
 installed by running 'vim --version'. If the version is too old, you may need
 to compile Vim from source [26] (don't worry, it's easy).
@@ -473,7 +473,7 @@ Fedora Linux x64 ~
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Make sure you have Vim 7.3.598 with Python 2 or Python 3 support. Fedora 21 and
+Make sure you have Vim 7.4 with Python 2 or Python 3 support. Fedora 21 and
 later have a Vim that's recent enough. You can see the version of Vim installed
 by running 'vim --version'. If the version is too old, you may need to compile
 Vim from source [26] (don't worry, it's easy).
@@ -544,7 +544,7 @@ provided on a best-effort basis and may not work for you.
 **Important:** we assume that you are using the 'cmd.exe' command prompt and
 that you know how to add an executable to the PATH environment variable.
 
-Make sure you have at least Vim 7.3.598 with Python 2 or Python 3 support. You
+Make sure you have at least Vim 7.4 with Python 2 or Python 3 support. You
 can check the version and which Python is supported by typing ':version' inside
 Vim. Look at the features included: '+python/dyn' for Python 2 and
 '+python3/dyn' for Python 3. Take note of the Vim architecture, i.e. 32 or
@@ -627,7 +627,7 @@ Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you. OpenBSD / FreeBSD are
 not officially supported platforms by YCM.
 
-Make sure you have Vim 7.3.598 with Python 2 or Python 3 support.
+Make sure you have Vim 7.4 with Python 2 or Python 3 support.
 
 OpenBSD 5.5 and later have a Vim that's recent enough. You can see the version
 of Vim installed by running 'vim --version'.
@@ -708,19 +708,17 @@ will notify you to recompile it. You should then rerun the install process.
 
 **Please follow the instructions carefully. Read EVERY WORD.**
 
-1. **Ensure that your version of Vim is _at least_ 7.3.598 _and_ that it has
+1. **Ensure that your version of Vim is _at least_ 7.4 _and_ that it has
    support for Python 2 or Python 3 scripting**.
 
    Inside Vim, type ':version'. Look at the first two to three lines of
    output; it should say 'Vi IMproved X.Y', where X.Y is the major version
-   of vim. If your version is greater than 7.3, then you're all set. If your
-   version is 7.3 then look below that where it says, 'Included patches:
-   1-Z', where Z will be some number. That number needs to be 598 or higher.
+   of vim. If your version is greater than 7.4, then you're all set.
 
    If your version of Vim is not recent enough, you may need to compile Vim
    from source [26] (don't worry, it's easy).
 
-   After you have made sure that you have Vim 7.3.598+, type the following
+   After you have made sure that you have Vim 7.4+, type the following
    in Vim: ":echo has('python') || has('python3')". The output should be 1.
    If it's 0, then get a version of Vim with Python support.
 
@@ -2939,7 +2937,9 @@ Those needed to be fixed upstream (and were). A few months after those bugs
 were fixed, Vim trunk landed the 'pyeval()' function which improved YCM
 performance even more since less time was spent serializing and deserializing
 data between Vim and the embedded Python interpreter. A few critical bugfixes
-for 'pyeval()' landed in Vim 7.3.584 (and a few commits before that).
+for 'pyeval()' landed in Vim 7.3.584 (and a few commits before that), and given
+the current availability of Vim 7.4, which packs improved events for text
+change detection, it has been chosen.
 
 -------------------------------------------------------------------------------
         *youcompleteme-i-get-annoying-messages-in-vims-status-area-when-i-type*

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -27,9 +27,9 @@ endfunction
 if exists( "g:loaded_youcompleteme" )
   call s:restore_cpo()
   finish
-elseif v:version < 704
+elseif v:version < 704 || (v:version == 704 && !has('patch143'))
   echohl WarningMsg |
-        \ echomsg "YouCompleteMe unavailable: requires Vim 7.4+" |
+        \ echomsg "YouCompleteMe unavailable: requires Vim 7.4.143+" |
         \ echohl None
   call s:restore_cpo()
   finish

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -27,9 +27,9 @@ endfunction
 if exists( "g:loaded_youcompleteme" )
   call s:restore_cpo()
   finish
-elseif v:version < 703 || (v:version == 703 && !has('patch598'))
+elseif v:version < 704
   echohl WarningMsg |
-        \ echomsg "YouCompleteMe unavailable: requires Vim 7.3.598+" |
+        \ echomsg "YouCompleteMe unavailable: requires Vim 7.4+" |
         \ echohl None
   call s:restore_cpo()
   finish


### PR DESCRIPTION
Long and personal experience, when TextChangedI gets used, YCM seems
to perform better, diagnostics will trigger much less frequently at
inappropriate occasions, even less with whitespace agnostic triggers,
if I recall correctly...

There's a previous discussion at #1337. At the time this change was bundled in
a single pull request with other changes.

It has gone through the test of the time, sole issue I've stumbled upon was reported
by @puremourning at https://github.com/oblitum/YouCompleteMe/issues/10. This
is what me and other users of my fork use daily.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1901)
<!-- Reviewable:end -->
