### PR TITLE
[READY] Avoid confusion with make command

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ process.
     other flags. **If you compiled LLVM from source, this is the flag you should
     be using.**
 
-    Running the `make` command will also place the `libclang.[so|dylib|dll]` in
+    Running the `cmake` command will also place the `libclang.[so|dylib|dll]` in
     the `YouCompleteMe/third_party/ycmd` folder for you if you compiled with
     clang support (it needs to be there for YCM to work).
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -809,7 +809,7 @@ process.
    the other flags. **If you compiled LLVM from source, this is the flag you
    should be using.**
 
-   Running the 'make' command will also place the 'libclang.[so|dylib|dll]'
+   Running the 'cmake' command will also place the 'libclang.[so|dylib|dll]'
    in the 'YouCompleteMe/third_party/ycmd' folder for you if you compiled
    with clang support (it needs to be there for YCM to work).
 


### PR DESCRIPTION
This sentence may be interpreted as executing the `make` command to move the libaries. See issue #1951. We *make* it clear by using `cmake` instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1954)
<!-- Reviewable:end -->
