### PR TITLE
[READY] Update get-pip.py script URL on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ environment:
 install:
   - git submodule update --init --recursive
   - ps: $env:python = if ($env:arch -eq 32) { 'C:\Python27' } else { 'C:\Python27-x64' }
-  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:\get-pip.py')
+  - appveyor DownloadFile https://bootstrap.pypa.io/get-pip.py
   - set PATH=%python%;%python%\Scripts;%PATH%
-  - python C:\get-pip.py
+  - python get-pip.py
   - pip install -r python\test_requirements.txt
 build_script:
   - python run_tests.py


### PR DESCRIPTION
This fixes the following error on AppVeyor:
```
You're using an outdated location for the get-pip.py script, please use the one available from https://bootstrap.pypa.io/get-pip.py
```

I also changed the way `get-pip.py` is downloaded. This is now done like in the `ycmd` repository.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1929)
<!-- Reviewable:end -->
