### PR TITLE
[READY] Update Go documentation with GoTo subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ YouCompleteMe is a fast, as-you-type, fuzzy-search code completion engine for
   "the C-family languages"),
 - a [Jedi][]-based completion engine for Python 2 and 3 (using the [JediHTTP][] wrapper),
 - an [OmniSharp][]-based completion engine for C#,
-- a [Gocode][]-based completion engine for Go,
+- a combination of [Gocode][] and [Godef][] semantic engines for Go,
 - a [TSServer][]-based completion engine for TypeScript,
 - a [Tern][]-based completion engine for JavaScript,
 - a [racer][]-based completion engine for Rust,
@@ -670,6 +670,7 @@ Quick Feature Summary
 ### Go
 
 * Semantic auto-completion
+* Go to definition (`GoTo`)
 * Management of `gocode` server instance
 
 ### TypeScript
@@ -1153,7 +1154,7 @@ Supported in filetypes: `c, cpp, objc, objcpp`
 
 Looks up the symbol under the cursor and jumps to its declaration.
 
-Supported in filetypes: `c, cpp, objc, objcpp, python, cs, rust`
+Supported in filetypes: `c, cpp, objc, objcpp, cs, go, python, rust`
 
 ### The `GoToDefinition` subcommand
 
@@ -1164,8 +1165,8 @@ the definition of the symbol is in the current translation unit. A translation
 unit consists of the file you are editing and all the files you are including
 with `#include` directives (directly or indirectly) in that file.
 
-Supported in filetypes: `c, cpp, objc, objcpp, python, cs, typescript,
-javascript, rust`
+Supported in filetypes: `c, cpp, objc, objcpp, cs, go, javascript, python,
+rust, typescript`
 
 ### The `GoTo` subcommand
 
@@ -1176,7 +1177,7 @@ the current translation unit, jumps to the symbol's declaration. For
 C/C++/Objective-C, it first tries to look up the current line for a header and
 jump to it. For C#, implementations are also considered and preferred.
 
-Supported in filetypes: `c, cpp, objc, objcpp, python, cs, javascript, rust`
+Supported in filetypes: `c, cpp, objc, objcpp, cs, go, javascript, python, rust`
 
 ### The `GoToImprecise` subcommand
 
@@ -1240,7 +1241,7 @@ std::cout << *x; // invoking on x returns "const char ** => const char **"
 
 NOTE: Causes re-parsing of the current translation unit.
 
-Supported in filetypes: `c, cpp, objc, objcpp, typescript, javascript`
+Supported in filetypes: `c, cpp, objc, objcpp, javascript, typescript`
 
 ### The `GetParent` subcommand
 
@@ -1325,14 +1326,14 @@ javascript`
 Starts the semantic-engine-as-localhost-server for those semantic engines that
 work as separate servers that YCM talks to.
 
-Supported in filetypes: `cs, javascript, go, rust`
+Supported in filetypes: `cs, go, javascript, rust`
 
 ### The `StopServer` subcommand
 
 Stops the semantic-engine-as-localhost-server for those semantic engines that
 work as separate servers that YCM talks to.
 
-Supported in filetypes: `cs, javascript, go, rust`
+Supported in filetypes: `cs, go, javascript, rust`
 
 ### The `RestartServer` subcommand
 
@@ -1346,7 +1347,7 @@ python binary to use to restart the Python semantic engine.
 :YcmCompleter RestartServer /usr/bin/python3.4
 ```
 
-Supported in filetypes: `cs, rust, python`
+Supported in filetypes: `cs, python, rust`
 
 ### The `ReloadSolution` subcommand
 
@@ -2722,6 +2723,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [Options]: https://github.com/Valloric/YouCompleteMe#options
 [ygen]: https://github.com/rdnetto/YCM-Generator
 [Gocode]: https://github.com/nsf/gocode
+[Godef]: https://github.com/Manishearth/godef
 [TSServer]: https://github.com/Microsoft/TypeScript/tree/master/src/server
 [NeoBundle]: https://github.com/Shougo/neobundle.vim
 [vim64-win-download]: https://bintray.com/veegee/generic/vim_x64

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -144,7 +144,7 @@ Contents ~
   25. I get weird errors when I press 'Ctrl-C' in Vim              |Ctrl-sub-C|
   26. Why did YCM stop using Syntastic for diagnostics display? |youcompleteme-why-did-ycm-stop-using-syntastic-for-diagnostics-display|
   27. Completion doesn't work with the C++ standard library headers |youcompleteme-completion-doesnt-work-with-c-standard-library-headers|
-  28. Install YCM with NeoBundle [53] |youcompleteme-install-ycm-with-neobundle-53|
+  28. Install YCM with NeoBundle [54] |youcompleteme-install-ycm-with-neobundle-54|
   29. When I open a JavaScript file, I get an annoying warning about '.tern-project'
 file |.tern-sub-project|
   30. When I run install.py I get a LINK error saying "fatal error LNK1104: cannot
@@ -219,19 +219,19 @@ Vim. It has several completion engines:
 
 - an OmniSharp [8]-based completion engine for C#,
 
-- a Gocode [9]-based completion engine for Go,
+- a combination of Gocode [9] and Godef [10] semantic engines for Go,
 
-- a TSServer [10]-based completion engine for TypeScript,
+- a TSServer [11]-based completion engine for TypeScript,
 
-- a Tern [11]-based completion engine for JavaScript,
+- a Tern [12]-based completion engine for JavaScript,
 
-- a racer [12]-based completion engine for Rust,
+- a racer [13]-based completion engine for Rust,
 
 - and an omnifunc-based completer that uses data from Vim's omnicomplete
   system to provide semantic completions for many other languages (Ruby, PHP
   etc.).
 
-  Image: YouCompleteMe GIF demo (see reference [13])
+  Image: YouCompleteMe GIF demo (see reference [14])
 
 Here's an explanation of what happens in the short GIF demo above.
 
@@ -250,7 +250,7 @@ typing to further filter out unwanted completions.
 
 A critical thing to notice is that the completion **filtering is NOT based on
 the input being a string prefix of the completion** (but that works too). The
-input needs to be a _subsequence [14] match_ of a completion. This is a fancy
+input needs to be a _subsequence [15] match_ of a completion. This is a fancy
 way of saying that any input characters need to be present in a completion
 string in the order in which they appear in the input. So 'abc' is a
 subsequence of 'xaybgc', but not of 'xbyxaxxc'. After the filter, a complicated
@@ -269,7 +269,7 @@ with a keyboard shortcut; see the rest of the docs).
 
 The last thing that you can see in the demo is YCM's diagnostic display
 features (the little red X that shows up in the left gutter; inspired by
-Syntastic [15]) if you are editing a C-family file. As Clang compiles your file
+Syntastic [16]) if you are editing a C-family file. As Clang compiles your file
 and detects warnings or errors, they will be presented in various ways. You
 don't need to save your file or press any keyboard shortcut to trigger this, it
 "just happens" in the background.
@@ -287,7 +287,7 @@ languages & Python. Expect more IDE features powered by the various YCM
 semantic engines in the future.
 
 You'll also find that YCM has filepath completers (try typing './' in a file)
-and a completer that integrates with UltiSnips [16].
+and a completer that integrates with UltiSnips [17].
 
 ===============================================================================
                                                    *youcompleteme-installation*
@@ -300,16 +300,16 @@ Mac OS X Installation ~
 Please refer to the full Installation Guide below; the following commands are
 provided on a best-effort basis and may not work for you.
 
-Install the latest version of MacVim [17]. Yes, MacVim. And yes, the _latest_.
+Install the latest version of MacVim [18]. Yes, MacVim. And yes, the _latest_.
 
 If you don't use the MacVim GUI, it is recommended to use the Vim binary that
 is inside the MacVim.app package ('MacVim.app/Contents/MacOS/Vim'). To ensure
-it works correctly copy the 'mvim' script from the MacVim [17] download to your
+it works correctly copy the 'mvim' script from the MacVim [18] download to your
 local binary folder (for example '/usr/local/bin/mvim') and then symlink it:
 >
   ln -s /usr/local/bin/mvim vim
 <
-Install YouCompleteMe with Vundle [18].
+Install YouCompleteMe with Vundle [19].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_support_libs library APIs have changed (happens
@@ -321,8 +321,8 @@ installed along with the latest Command Line Tools (they are installed
 automatically when you run 'clang' for the first time, or manually by running
 'xcode-select --install')
 
-Install CMake. Preferably with Homebrew [19], but here's the stand-alone CMake
-installer [20].
+Install CMake. Preferably with Homebrew [20], but here's the stand-alone CMake
+installer [21].
 
 _If_ you have installed a Homebrew Python and/or Homebrew MacVim, see the _FAQ_
 for details.
@@ -343,13 +343,13 @@ The following additional language support options are available:
 
 - Go support: ensure go is installed and add '--gocode-completer'
 
-- TypeScript support: install nodejs and npm [21] then install the TypeScript
+- TypeScript support: install nodejs and npm [22] then install the TypeScript
   SDK with 'npm install -g typescript'.
 
-- JavaScript support: install nodejs and npm [21] and add '--tern-completer'
+- JavaScript support: install nodejs and npm [22] and add '--tern-completer'
   to './install.py'
 
-- Rust support: install rustc and cargo [22] and add '--racer-completer' to
+- Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
 For example, to install with all language features, ensure npm, go, mono, rust,
@@ -378,9 +378,9 @@ provided on a best-effort basis and may not work for you.
 Make sure you have Vim 7.3.598 with python2 support. Ubuntu 14.04 and later
 have a Vim that's recent enough. You can see the version of Vim installed by
 running 'vim --version'. If the version is too old, you may need to compile Vim
-from source [23] (don't worry, it's easy).
+from source [24] (don't worry, it's easy).
 
-Install YouCompleteMe with Vundle [18].
+Install YouCompleteMe with Vundle [19].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_support_libs library APIs have changed (happens
@@ -408,13 +408,13 @@ The following additional language support options are available:
 
 - Go support: ensure go is installed and add '--gocode-completer'
 
-- TypeScript support: install nodejs and npm [21] then install the TypeScript
+- TypeScript support: install nodejs and npm [22] then install the TypeScript
   SDK with 'npm install -g typescript'.
 
-- JavaScript support: install nodejs and npm [21] and add '--tern-completer'
+- JavaScript support: install nodejs and npm [22] and add '--tern-completer'
   to './install.py'
 
-- Rust support: install rustc and cargo [22] and add '--racer-completer' to
+- Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
 For example, to install with all language features, ensure npm, go, mono, rust,
@@ -443,9 +443,9 @@ provided on a best-effort basis and may not work for you.
 Make sure you have Vim 7.3.598 with python2 support. Fedora 21 and later have a
 Vim that's recent enough. You can see the version of Vim installed by running
 'vim --version'. If the version is too old, you may need to compile Vim from
-source [23] (don't worry, it's easy).
+source [24] (don't worry, it's easy).
 
-Install YouCompleteMe with Vundle [18].
+Install YouCompleteMe with Vundle [19].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_support_libs library APIs have changed (happens
@@ -473,13 +473,13 @@ The following additional language support options are available:
 
 - Go support: ensure go is installed and add '--gocode-completer'
 
-- TypeScript support: install nodejs and npm [21] then install the TypeScript
+- TypeScript support: install nodejs and npm [22] then install the TypeScript
   SDK with 'npm install -g typescript'.
 
-- JavaScript support: install nodejs and npm [21] and add '--tern-completer'
+- JavaScript support: install nodejs and npm [22] and add '--tern-completer'
   to './install.py'
 
-- Rust support: install rustc and cargo [22] and add '--racer-completer' to
+- Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
 For example, to install with all language features, ensure npm, go, mono, rust,
@@ -512,9 +512,9 @@ Make sure you have at least Vim 7.3.598 with python2 support. You can check the
 version by typing ':version' inside Vim. Take note of the Vim architecture,
 i.e. 32 or 64-bit. It will be important when choosing the python2 installer. We
 recommend using a 64-bit client. Don't worry, a frequently updated copy of
-64-bit Vim [24] is available.
+64-bit Vim [25] is available.
 
-Install YouCompleteMe with Vundle [18].
+Install YouCompleteMe with Vundle [19].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_support_libs library APIs have changed (happens
@@ -523,16 +523,16 @@ process.
 
 Download and install the following software:
 
-- python2 [25]. Be sure to pick the version corresponding to your Vim
+- python2 [26]. Be sure to pick the version corresponding to your Vim
   architecture. It is _Windows x86-64 MSI installer_ if you are using the Vim
   previously linked.
 
-- CMake [20]. Add CMake executable to the PATH environment variable.
+- CMake [21]. Add CMake executable to the PATH environment variable.
 
-- Visual Studio [26]. Download the community edition. During setup, choose
+- Visual Studio [27]. Download the community edition. During setup, choose
   _Custom_ as the installation type and select the _Visual C++_ component.
 
-- 7-zip [27]. Required to build YCM with semantic support for C-family
+- 7-zip [28]. Required to build YCM with semantic support for C-family
   languages.
 
 Compiling YCM **with** semantic support for C-family languages:
@@ -548,17 +548,17 @@ Compiling YCM **without** semantic support for C-family languages:
 The following additional language support options are available:
 
 - C# support: add '--omnisharp-completer' to 'install.py'. Be sure that the
-  build utility 'msbuild' is in your PATH [28].
+  build utility 'msbuild' is in your PATH [29].
 
 - Go support: ensure go is installed and add '--gocode-completer'.
 
-- TypeScript support: install nodejs and npm [21] then install the TypeScript
+- TypeScript support: install nodejs and npm [22] then install the TypeScript
   SDK with 'npm install -g typescript'.
 
-- JavaScript support: install nodejs and npm [21] and add '--tern-completer'
+- JavaScript support: install nodejs and npm [22] and add '--tern-completer'
   to 'install.py'.
 
-- Rust support: install rustc and cargo [22] and add '--racer-completer' to
+- Rust support: install rustc and cargo [23] and add '--racer-completer' to
   'install.py'.
 
 For example, to install with all language features, ensure npm, go, mono, rust,
@@ -598,7 +598,7 @@ FreeBSD 10.x comes with clang compiler but not the libraries needed to install.
   pkg install llvm35 boost-all boost-python-libs clang35
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/llvm35/lib/
 <
-Install YouCompleteMe with Vundle [18].
+Install YouCompleteMe with Vundle [19].
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_support_libs library APIs have changed (happens
@@ -623,13 +623,13 @@ The following additional language support options are available:
 
 - Go support: ensure go is installed and add '--gocode-completer'
 
-- TypeScript support: install nodejs and npm [21] then install the TypeScript
+- TypeScript support: install nodejs and npm [22] then install the TypeScript
   SDK with 'npm install -g typescript'.
 
-- JavaScript support: install nodejs and npm [21] and add '--tern-completer'
+- JavaScript support: install nodejs and npm [22] and add '--tern-completer'
   to './install.py'
 
-- Rust support: install rustc and cargo [22] and add '--racer-completer' to
+- Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
 For example, to install with all language features, ensure npm, go, mono, rust,
@@ -679,7 +679,7 @@ process.
    1-Z', where Z will be some number. That number needs to be 598 or higher.
 
    If your version of Vim is not recent enough, you may need to compile Vim
-   from source [23] (don't worry, it's easy).
+   from source [24] (don't worry, it's easy).
 
    After you have made sure that you have Vim 7.3.598+, type the following
    in Vim: ":echo has('python')". The output should be 1. If it's 0, then
@@ -689,9 +689,9 @@ process.
    critical because it must match the python2 and the YCM libraries
    architectures. We recommend using a 64-bit Vim.
 
-2. **Install YCM** with Vundle [18] (or Pathogen [29], but Vundle is a
+2. **Install YCM** with Vundle [19] (or Pathogen [30], but Vundle is a
    better idea). With Vundle, this would mean adding a "Plugin
-   'Valloric/YouCompleteMe'" line to your vimrc [30].
+   'Valloric/YouCompleteMe'" line to your vimrc [31].
 
    If you don't install YCM with Vundle, make sure you have run 'git
    submodule update --init --recursive' after checking out the YCM
@@ -708,7 +708,7 @@ process.
 
    You can use the system libclang _only if you are sure it is version 3.3
    or higher_, otherwise don't. Even if it is, we recommend using the
-   official binaries from llvm.org [31] if at all possible. Make sure you
+   official binaries from llvm.org [32] if at all possible. Make sure you
    download the correct archive file for your OS.
 
    We **STRONGLY recommend AGAINST use** of the system libclang instead of
@@ -721,17 +721,17 @@ process.
    You will need to have 'cmake' installed in order to generate the required
    makefiles. Linux users can install cmake with their package manager
    ('sudo apt-get install cmake' for Ubuntu) whereas other users can
-   download and install [20] cmake from its project site. Mac users can also
-   get it through Homebrew [19] with 'brew install cmake'.
+   download and install [21] cmake from its project site. Mac users can also
+   get it through Homebrew [20] with 'brew install cmake'.
 
    On a Unix OS, you need to make sure you have Python headers installed. On
    a Debian-like Linux distro, this would be 'sudo apt-get install python-
    dev'. On Mac they should already be present.
 
-   On Windows, you need to download and install python2 [25]. Pick the
+   On Windows, you need to download and install python2 [26]. Pick the
    version corresponding to your Vim architecture. You will also need
    Microsoft Visual C++ (MSVC) to build YCM. You can obtain it by installing
-   Visual Studio [26]. MSVC 11 (Visual Studio 2012), 12 (2013), and 14
+   Visual Studio [27]. MSVC 11 (Visual Studio 2012), 12 (2013), and 14
    (2015) are officially supported.
 
    Here we'll assume you installed YCM with Vundle. That means that the top-
@@ -774,7 +774,7 @@ process.
    extracted the archive file to folder '~/ycm_temp/llvm_root_dir' (with
    'bin', 'lib', 'include' etc. folders right inside that folder). On
    Windows, you can extract the files from the LLVM+Clang installer using
-   7-zip [27].
+   7-zip [28].
 
    NOTE: This _only_ works with a _downloaded_ LLVM binary package, not a
    custom-built LLVM! See docs below for 'EXTERNAL_LIBCLANG_PATH' when using
@@ -819,20 +819,20 @@ process.
    'YouCompleteMe/third_party/ycmd/third_party/OmniSharpServer' and run
    'msbuild' (Windows) or 'xbuild' (other platforms, using mono) depending
    on your platform. If mono is not installed, install it. When on Windows,
-   be sure that the build utility 'msbuild' is in your PATH [28].
+   be sure that the build utility 'msbuild' is in your PATH [29].
 
 7. Go support: If go is not installed on your system, install it and add it
    to your path. Navigate to
    'YouCompleteMe/third_party/ycmd/third_party/gocode' and run 'go build'.
 
 8. TypeScript support: As with the quick installation, simply 'npm install
-   -g typescript' after successfully installing nodejs and npm [21].
+   -g typescript' after successfully installing nodejs and npm [22].
 
-9. JavaScript support: Install nodejs and npm [21]. Then navigate to
+9. JavaScript support: Install nodejs and npm [22]. Then navigate to
    'YouCompleteMe/third_party/ycmd/third_party/tern' and run 'npm install
    --production'
 
-10. Rust support: Install rustc and cargo [22]. Navigate to
+10. Rust support: Install rustc and cargo [23]. Navigate to
     'YouCompleteMe/third_party/ycmd/third_party/racerd' and run 'cargo
     build --release'.
 
@@ -896,6 +896,7 @@ Python ~
 Go ~
 
 - Semantic auto-completion
+- Go to definition (|GoTo|)
 - Management of 'gocode' server instance
 
 -------------------------------------------------------------------------------
@@ -948,7 +949,7 @@ General Usage ~
   through the completions. Use Shift-TAB to cycle backwards. Note that if
   you're using console Vim (that is, not Gvim or MacVim) then it's likely
   that the Shift-TAB binding will not work because the console will not pass
-  it to Vim. You can remap the keys; see the _Options [32]_ section below.
+  it to Vim. You can remap the keys; see the _Options [33]_ section below.
 
 Knowing a little bit about how YCM works internally will prevent confusion. YCM
 has several completion engines: an identifier-based completer that collects all
@@ -1019,20 +1020,20 @@ This system was designed this way so that the user can perform any arbitrary
 sequence of operations to produce a list of compilation flags YCM should hand
 to Clang.
 
-See YCM's own '.ycm_extra_conf.py' [33] for details on how this works. You
+See YCM's own '.ycm_extra_conf.py' [34] for details on how this works. You
 should be able to use it _as a starting point_. **Don't** just copy/paste that
 file somewhere and expect things to magically work; **your project needs
 different flags**. Hint: just replace the strings in the 'flags' variable with
 compilation flags necessary for your project. That should be enough for 99% of
 projects.
 
-Yes, Clang's 'CompilationDatabase' system [34] is also supported. Again, see
+Yes, Clang's 'CompilationDatabase' system [35] is also supported. Again, see
 the above linked example file. You can get CMake to generate this file for you
 by adding 'set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )' to your project's
 'CMakeLists.txt' file (if using CMake). If you're not using CMake, you could
-use something like Bear [35] to generate the 'compile_commands.json' file.
+use something like Bear [36] to generate the 'compile_commands.json' file.
 
-Consider using YCM-Generator [36] to generate the 'ycm_extra_conf.py' file.
+Consider using YCM-Generator [37] to generate the 'ycm_extra_conf.py' file.
 
 If Clang encounters errors when compiling the header files that your file
 includes, then it's probably going to take a long time to get completions. When
@@ -1057,7 +1058,7 @@ Quick start ~
    guide for details.
 
 2. Create a '.tern-project' file in the root directory of your JavaScript
-   project, by following the instructions [37] in the Tern [11]
+   project, by following the instructions [38] in the Tern [12]
    documentation.
 
 3. Make sure that Vim's working directory is a descendent of that directory
@@ -1067,14 +1068,14 @@ Quick start ~
                                                     *youcompleteme-explanation*
 Explanation ~
 
-JavaScript completion is based on Tern [11]. This completion engine requires a
-file named '.tern-project' [37] to exist in the current working directory or a
+JavaScript completion is based on Tern [12]. This completion engine requires a
+file named '.tern-project' [38] to exist in the current working directory or a
 directory which is an ancestor of the current working directory when the tern
 server is started. YCM starts the Tern server the first time a JavaScript file
 is edited, so Vim's working directory at that time needs to be a descendent of
 the directory containing the '.tern-project' file (or that directory itself).
 
-Alternatively, as described in the Tern documentation [38], a global '.tern-
+Alternatively, as described in the Tern documentation [39], a global '.tern-
 config' file may be used.
 
 Multiple Tern servers, are not supported. To switch to a different JavaScript
@@ -1096,9 +1097,9 @@ Tips and tricks ~
 
 This section contains some advice for configuring '.tern-project' and working
 with JavaScript files. The canonical reference for correctly configuring Tern
-is the Tern documentation [38]. Any issues, improvements, advice, etc. should
-be sought from the Tern [11] project. For example, see the list of tern plugins
-[39] for the list of plugins which can be enabled in the 'plugins' section of
+is the Tern documentation [39]. Any issues, improvements, advice, etc. should
+be sought from the Tern [12] project. For example, see the list of tern plugins
+[40] for the list of plugins which can be enabled in the 'plugins' section of
 the '.tern-project' file.
 
 -------------------------------------------------------------------------------
@@ -1150,7 +1151,7 @@ Completions and GoTo commands within the current crate and its dependencies
 should work out of the box with no additional configuration (provided that you
 built YCM with the '--racer-completer' flag; see the _Installation_ section for
 details). For semantic analysis inclusive of the standard library, you must
-have a local copy of the rust source code [40]. You also need to set the
+have a local copy of the rust source code [41]. You also need to set the
 following option so YouCompleteMe can locate it.
 >
   " In this example, the rust source code zip has been extracted to
@@ -1176,7 +1177,7 @@ use. For example, to provide Python 3 completion in your project, set:
 Semantic completion for other languages ~
 
 Python, C#, Go, Rust, and TypeScript are supported natively by YouCompleteMe
-using the Jedi [6], Omnisharp [8], Gocode [9], racer [12], and TSServer [10]
+using the Jedi [6], Omnisharp [8], Gocode [9], racer [13], and TSServer [11]
 engines, respectively. Check the installation section for instructions to
 enable these features if desired.
 
@@ -1185,7 +1186,7 @@ semantic completions if it does not have a native semantic completion engine
 for your file's filetype. Vim comes with okayish omnifuncs for various
 languages like Ruby, PHP etc. It depends on the language.
 
-You can get stellar omnifuncs for Java and Ruby with Eclim [41]. Just make sure
+You can get stellar omnifuncs for Java and Ruby with Eclim [42]. Just make sure
 you have the _latest_ Eclim installed and configured (this means Eclim '>=
 2.2.*' and Eclipse '>= 4.2.*').
 
@@ -1203,7 +1204,7 @@ Writing New Semantic Completers ~
 
 You have two options here: writing an 'omnifunc' for Vim's omnicomplete system
 that YCM will then use through its omni-completer, or a custom completer for
-YCM using the Completer API [42].
+YCM using the Completer API [43].
 
 Here are the differences between the two approaches:
 
@@ -1222,7 +1223,7 @@ Here are the differences between the two approaches:
   than VimScript.
 
 If you want to use the 'omnifunc' system, see the relevant Vim docs with ':h
-complete-functions'. For the Completer API, see the API docs [42].
+complete-functions'. For the Completer API, see the API docs [43].
 
 If you want to upstream your completer into YCM's source, you should use the
 Completer API.
@@ -1273,7 +1274,7 @@ current file in Vim's 'locationlist', which can be opened with the ':lopen' and
 ':lclose' commands (make sure you have set 'let
 g:ycm_always_populate_location_list = 1' in your vimrc). A good way to toggle
 the display of the 'locationlist' with a single key mapping is provided by
-another (very small) Vim plugin called ListToggle [43] (which also makes it
+another (very small) Vim plugin called ListToggle [44] (which also makes it
 possible to change the height of the 'locationlist' window), also written by
 yours truly.
 
@@ -1424,7 +1425,7 @@ The *GoToDeclaration* subcommand
 
 Looks up the symbol under the cursor and jumps to its declaration.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, python, cs, rust'
+Supported in filetypes: 'c, cpp, objc, objcpp, cs, go, python, rust'
 
 -------------------------------------------------------------------------------
 The *GoToDefinition* subcommand
@@ -1436,8 +1437,8 @@ when the definition of the symbol is in the current translation unit. A
 translation unit consists of the file you are editing and all the files you are
 including with '#include' directives (directly or indirectly) in that file.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, python, cs, typescript,
-javascript, rust'
+Supported in filetypes: 'c, cpp, objc, objcpp, cs, go, javascript, python,
+rust, typescript'
 
 -------------------------------------------------------------------------------
 The *GoTo* subcommand
@@ -1449,7 +1450,8 @@ the current translation unit, jumps to the symbol's declaration. For
 C/C++/Objective-C, it first tries to look up the current line for a header and
 jump to it. For C#, implementations are also considered and preferred.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, python, cs, javascript, rust'
+Supported in filetypes: 'c, cpp, objc, objcpp, cs, go, javascript, python,
+rust'
 
 -------------------------------------------------------------------------------
 The *GoToImprecise* subcommand
@@ -1513,7 +1515,7 @@ For example:
 <
 NOTE: Causes re-parsing of the current translation unit.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, typescript, javascript'
+Supported in filetypes: 'c, cpp, objc, objcpp, javascript, typescript'
 
 -------------------------------------------------------------------------------
 The *GetParent* subcommand
@@ -1601,7 +1603,7 @@ The *StartServer* subcommand
 Starts the semantic-engine-as-localhost-server for those semantic engines that
 work as separate servers that YCM talks to.
 
-Supported in filetypes: 'cs, javascript, go, rust'
+Supported in filetypes: 'cs, go, javascript, rust'
 
 -------------------------------------------------------------------------------
 The *StopServer* subcommand
@@ -1609,7 +1611,7 @@ The *StopServer* subcommand
 Stops the semantic-engine-as-localhost-server for those semantic engines that
 work as separate servers that YCM talks to.
 
-Supported in filetypes: 'cs, javascript, go, rust'
+Supported in filetypes: 'cs, go, javascript, rust'
 
 -------------------------------------------------------------------------------
 The *RestartServer* subcommand
@@ -1622,7 +1624,7 @@ python binary to use to restart the Python semantic engine.
 >
   :YcmCompleter RestartServer /usr/bin/python3.4
 <
-Supported in filetypes: 'cs, rust, python'
+Supported in filetypes: 'cs, python, rust'
 
 -------------------------------------------------------------------------------
 The *ReloadSolution* subcommand
@@ -1666,7 +1668,7 @@ For example:
   call youcompleteme#GetErrorCount()
 <
 Both this function and |youcompleteme#GetWarningCount| can be useful when
-integrating YCM with other Vim plugins. For example, a lightline [44] user
+integrating YCM with other Vim plugins. For example, a lightline [45] user
 could add a diagnostics section to their statusline which would display the
 number of errors and warnings.
 
@@ -1686,11 +1688,11 @@ Options ~
 
 All options have reasonable defaults so if the plug-in works after installation
 you don't need to change any options. These options can be configured in your
-vimrc script [30] by including a line like this:
+vimrc script [31] by including a line like this:
 >
   let g:ycm_min_num_of_chars_for_completion = 1
 <
-Note that after changing an option in your vimrc script [30] you have to
+Note that after changing an option in your vimrc script [31] you have to
 restart Vim for the changes to take effect.
 
 -------------------------------------------------------------------------------
@@ -2011,7 +2013,7 @@ from the 'tagfiles()' Vim function which examines the 'tags' Vim option. See
 
 YCM will re-index your tags files if it detects that they have been modified.
 
-The only supported tag format is the Exuberant Ctags format [45]. The format
+The only supported tag format is the Exuberant Ctags format [46]. The format
 from "plain" ctags is NOT supported. Ctags needs to be called with the '--
 fields=+l' option (that's a lowercase 'L', not a one) because YCM needs the
 'language:<lang>' field in the tags output.
@@ -2378,7 +2380,7 @@ It's also possible to use a regular expression as a trigger. You have to prefix
 your trigger with 're!' to signify it's a regex trigger. For instance,
 're!\w+\.' would only trigger after the '\w+\.' regex matches.
 
-NOTE: The regex syntax is **NOT** Vim's, it's Python's [46].
+NOTE: The regex syntax is **NOT** Vim's, it's Python's [47].
 
 Default: '[see next line]'
 >
@@ -2575,7 +2577,7 @@ produced. See the full installation guide for help.
 I'm trying to use a Homebrew Vim with YCM and I'm getting segfaults ~
 
 Something (I don't know what) is wrong with the way that Homebrew configures
-and builds Vim. I recommend using MacVim [17]. Even if you don't like the
+and builds Vim. I recommend using MacVim [18]. Even if you don't like the
 MacVim GUI, you can use the Vim binary that is inside the MacVim.app package
 (it's 'MacVim.app/Contents/MacOS/Vim') and get the Vim console experience.
 
@@ -2585,7 +2587,7 @@ I have a Homebrew Python and/or MacVim; can't compile/SIGABRT when starting ~
 
 You should probably run 'brew rm python; brew install python' to get the latest
 fixes that should make YCM work with such a configuration. Also rebuild Macvim
-then. If you still get problems with this, see issue #18 [47] for suggestions.
+then. If you still get problems with this, see issue #18 [48] for suggestions.
 
 -------------------------------------------------------------------------------
       *youcompleteme-vim-segfaults-when-i-use-semantic-completer-in-ruby-files*
@@ -2670,15 +2672,15 @@ YCM does not read identifiers from my tags files ~
 
 First, put 'let g:ycm_collect_identifiers_from_tags_files = 1' in your vimrc.
 
-Make sure you are using Exuberant Ctags [48] to produce your tags files since
-the only supported tag format is the Exuberant Ctags format [45]. The format
+Make sure you are using Exuberant Ctags [49] to produce your tags files since
+the only supported tag format is the Exuberant Ctags format [46]. The format
 from "plain" ctags is NOT supported. The output of 'ctags --version' should
 list "Exuberant Ctags".
 
 Ctags needs to be called with the '--fields=+l' (that's a lowercase 'L', not a
 one) option because YCM needs the 'language:<lang>' field in the tags output.
 
-NOTE: Exuberant Ctags [48] by default sets language tag for '*.h' files as
+NOTE: Exuberant Ctags [49] by default sets language tag for '*.h' files as
 'C++'. If you have C (not C++) project, consider giving parameter '--
 langmap=c:.c.h' to ctags to see tags from '*.h' files.
 
@@ -2749,7 +2751,7 @@ and similar, then just update to Vim 7.4.314 (or later) and they'll go away.
                                                             *vim-sub-autoclose*
 Nasty bugs happen if I have the 'vim-autoclose' plugin installed ~
 
-Use the delimitMate [49] plugin instead. It does the same thing without
+Use the delimitMate [50] plugin instead. It does the same thing without
 conflicting with YCM.
 
 -------------------------------------------------------------------------------
@@ -2757,7 +2759,7 @@ conflicting with YCM.
 Is there some sort of YCM mailing list? I have questions ~
 
 If you have questions about the plugin or need help, please use the ycm-users
-[50] mailing list, _don't_ create issues on the tracker. The tracker is for bug
+[51] mailing list, _don't_ create issues on the tracker. The tracker is for bug
 reports and feature requests.
 
 -------------------------------------------------------------------------------
@@ -2811,7 +2813,7 @@ mismatch in assumptions causes performance problems since Syntastic code isn't
 optimized for this use case of constant diagnostic refreshing.
 
 Poor support for this use case also led to crash bugs in Vim caused by
-Syntastic-Vim interactions (issue #593 [51]) and other problems, like random
+Syntastic-Vim interactions (issue #593 [52]) and other problems, like random
 Vim flickering. Attempts were made to resolve these issues in Syntastic, but
 ultimately some of them failed (for various reasons).
 
@@ -2847,13 +2849,13 @@ paths, prepend '-isystem' to each individual path and append them all to the
 list of flags you return from your 'FlagsForFile' function in your
 '.ycm_extra_conf.py' file.
 
-See issue #303 [52] for details.
+See issue #303 [53] for details.
 
 -------------------------------------------------------------------------------
-                                  *youcompleteme-install-ycm-with-neobundle-53*
-Install YCM with NeoBundle [53] ~
+                                  *youcompleteme-install-ycm-with-neobundle-54*
+Install YCM with NeoBundle [54] ~
 
-NeoBundle [53] can do the compilation for you; just add the following to your
+NeoBundle [54] can do the compilation for you; just add the following to your
 vimrc:
 >
   NeoBundle 'Valloric/YouCompleteMe', {
@@ -2897,7 +2899,7 @@ When I start vim I get a runtime error saying 'R6034 An application has made ~
 an attempt to load the C runtime library incorrectly.' ~
 
 CMake and other things seem to screw up the PATH with their own msvcrXX.dll
-versions. [54] Add the following to the very top of your vimrc to remove these
+versions. [55] Add the following to the very top of your vimrc to remove these
 entries from the path.
 >
   python << EOF
@@ -2932,17 +2934,17 @@ that version of Python.
 Contributor Code of Conduct ~
 
 Please note that this project is released with a Contributor Code of Conduct
-[55]. By participating in this project you agree to abide by its terms.
+[56]. By participating in this project you agree to abide by its terms.
 
 ===============================================================================
                                                         *youcompleteme-contact*
 Contact ~
 
 If you have questions about the plugin or need help, please use the ycm-users
-[50] mailing list.
+[51] mailing list.
 
 If you have bug reports or feature suggestions, please use the issue tracker
-[56].
+[57].
 
 The latest version of the plugin is available at
 http://valloric.github.io/YouCompleteMe/.
@@ -2953,10 +2955,10 @@ The author's homepage is http://val.markovic.io.
                                                         *youcompleteme-license*
 License ~
 
-This software is licensed under the GPL v3 license [57]. © 2015 YouCompleteMe
+This software is licensed under the GPL v3 license [58]. © 2015 YouCompleteMe
 contributors
 
-  Image: Bitdeli Badge [58]
+  Image: Bitdeli Badge [59]
 
 ===============================================================================
                                                      *youcompleteme-references*
@@ -2971,55 +2973,56 @@ References ~
 [7] https://github.com/vheon/JediHTTP
 [8] https://github.com/OmniSharp/omnisharp-server
 [9] https://github.com/nsf/gocode
-[10] https://github.com/Microsoft/TypeScript/tree/master/src/server
-[11] http://ternjs.net
-[12] https://github.com/phildawes/racer
-[13] http://i.imgur.com/0OP4ood.gif
-[14] https://en.wikipedia.org/wiki/Subsequence
-[15] https://github.com/scrooloose/syntastic
-[16] https://github.com/SirVer/ultisnips/blob/master/doc/UltiSnips.txt
-[17] https://github.com/macvim-dev/macvim/releases
-[18] https://github.com/VundleVim/Vundle.vim#about
-[19] http://brew.sh
-[20] https://cmake.org/download/
-[21] https://docs.npmjs.com/getting-started/installing-node
-[22] https://www.rust-lang.org/
-[23] https://github.com/Valloric/YouCompleteMe/wiki/Building-Vim-from-source
-[24] https://bintray.com/veegee/generic/vim_x64
-[25] https://www.python.org/downloads/windows/
-[26] https://www.visualstudio.com/products/free-developer-offers-vs.aspx
-[27] http://www.7-zip.org/download.html
-[28] http://stackoverflow.com/questions/6319274/how-do-i-run-msbuild-from-the-command-line-using-windows-sdk-7-1
-[29] https://github.com/tpope/vim-pathogen#pathogenvim
-[30] http://vimhelp.appspot.com/starting.txt.html#vimrc
-[31] http://llvm.org/releases/download.html
-[32] https://github.com/Valloric/YouCompleteMe#options
-[33] https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py
-[34] http://clang.llvm.org/docs/JSONCompilationDatabase.html
-[35] https://github.com/rizsotto/Bear
-[36] https://github.com/rdnetto/YCM-Generator
-[37] http://ternjs.net/doc/manual.html#configuration
-[38] http://ternjs.net/doc/manual.html#server
-[39] http://ternjs.net/doc/manual.html#plugins
-[40] https://www.rust-lang.org/downloads.html
-[41] http://eclim.org/
-[42] https://github.com/Valloric/ycmd/blob/master/ycmd/completers/completer.py
-[43] https://github.com/Valloric/ListToggle
-[44] https://github.com/itchyny/lightline.vim
-[45] http://ctags.sourceforge.net/FORMAT
-[46] https://docs.python.org/2/library/re.html#regular-expression-syntax
-[47] https://github.com/Valloric/YouCompleteMe/issues/18
-[48] http://ctags.sourceforge.net/
-[49] https://github.com/Raimondi/delimitMate
-[50] https://groups.google.com/forum/?hl=en#!forum/ycm-users
-[51] https://github.com/Valloric/YouCompleteMe/issues/593
-[52] https://github.com/Valloric/YouCompleteMe/issues/303
-[53] https://github.com/Shougo/neobundle.vim
-[54] http://stackoverflow.com/questions/14552348/runtime-error-r6034-in-embedded-python-application/34696022
-[55] https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
-[56] https://github.com/Valloric/YouCompleteMe/issues?state=open
-[57] http://www.gnu.org/copyleft/gpl.html
-[58] https://bitdeli.com/free
-[59] https://d2weczhvl823v0.cloudfront.net/Valloric/youcompleteme/trend.png
+[10] https://github.com/Manishearth/godef
+[11] https://github.com/Microsoft/TypeScript/tree/master/src/server
+[12] http://ternjs.net
+[13] https://github.com/phildawes/racer
+[14] http://i.imgur.com/0OP4ood.gif
+[15] https://en.wikipedia.org/wiki/Subsequence
+[16] https://github.com/scrooloose/syntastic
+[17] https://github.com/SirVer/ultisnips/blob/master/doc/UltiSnips.txt
+[18] https://github.com/macvim-dev/macvim/releases
+[19] https://github.com/VundleVim/Vundle.vim#about
+[20] http://brew.sh
+[21] https://cmake.org/download/
+[22] https://docs.npmjs.com/getting-started/installing-node
+[23] https://www.rust-lang.org/
+[24] https://github.com/Valloric/YouCompleteMe/wiki/Building-Vim-from-source
+[25] https://bintray.com/veegee/generic/vim_x64
+[26] https://www.python.org/downloads/windows/
+[27] https://www.visualstudio.com/products/free-developer-offers-vs.aspx
+[28] http://www.7-zip.org/download.html
+[29] http://stackoverflow.com/questions/6319274/how-do-i-run-msbuild-from-the-command-line-using-windows-sdk-7-1
+[30] https://github.com/tpope/vim-pathogen#pathogenvim
+[31] http://vimhelp.appspot.com/starting.txt.html#vimrc
+[32] http://llvm.org/releases/download.html
+[33] https://github.com/Valloric/YouCompleteMe#options
+[34] https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py
+[35] http://clang.llvm.org/docs/JSONCompilationDatabase.html
+[36] https://github.com/rizsotto/Bear
+[37] https://github.com/rdnetto/YCM-Generator
+[38] http://ternjs.net/doc/manual.html#configuration
+[39] http://ternjs.net/doc/manual.html#server
+[40] http://ternjs.net/doc/manual.html#plugins
+[41] https://www.rust-lang.org/downloads.html
+[42] http://eclim.org/
+[43] https://github.com/Valloric/ycmd/blob/master/ycmd/completers/completer.py
+[44] https://github.com/Valloric/ListToggle
+[45] https://github.com/itchyny/lightline.vim
+[46] http://ctags.sourceforge.net/FORMAT
+[47] https://docs.python.org/2/library/re.html#regular-expression-syntax
+[48] https://github.com/Valloric/YouCompleteMe/issues/18
+[49] http://ctags.sourceforge.net/
+[50] https://github.com/Raimondi/delimitMate
+[51] https://groups.google.com/forum/?hl=en#!forum/ycm-users
+[52] https://github.com/Valloric/YouCompleteMe/issues/593
+[53] https://github.com/Valloric/YouCompleteMe/issues/303
+[54] https://github.com/Shougo/neobundle.vim
+[55] http://stackoverflow.com/questions/14552348/runtime-error-r6034-in-embedded-python-application/34696022
+[56] https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
+[57] https://github.com/Valloric/YouCompleteMe/issues?state=open
+[58] http://www.gnu.org/copyleft/gpl.html
+[59] https://bitdeli.com/free
+[60] https://d2weczhvl823v0.cloudfront.net/Valloric/youcompleteme/trend.png
 
 vim: ft=help


### PR DESCRIPTION
This also updates to latest ycmd. Changes that affect the client:
 - update racerd;
 - add GoTo support for Go completer;
 - add concurrent requests for Typescript completer;
 - fix issue #1953;
 - add GoToReferences support for Typescript completer.

I changed the filetypes lists to be in alphabetical order, except the C-family languages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1965)
<!-- Reviewable:end -->
