### PR TITLE
python3 support - all tests (except go passed)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/ross/requests-futures
 [submodule "third_party/ycmd"]
 	path = third_party/ycmd
-	url = https://github.com/Valloric/ycmd
+	url = https://github.com/ocehugo/ycmd

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -128,17 +128,17 @@ endfunction
 
 
 function! youcompleteme#GetErrorCount()
-  return pyeval( 'ycm_state.GetErrorCount()' )
+  return py3eval( 'ycm_state.GetErrorCount()' )
 endfunction
 
 
 function! youcompleteme#GetWarningCount()
-  return pyeval( 'ycm_state.GetWarningCount()' )
+  return py3eval( 'ycm_state.GetWarningCount()' )
 endfunction
 
 
 function! s:SetUpPython() abort
-python << EOF
+python3 << EOF
 import sys
 import vim
 import os
@@ -352,7 +352,7 @@ function! s:SetUpCpoptions()
 
   " This prevents the display of "Pattern not found" & similar messages during
   " completion. This is only available since Vim 7.4.314
-  if pyeval( 'vimsupport.VimVersionAtLeast("7.4.314")' )
+  if py3eval( 'vimsupport.VimVersionAtLeast("7.4.314")' )
     set shortmess+=c
   endif
 endfunction
@@ -395,12 +395,12 @@ endfunction
 
 
 function! s:OnVimLeave()
-  py ycm_state.OnVimLeave()
+  py3 ycm_state.OnVimLeave()
 endfunction
 
 
 function! s:OnCompleteDone()
-  py ycm_state.OnCompleteDone()
+  py3 ycm_state.OnCompleteDone()
 endfunction
 
 
@@ -433,7 +433,7 @@ function! s:OnBufferVisit()
     call s:SetOmnicompleteFunc()
   endif
 
-  py ycm_state.OnBufferVisit()
+  py3 ycm_state.OnBufferVisit()
   call s:OnFileReadyToParse()
 endfunction
 
@@ -443,7 +443,7 @@ function! s:OnBufferUnload( deleted_buffer_file )
     return
   endif
 
-  py ycm_state.OnBufferUnload( vim.eval( 'a:deleted_buffer_file' ) )
+  py3 ycm_state.OnBufferUnload( vim.eval( 'a:deleted_buffer_file' ) )
 endfunction
 
 
@@ -470,7 +470,7 @@ function! s:OnFileReadyToParse()
 
   let buffer_changed = b:changedtick != b:ycm_changedtick.file_ready_to_parse
   if buffer_changed
-    py ycm_state.OnFileReadyToParse()
+    py3 ycm_state.OnFileReadyToParse()
   endif
   let b:ycm_changedtick.file_ready_to_parse = b:changedtick
 endfunction
@@ -483,7 +483,7 @@ endfunction
 
 
 function! s:SetOmnicompleteFunc()
-  if pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
+  if py3eval( 'ycm_state.NativeFiletypeCompletionUsable()' )
     let &omnifunc = 'youcompleteme#OmniComplete'
     let &l:omnifunc = 'youcompleteme#OmniComplete'
 
@@ -501,7 +501,7 @@ function! s:OnCursorMovedInsertMode()
     return
   endif
 
-  py ycm_state.OnCursorMoved()
+  py3 ycm_state.OnCursorMoved()
   call s:UpdateCursorMoved()
 
   " Basically, we need to only trigger the completion menu when the user has
@@ -527,7 +527,7 @@ function! s:OnCursorMovedInsertMode()
   " We have to make sure we correctly leave omnifunc mode even when the user
   " inserts something like a "operator[]" candidate string which fails
   " CurrentIdentifierFinished check.
-  if s:omnifunc_mode && !pyeval( 'base.LastEnteredCharIsIdentifierChar()')
+  if s:omnifunc_mode && !py3eval( 'base.LastEnteredCharIsIdentifierChar()')
     let s:omnifunc_mode = 0
   endif
 endfunction
@@ -539,7 +539,7 @@ function! s:OnCursorMovedNormalMode()
   endif
 
   call s:OnFileReadyToParse()
-  py ycm_state.OnCursorMoved()
+  py3 ycm_state.OnCursorMoved()
 endfunction
 
 
@@ -550,7 +550,7 @@ function! s:OnInsertLeave()
 
   let s:omnifunc_mode = 0
   call s:OnFileReadyToParse()
-  py ycm_state.OnInsertLeave()
+  py3 ycm_state.OnInsertLeave()
   if g:ycm_autoclose_preview_window_after_completion ||
         \ g:ycm_autoclose_preview_window_after_insertion
     call s:ClosePreviewWindowIfNeeded()
@@ -617,19 +617,19 @@ function! s:UpdateDiagnosticNotifications()
         \ s:DiagnosticUiSupportedForCurrentFiletype()
 
   if !should_display_diagnostics
-    py ycm_state.ValidateParseRequest()
+    py3 ycm_state.ValidateParseRequest()
     return
   endif
 
-  py ycm_state.UpdateDiagnosticInterface()
+  py3 ycm_state.UpdateDiagnosticInterface()
 endfunction
 
 
 function! s:IdentifierFinishedOperations()
-  if !pyeval( 'base.CurrentIdentifierFinished()' )
+  if !py3eval( 'base.CurrentIdentifierFinished()' )
     return
   endif
-  py ycm_state.OnCurrentIdentifierFinished()
+  py3 ycm_state.OnCurrentIdentifierFinished()
   let s:omnifunc_mode = 0
 endfunction
 
@@ -667,7 +667,7 @@ endfunction
 
 
 function! s:OnBlankLine()
-  return pyeval( 'not vim.current.line or vim.current.line.isspace()' )
+  return py3eval( 'not vim.current.line or vim.current.line.isspace()' )
 endfunction
 
 
@@ -703,7 +703,7 @@ function! s:InvokeCompletion()
 endfunction
 
 
-python << EOF
+python3 << EOF
 def GetCompletionsInner():
   request = ycm_state.GetCurrentCompletionRequest()
   request.Start()
@@ -717,8 +717,8 @@ EOF
 
 
 function! s:GetCompletions()
-  py results = GetCompletionsInner()
-  let results = pyeval( 'results' )
+  py3 results = GetCompletionsInner()
+  let results = py3eval( 'results' )
   return results
 endfunction
 
@@ -743,11 +743,11 @@ function! youcompleteme#Complete( findstart, base )
       return -2
     endif
 
-    if !pyeval( 'ycm_state.IsServerAlive()' )
+    if !py3eval( 'ycm_state.IsServerAlive()' )
       return -2
     endif
-    py ycm_state.CreateCompletionRequest()
-    return pyeval( 'base.CompletionStartColumn()' )
+    py3 ycm_state.CreateCompletionRequest()
+    return py3eval( 'base.CompletionStartColumn()' )
   else
     return s:GetCompletions()
   endif
@@ -756,12 +756,12 @@ endfunction
 
 function! youcompleteme#OmniComplete( findstart, base )
   if a:findstart
-    if !pyeval( 'ycm_state.IsServerAlive()' )
+    if !py3eval( 'ycm_state.IsServerAlive()' )
       return -2
     endif
     let s:omnifunc_mode = 1
-    py ycm_state.CreateCompletionRequest( force_semantic = True )
-    return pyeval( 'base.CompletionStartColumn()' )
+    py3 ycm_state.CreateCompletionRequest( force_semantic = True )
+    return py3eval( 'base.CompletionStartColumn()' )
   else
     return s:GetCompletions()
   endif
@@ -769,23 +769,23 @@ endfunction
 
 
 function! youcompleteme#ServerPid()
-  return pyeval( 'ycm_state.ServerPid()' )
+  return py3eval( 'ycm_state.ServerPid()' )
 endfunction
 
 
 function! s:RestartServer()
-  py ycm_state.RestartServer()
+  py3 ycm_state.RestartServer()
 endfunction
 
 
 function! s:ShowDetailedDiagnostic()
-  py ycm_state.ShowDetailedDiagnostic()
+  py3 ycm_state.ShowDetailedDiagnostic()
 endfunction
 
 
 function! s:DebugInfo()
   echom "Printing YouCompleteMe debug information..."
-  let debug_info = pyeval( 'ycm_state.DebugInfo()' )
+  let debug_info = py3eval( 'ycm_state.DebugInfo()' )
   for line in split( debug_info, "\n" )
     echom '-- ' . line
   endfor
@@ -795,7 +795,7 @@ endfunction
 function! s:ToggleLogs(...)
   let stderr = a:0 == 0 || a:1 !=? 'stdout'
   let stdout = a:0 == 0 || a:1 !=? 'stderr'
-  py ycm_state.ToggleLogs( stdout = vimsupport.GetBoolValue( 'l:stdout' ),
+  py3 ycm_state.ToggleLogs( stdout = vimsupport.GetBoolValue( 'l:stdout' ),
                          \ stderr = vimsupport.GetBoolValue( 'l:stderr' ) )
 endfunction
 
@@ -818,7 +818,7 @@ function! s:CompleterCommand(...)
     let arguments = arguments[1:]
   endif
 
-  py ycm_state.SendCommandRequest( vim.eval( 'l:arguments' ),
+  py3 ycm_state.SendCommandRequest( vim.eval( 'l:arguments' ),
         \                          vim.eval( 'l:completer' ) )
 endfunction
 
@@ -839,22 +839,22 @@ endfunction
 
 
 function! youcompleteme#SubCommandsComplete( arglead, cmdline, cursorpos )
-  return join( pyeval( 'ycm_state.GetDefinedSubcommands()' ),
+  return join( py3eval( 'ycm_state.GetDefinedSubcommands()' ),
     \ "\n")
 endfunction
 
 
 function! s:ForceCompile()
-  if !pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
+  if !py3eval( 'ycm_state.NativeFiletypeCompletionUsable()' )
     echom "Native filetype completion not supported for current file, "
           \ . "cannot force recompilation."
     return 0
   endif
 
   echom "Forcing compilation, this will block Vim until done."
-  py ycm_state.OnFileReadyToParse()
+  py3 ycm_state.OnFileReadyToParse()
   while 1
-    let diagnostics_ready = pyeval(
+    let diagnostics_ready = py3eval(
           \ 'ycm_state.DiagnosticsForCurrentFileReady()' )
     if diagnostics_ready
       break
@@ -883,7 +883,7 @@ function! s:ShowDiagnostics()
     return
   endif
 
-  let diags = pyeval(
+  let diags = py3eval(
         \ 'ycm_state.GetDiagnosticsFromStoredRequest( qflist_format = True )' )
   if !empty( diags )
     call setloclist( 0, diags )

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -33,7 +33,7 @@ elseif v:version < 703 || (v:version == 703 && !has('patch598'))
         \ echohl None
   call s:restore_cpo()
   finish
-elseif !has( 'python' )
+elseif !has( 'python3' )
   echohl WarningMsg |
         \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .
         \ "Python 2.x support" |

--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -47,8 +47,13 @@ def BuildServerConf():
 def LoadJsonDefaultsIntoVim():
   defaults = user_options_store.DefaultOptions()
   vim_defaults = {}
-  for key, value in defaults.iteritems():
-    vim_defaults[ 'ycm_' + key ] = value
+# support python3
+  try:
+    for key, value in defaults.iteritems():
+        vim_defaults[ 'ycm_' + key ] = value
+  except AttributeError:
+    for key, value in defaults.items():
+        vim_defaults[ 'ycm_' + key ] = value
 
   vimsupport.LoadDictIntoVimGlobals( vim_defaults, overwrite = False )
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -18,7 +18,11 @@
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
 import requests
-import urlparse
+# support python3
+try:
+    import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 from base64 import b64decode, b64encode
 from retries import retries
 from requests_futures.sessions import FuturesSession

--- a/python/ycm/client/tests/command_request_test.py
+++ b/python/ycm/client/tests/command_request_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 YouCompleteMe Contributors
 #
@@ -21,6 +22,13 @@ MockVimModule()
 
 from mock import patch, call
 from ycm.client.command_request import CommandRequest
+# support python3
+import sys
+
+if sys.version_info.major > 2:
+    PY3 = True
+else:
+    PY3 = False
 
 
 class GoToResponse_QuickFix_test:
@@ -84,8 +92,7 @@ class GoToResponse_QuickFix_test:
     self._request._response = completer_response
 
     self._request.RunPostCommandActionsIfNeeded()
-
     vim_eval.assert_has_calls( [
-      call( 'setqflist( {0} )'.format( repr( expected_qf_list ) ) ),
-      call( 'youcompleteme#OpenGoToList()' ),
+        call( 'setqflist( {0} )'.format( repr( expected_qf_list ) ) ),
+        call( 'youcompleteme#OpenGoToList()' ),
     ] )

--- a/python/ycm/client/tests/completion_request_test.py
+++ b/python/ycm/client/tests/completion_request_test.py
@@ -34,10 +34,10 @@ class ConvertCompletionResponseToVimDatas_test:
     try:
       eq_( expected_vim_data, vim_data )
     except:
-      print "Expected:\n'{0}'\nwhen parsing:\n'{1}'\nBut found:\n'{2}'".format(
+      print("Expected:\n'{0}'\nwhen parsing:\n'{1}'\nBut found:\n'{2}'".format(
           expected_vim_data,
           completion_data,
-          vim_data )
+          vim_data ))
       raise
 
 

--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -33,7 +33,6 @@ class DiagnosticInterface( object ):
     self._diag_message_needs_clearing = False
     self._placed_signs = []
 
-
   def OnCursorMoved( self ):
     line, _ = vimsupport.CurrentLineAndColumn()
     line += 1  # Convert to 1-based

--- a/python/ycm/paths.py
+++ b/python/ycm/paths.py
@@ -50,7 +50,8 @@ def PathToPythonInterpreter():
   # We check for 'python2' before 'python' because some OS's (I'm looking at
   # you Arch Linux) have made the... interesting decision to point
   # /usr/bin/python to python3.
-  python_names = [ 'python2', 'python' ]
+# support python3
+  python_names = ['python3', 'python2', 'python' ]
 
   path_to_python = utils.PathToFirstExistingExecutable( python_names )
   if path_to_python:

--- a/python/ycm/syntax_parse.py
+++ b/python/ycm/syntax_parse.py
@@ -175,8 +175,13 @@ def _ConnectGroupChildren( group_name_to_group ):
       if line.startswith( links_to ):
         parent_names.append( line[ len( links_to ): ] )
     return parent_names
+# support python3
+  try:
+      g_name_to_g_iter = group_name_to_group.itervalues()
+  except AttributeError:
+      g_name_to_g_iter = group_name_to_group.values()
 
-  for group in group_name_to_group.itervalues():
+  for group in g_name_to_g_iter:
     parent_names = GetParentNames( group )
 
     for parent_name in parent_names:

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -24,6 +24,20 @@ import json
 import re
 from ycmd.utils import ToUtf8IfNeeded
 from ycmd import user_options_store
+# support python3
+try:
+    unicode = unicode
+except NameError:
+    str = str
+    bytes = bytes
+    unicode = str
+    basestring = (str,bytes)
+else:
+    str = str
+    bytes = str
+    unicode = unicode
+    basestring = basestring
+
 
 BUFFER_COMMAND_MAP = { 'same-buffer'      : 'edit',
                        'horizontal-split' : 'split',
@@ -295,7 +309,13 @@ def GetReadOnlyVimGlobals( force_python_objects = False ):
 
 def VimExpressionToPythonType( vim_expression ):
   result = vim.eval( vim_expression )
-  if not isinstance( result, basestring ):
+# suppory python3
+  try:
+      instance_check = isinstance(result, basestring )
+  except:
+      instance_check = isinstance(result, str)
+
+  if not instance_check:
     return result
   try:
     return int( result )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -16,6 +16,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+# support python3
+import sys
+if sys.version_info.major > 2:
+    PY3 = True
+else:
+    PY3 = False
 
 import os
 import vim
@@ -98,18 +104,30 @@ class YouCompleteMe( object ):
     self._ycmd_keepalive = YcmdKeepalive()
     self._SetupServer()
     self._ycmd_keepalive.Start()
+    # update syntax to support python3
     self._complete_done_hooks = {
-      'cs': lambda( self ): self._OnCompleteDone_Csharp()
+        'cs': lambda self: self._OnCompleteDone_Csharp()
     }
+
 
   def _SetupServer( self ):
     self._available_completers = {}
     server_port = utils.GetUnusedLocalhostPort()
     # The temp options file is deleted by ycmd during startup
-    with tempfile.NamedTemporaryFile( delete = False ) as options_file:
+# support python3
+    if PY3:
+        temp_mode_opt = 'w+'
+    else:
+        temp_mode_opt = 'w+b'
+
+    with tempfile.NamedTemporaryFile(delete = False, mode=temp_mode_opt ) as options_file:
       hmac_secret = os.urandom( HMAC_SECRET_LENGTH )
       options_dict = dict( self._user_options )
       options_dict[ 'hmac_secret' ] = base64.b64encode( hmac_secret )
+#       support python3
+      if PY3:
+          options_dict[ 'hmac_secret' ] = str(options_dict['hmac_secret'],'utf8')
+
       json.dump( options_dict, options_file )
       options_file.flush()
 
@@ -307,9 +325,14 @@ class YouCompleteMe( object ):
 
   def GetCompleteDoneHooks( self ):
     filetypes = vimsupport.CurrentFiletypes()
-    for key, value in self._complete_done_hooks.iteritems():
-      if key in filetypes:
-        yield value
+    try:
+        for key, value in self._complete_done_hooks.iteritems():
+          if key in filetypes:
+            yield value
+    except AttributeError:
+        for key, value in self._complete_done_hooks.items():
+          if key in filetypes:
+            yield value
 
 
   def GetCompletionsUserMayHaveCompleted( self ):

--- a/third_party/retries/retries.py
+++ b/third_party/retries/retries.py
@@ -24,6 +24,13 @@
 import sys
 from time import sleep
 
+# support python3
+major, minor = sys.version_info[ 0 : 2 ]
+if major >2:
+    PY3 = True
+else:
+    PY3 = False
+
 # Source: https://gist.github.com/n1ywb/2570004
 
 def example_exc_handler(tries_remaining, exception, delay):
@@ -62,7 +69,12 @@ def retries(max_tries, delay=1, backoff=2, exceptions=(Exception,), hook=None):
         def f2(*args, **kwargs):
             mydelay = delay
             tries = range(max_tries)
-            tries.reverse()
+# support python3
+            if PY3:
+                tries = reversed(tries)
+            else:
+                tries.reverse()
+
             for tries_remaining in tries:
                 try:
                    return func(*args, **kwargs)


### PR DESCRIPTION
Hello @Valloric,

I did a python3 port of the vimscripts,YCM and YCMD. It's not perfect but at least all tests works and vim doesn't raise any errors loading it. All the problems seems to be now debugable within YCM server which I found extremely painful since I'm not used to it.

All the python code is suppose to work with both py2 and py3. Only the vim scripts i changed to python3 since i'm not versed in vim script that much ( I was thinking that a global check would be better than simply copying and renaming all functions to use py3).

Completions still did not work (python code mostly). I hope that the way the code is now you guys can track much more easily the errors than me.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1920)
<!-- Reviewable:end -->
