### PR TITLE
Add missing implementation on OmniCompletionRequest

### DIFF
--- a/python/ycm/client/omni_completion_request.py
+++ b/python/ycm/client/omni_completion_request.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
+from ycmd.utils import ToUtf8IfNeeded
 from ycm.client.completion_request import CompletionRequest
 
 
@@ -34,5 +35,32 @@ class OmniCompletionRequest( CompletionRequest ):
     return True
 
 
+  def RawResponse( self ):
+    return _ConvertVimDatasToCompletionDatas( self._results )
+
+
   def Response( self ):
     return self._results
+
+
+def ConvertVimDataToCompletionData( vim_data ):
+  # see :h complete-items for a description of the dictionary fields
+  completion_data = {}
+
+  if 'word' in vim_data:
+    completion_data[ 'insertion_text' ] = ToUtf8IfNeeded( vim_data[ 'word' ] )
+  if 'abbr' in vim_data:
+    completion_data[ 'menu_text' ] = ToUtf8IfNeeded( vim_data[ 'abbr' ] )
+  if 'menu' in vim_data:
+    completion_data[ 'extra_menu_info' ] = ToUtf8IfNeeded( vim_data[ 'menu' ] )
+  if 'kind' in vim_data:
+    completion_data[ 'kind' ] = [ ToUtf8IfNeeded( vim_data[ 'kind' ] ) ]
+  if 'info' in vim_data:
+    completion_data[ 'detailed_info' ] = ToUtf8IfNeeded( vim_data[ 'info' ] )
+
+  return completion_data
+
+
+def _ConvertVimDatasToCompletionDatas( response_data ):
+  return [ ConvertVimDataToCompletionData( x )
+           for x in response_data ]

--- a/python/ycm/tests/omni_completion_request_tests.py
+++ b/python/ycm/tests/omni_completion_request_tests.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2016 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from mock import MagicMock
+from nose.tools import eq_
+from hamcrest import assert_that, has_entries
+
+from ycm.client.omni_completion_request import OmniCompletionRequest
+
+
+def BuildOmnicompletionRequest( results ):
+  omni_completer = MagicMock()
+  omni_completer.ComputeCandidates = MagicMock( return_value = results )
+
+  request = OmniCompletionRequest( omni_completer, None )
+  request.Start()
+
+  return request;
+
+
+def Done_AlwaysTrue_test():
+  request = BuildOmnicompletionRequest( [] )
+
+  eq_( request.Done(), True )
+
+
+def Response_FromOmniCompleter_test():
+  results = [ { "word": "test" } ]
+  request = BuildOmnicompletionRequest( results )
+
+  eq_( request.Response(), results )
+
+
+def RawResponse_ConvertedFromOmniCompleter_test():
+  vim_results = [
+    { "word": "WORD", "abbr": "ABBR", "menu": "MENU",
+      "kind": "KIND", "info": "INFO" },
+    { "word": "WORD2", "abbr": "ABBR2", "menu": "MENU2",
+      "kind": "KIND2", "info": "INFO" },
+    { "word": "WORD", "abbr": "ABBR",  },
+    {  },
+  ]
+  expected_results = [
+    has_entries( { "insertion_text": "WORD", "menu_text": "ABBR",
+                   "extra_menu_info": "MENU", "kind": [ "KIND" ],
+                   "detailed_info": "INFO" } ),
+    has_entries( { "insertion_text": "WORD2", "menu_text": "ABBR2",
+                   "extra_menu_info": "MENU2", "kind": [ "KIND2" ],
+                   "detailed_info": "INFO" } ),
+    has_entries( { "insertion_text": "WORD", "menu_text": "ABBR",  } ),
+    has_entries( {  } ),
+  ]
+  request = BuildOmnicompletionRequest( vim_results )
+
+  results = request.RawResponse()
+
+  eq_( len( results ), len( expected_results ) )
+  for result, expected_result in zip( results, expected_results ):
+    assert_that( result, expected_result )


### PR DESCRIPTION
OmniCompletionRequest is missing the RawResponse method, so any attempt to call
it calls the base class method instead. However, since the data structures of
this class and base class are different, this causes an error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1916)
<!-- Reviewable:end -->
