### PR TITLE
[WIP] Discard whitespace after potential hint trigger matching.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -666,17 +666,12 @@ function! s:InsideCommentOrStringAndShouldStop()
 endfunction
 
 
-function! s:OnBlankLine()
-  return s:Pyeval( 'not vim.current.line or vim.current.line.isspace()' )
-endfunction
-
-
 function! s:InvokeCompletion()
   if &completefunc != "youcompleteme#Complete"
     return
   endif
 
-  if s:InsideCommentOrStringAndShouldStop() || s:OnBlankLine()
+  if s:InsideCommentOrStringAndShouldStop() || !s:Pyeval( 'vimsupport.CanComplete()' )
     return
   endif
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -155,7 +155,7 @@ class BaseRequest( object ):
 
 
 def BuildRequestData( include_buffer_data = True ):
-  line, column = vimsupport.CurrentLineAndColumn()
+  line, column = vimsupport.SnappedLineAndColumn()
   filepath = vimsupport.GetCurrentBufferFilepath()
   request_data = {
     'line_num': line + 1,


### PR DESCRIPTION
This is useful and noticeable with new kinds of semantic completion
like argument hints. For example, for when you want to pass several
arguments to a function, each argument in its own line, and still want
to have hints for each argument across lines.

This relax the first phase of trigger verification to allow semantic
triggering to be possible after `[`, `(`, `,`, `:` (with any whitespace
following), in the last phase (see hint trigger support in [1](https://github.com/Valloric/ycmd/pull/305)). This is
hard-coded for now since client has no access to actual per-file trigger
matching functions.
- Side effects:

The user will be unable to enter TAB after a hint trigger in case TAB is
listed in `g:ycm_key_list_select_completion`, which it is by default.
This already happens, but now this behavior extends for as much
consecutive whitespace exists after the hint trigger, including line breaks.

It just affect users of argument hints that want to put tabulation for
arguments expanding across lines.

For best argument hints usage it's advised to remove TAB from
`g:ycm_key_list_select_completion` and instead rely on standard Vim
hotkeys (CTRL-N and CTRL-P) for popup menu selection (no need to list
them in `g:ycm_key_list_select_completion`, since they're standard Vim
shortcuts).

This activates issue #1352, but only after `[`, `(`, `,`, `:` (with any
whitespace following).

Check:
- https://github.com/Valloric/YouCompleteMe/pull/1337#issuecomment-71755134

for further arguments of this approach over other possible ones.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1902)

<!-- Reviewable:end -->
