### PR TITLE
[READY] Add links to ycmd repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,9 +735,9 @@ outputs and presents the results to you.
 ### Client-server architecture
 
 YCM has a client-server architecture; the Vim part of YCM is only a thin client
-that talks to the `ycmd` HTTP+JSON server that has the vast majority of YCM
-logic and functionality. The server is started and stopped automatically as you
-start and stop Vim.
+that talks to the [ycmd HTTP+JSON server][ycmd] that has the vast majority of
+YCM logic and functionality. The server is started and stopped automatically as
+you start and stop Vim.
 
 ### Completion string ranking
 
@@ -831,7 +831,7 @@ JavaScript project, you can do one of the following:
 
 - start a new instance of Vim from the new project's directory
 - change Vim's working directory (`:cd /path/to/new/project`) and restart the
-  `ycmd` server (`:YcmRestartServer`)
+  [ycmd server][ycmd] (`:YcmRestartServer`)
 - change Vim's working directory (`:cd /path/to/new/project`), open a JavaScript
   file (or set filetype to JavaScript) and restart the Tern server using YCM
   completer subcommands `:YcmCompleter StopServer` and `:YcmCompleter
@@ -915,9 +915,9 @@ Completion and GoTo commands work out of the box with no additional
 configuration. Those features are provided by the [jedi][] library which
 supports a variety of python versions (2.6, 2.7, 3.2, 3.3 or 3.4) as long as it
 runs in the corresponding python interpreter. By default YCM runs [jedi][] with
-the same python interpreter used by [ycmd][], so if you would like to use a
-different interpreter, use the following option specifying the python binary to
-use. For example, to provide Python 3 completion in your project, set:
+the same python interpreter used by the [ycmd server][ycmd], so if you would like to
+use a different interpreter, use the following option specifying the python
+binary to use. For example, to provide Python 3 completion in your project, set:
 
 ```viml
 let g:ycm_python_binary_path = '/usr/bin/python3'
@@ -1054,8 +1054,8 @@ Commands
 
 ### The `:YcmRestartServer` command
 
-If the `ycmd` completion server suddenly stops for some reason, you can restart
-it with this command.
+If the [ycmd completion server][ycmd] suddenly stops for some reason, you can
+restart it with this command.
 
 ### The `:YcmForceCompileAndDiagnostics` command
 
@@ -1098,10 +1098,11 @@ completion engine.
 ### The `:YcmToggleLogs` command
 
 This command automatically opens in windows the stdout and stderr logfiles
-written by the `ycmd` server. If one or both logfiles are already opened, they
-are automatically closed. `stderr` or `stdout` can be specified as an argument
-of this command to only open the corresponding logfile instead of both. If this
-logfile is already opened, it will be closed. Only for debugging purpose.
+written by the [ycmd server][ycmd]. If one or both logfiles are already opened,
+they are automatically closed. `stderr` or `stdout` can be specified as an
+argument of this command to only open the corresponding logfile instead of both.
+If this logfile is already opened, it will be closed. Only for debugging
+purpose.
 
 ### The `:YcmCompleter` command
 
@@ -1781,7 +1782,7 @@ handy; it's a way of sending data from Vim to your `FlagsForFile` function in
 your `.ycm_extra_conf.py` file.
 
 This option is supposed to be a list of VimScript expression strings that are
-evaluated for every request to the `ycmd` server and then passed to your
+evaluated for every request to the [ycmd server][ycmd] and then passed to your
 `FlagsForFile` function as a `client_data` keyword argument.
 
 For instance, if you set this option to `['v:version']`, your `FlagsForFile`
@@ -1815,7 +1816,7 @@ YCM will by default search for an appropriate Python interpreter on your system.
 You can use this option to override that behavior and force the use of a
 specific interpreter of your choosing.
 
-NOTE: This interpreter is only used for the `ycmd` server. The YCM client
+NOTE: This interpreter is only used for the [ycmd server][ycmd]. The YCM client
 running inside Vim always uses the Python interpreter that's embedded inside
 Vim.
 
@@ -1827,7 +1828,7 @@ let g:ycm_path_to_python_interpreter = ''
 
 ### The `g:ycm_server_keep_logfiles` option
 
-When this option is set to `1`, the `ycmd` completion server will keep the
+When this option is set to `1`, the [ycmd completion server][ycmd] will keep the
 logfiles around after shutting down (they are deleted on shutdown by default).
 
 To see where the logfiles are, call `:YcmDebugInfo`.
@@ -1840,8 +1841,8 @@ let g:ycm_server_keep_logfiles = 0
 
 ### The `g:ycm_server_log_level` option
 
-The logging level that the `ycmd` completion server uses. Valid values are the
-following, from most verbose to least verbose:
+The logging level that the [ycmd completion server][ycmd] uses. Valid values are
+the following, from most verbose to least verbose:
 - `debug`
 - `info`
 - `warning`
@@ -2229,7 +2230,7 @@ FAQ
 ### I used to be able to `import vim` in `.ycm_extra_conf.py`, but now can't
 
 YCM was rewritten to use a client-server architecture where most of the logic is
-in the `ycmd` server. So the magic `vim` module you could have previously
+in the [ycmd server][ycmd]. So the magic `vim` module you could have previously
 imported in your `.ycm_extra_conf.py` files doesn't exist anymore.
 
 To be fair, importing the magic `vim` module in extra conf files was never
@@ -2277,7 +2278,7 @@ the message log if it encounters problems. It's likely you misconfigured
 something and YCM is complaining about it.
 
 Also, you may want to run the `:YcmDebugInfo` command; it will make YCM spew out
-various debugging information, including the `ycmd` logfile paths and the
+various debugging information, including the [ycmd][] logfile paths and the
 compile flags for the current file if the file is a C-family language file and
 you have compiled in Clang support. Logfiles can be automatically opened in the
 editor using the `:YcmToggleLogs` command.
@@ -2639,9 +2640,9 @@ EOF
 
 ### I hear that YCM only supports Python 2, is that true?
 
-No. The Vim client and the [ycmd][] server only run under Python 2 but if you
-work on a Python 3 project then just set the `g:ycm_python_binary_path` to the
-Python interpreter you use for your project and you will get completions for
+No. The Vim client and the [ycmd server][ycmd] only run under Python 2 but if
+you work on a Python 3 project then just set the `g:ycm_python_binary_path` to
+the Python interpreter you use for your project and you will get completions for
 that version of Python.
 
 Contributor Code of Conduct
@@ -2675,6 +2676,7 @@ This software is licensed under the [GPL v3 license][gpl].
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/Valloric/youcompleteme/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
+[ycmd]: https://github.com/Valloric/ycmd
 [Clang]: http://clang.llvm.org/
 [vundle]: https://github.com/VundleVim/Vundle.vim#about
 [pathogen]: https://github.com/tpope/vim-pathogen#pathogenvim

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -143,7 +143,7 @@ Contents ~
   25. I get weird errors when I press 'Ctrl-C' in Vim              |Ctrl-sub-C|
   26. Why did YCM stop using Syntastic for diagnostics display? |youcompleteme-why-did-ycm-stop-using-syntastic-for-diagnostics-display|
   27. Completion doesn't work with the C++ standard library headers |youcompleteme-completion-doesnt-work-with-c-standard-library-headers|
-  28. Install YCM with NeoBundle [54] |youcompleteme-install-ycm-with-neobundle-54|
+  28. Install YCM with NeoBundle [55] |youcompleteme-install-ycm-with-neobundle-55|
   29. When I open a JavaScript file, I get an annoying warning about '.tern-project'
 file |.tern-sub-project|
   30. When I run install.py I get a LINK error saying "fatal error LNK1104: cannot
@@ -974,7 +974,7 @@ and presents the results to you.
 Client-server architecture ~
 
 YCM has a client-server architecture; the Vim part of YCM is only a thin client
-that talks to the 'ycmd' HTTP+JSON server that has the vast majority of YCM
+that talks to the ycmd HTTP+JSON server [34] that has the vast majority of YCM
 logic and functionality. The server is started and stopped automatically as you
 start and stop Vim.
 
@@ -1018,20 +1018,20 @@ This system was designed this way so that the user can perform any arbitrary
 sequence of operations to produce a list of compilation flags YCM should hand
 to Clang.
 
-See YCM's own '.ycm_extra_conf.py' [34] for details on how this works. You
+See YCM's own '.ycm_extra_conf.py' [35] for details on how this works. You
 should be able to use it _as a starting point_. **Don't** just copy/paste that
 file somewhere and expect things to magically work; **your project needs
 different flags**. Hint: just replace the strings in the 'flags' variable with
 compilation flags necessary for your project. That should be enough for 99% of
 projects.
 
-Yes, Clang's 'CompilationDatabase' system [35] is also supported. Again, see
+Yes, Clang's 'CompilationDatabase' system [36] is also supported. Again, see
 the above linked example file. You can get CMake to generate this file for you
 by adding 'set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )' to your project's
 'CMakeLists.txt' file (if using CMake). If you're not using CMake, you could
-use something like Bear [36] to generate the 'compile_commands.json' file.
+use something like Bear [37] to generate the 'compile_commands.json' file.
 
-Consider using YCM-Generator [37] to generate the 'ycm_extra_conf.py' file.
+Consider using YCM-Generator [38] to generate the 'ycm_extra_conf.py' file.
 
 If Clang encounters errors when compiling the header files that your file
 includes, then it's probably going to take a long time to get completions. When
@@ -1056,7 +1056,7 @@ Quick start ~
    guide for details.
 
 2. Create a '.tern-project' file in the root directory of your JavaScript
-   project, by following the instructions [38] in the Tern [12]
+   project, by following the instructions [39] in the Tern [12]
    documentation.
 
 3. Make sure that Vim's working directory is a descendent of that directory
@@ -1067,13 +1067,13 @@ Quick start ~
 Explanation ~
 
 JavaScript completion is based on Tern [12]. This completion engine requires a
-file named '.tern-project' [38] to exist in the current working directory or a
+file named '.tern-project' [39] to exist in the current working directory or a
 directory which is an ancestor of the current working directory when the tern
 server is started. YCM starts the Tern server the first time a JavaScript file
 is edited, so Vim's working directory at that time needs to be a descendent of
 the directory containing the '.tern-project' file (or that directory itself).
 
-Alternatively, as described in the Tern documentation [39], a global '.tern-
+Alternatively, as described in the Tern documentation [40], a global '.tern-
 config' file may be used.
 
 Multiple Tern servers, are not supported. To switch to a different JavaScript
@@ -1082,7 +1082,7 @@ project, you can do one of the following:
 - start a new instance of Vim from the new project's directory
 
 - change Vim's working directory (':cd /path/to/new/project') and restart the
-  'ycmd' server (|:YcmRestartServer|)
+  ycmd server [34] (|:YcmRestartServer|)
 
 - change Vim's working directory (':cd /path/to/new/project'), open a
   JavaScript file (or set filetype to JavaScript) and restart the Tern server
@@ -1095,9 +1095,9 @@ Tips and tricks ~
 
 This section contains some advice for configuring '.tern-project' and working
 with JavaScript files. The canonical reference for correctly configuring Tern
-is the Tern documentation [39]. Any issues, improvements, advice, etc. should
+is the Tern documentation [40]. Any issues, improvements, advice, etc. should
 be sought from the Tern [12] project. For example, see the list of tern plugins
-[40] for the list of plugins which can be enabled in the 'plugins' section of
+[41] for the list of plugins which can be enabled in the 'plugins' section of
 the '.tern-project' file.
 
 -------------------------------------------------------------------------------
@@ -1149,7 +1149,7 @@ Completions and GoTo commands within the current crate and its dependencies
 should work out of the box with no additional configuration (provided that you
 built YCM with the '--racer-completer' flag; see the _Installation_ section for
 details). For semantic analysis inclusive of the standard library, you must
-have a local copy of the rust source code [41]. You also need to set the
+have a local copy of the rust source code [42]. You also need to set the
 following option so YouCompleteMe can locate it.
 >
   " In this example, the rust source code zip has been extracted to
@@ -1164,9 +1164,10 @@ Completion and GoTo commands work out of the box with no additional
 configuration. Those features are provided by the jedi [6] library which
 supports a variety of python versions (2.6, 2.7, 3.2, 3.3 or 3.4) as long as it
 runs in the corresponding python interpreter. By default YCM runs jedi [6] with
-the same python interpreter used by [ycmd][], so if you would like to use a
-different interpreter, use the following option specifying the python binary to
-use. For example, to provide Python 3 completion in your project, set:
+the same python interpreter used by the ycmd server [34], so if you would like
+to use a different interpreter, use the following option specifying the python
+binary to use. For example, to provide Python 3 completion in your project,
+set:
 >
   let g:ycm_python_binary_path = '/usr/bin/python3'
 <
@@ -1184,7 +1185,7 @@ semantic completions if it does not have a native semantic completion engine
 for your file's filetype. Vim comes with okayish omnifuncs for various
 languages like Ruby, PHP etc. It depends on the language.
 
-You can get stellar omnifuncs for Java and Ruby with Eclim [42]. Just make sure
+You can get stellar omnifuncs for Java and Ruby with Eclim [43]. Just make sure
 you have the _latest_ Eclim installed and configured (this means Eclim '>=
 2.2.*' and Eclipse '>= 4.2.*').
 
@@ -1202,7 +1203,7 @@ Writing New Semantic Completers ~
 
 You have two options here: writing an 'omnifunc' for Vim's omnicomplete system
 that YCM will then use through its omni-completer, or a custom completer for
-YCM using the Completer API [43].
+YCM using the Completer API [44].
 
 Here are the differences between the two approaches:
 
@@ -1221,7 +1222,7 @@ Here are the differences between the two approaches:
   than VimScript.
 
 If you want to use the 'omnifunc' system, see the relevant Vim docs with ':h
-complete-functions'. For the Completer API, see the API docs [43].
+complete-functions'. For the Completer API, see the API docs [44].
 
 If you want to upstream your completer into YCM's source, you should use the
 Completer API.
@@ -1272,7 +1273,7 @@ current file in Vim's 'locationlist', which can be opened with the ':lopen' and
 ':lclose' commands (make sure you have set 'let
 g:ycm_always_populate_location_list = 1' in your vimrc). A good way to toggle
 the display of the 'locationlist' with a single key mapping is provided by
-another (very small) Vim plugin called ListToggle [44] (which also makes it
+another (very small) Vim plugin called ListToggle [45] (which also makes it
 possible to change the height of the 'locationlist' window), also written by
 yours truly.
 
@@ -1314,8 +1315,8 @@ Commands ~
 -------------------------------------------------------------------------------
 The *:YcmRestartServer* command
 
-If the 'ycmd' completion server suddenly stops for some reason, you can restart
-it with this command.
+If the ycmd completion server [34] suddenly stops for some reason, you can
+restart it with this command.
 
 -------------------------------------------------------------------------------
 The *:YcmForceCompileAndDiagnostics* command
@@ -1362,10 +1363,11 @@ semantic completion engine.
 The *:YcmToggleLogs* command
 
 This command automatically opens in windows the stdout and stderr logfiles
-written by the 'ycmd' server. If one or both logfiles are already opened, they
-are automatically closed. 'stderr' or 'stdout' can be specified as an argument
-of this command to only open the corresponding logfile instead of both. If this
-logfile is already opened, it will be closed. Only for debugging purpose.
+written by the ycmd server [34]. If one or both logfiles are already opened,
+they are automatically closed. 'stderr' or 'stdout' can be specified as an
+argument of this command to only open the corresponding logfile instead of
+both. If this logfile is already opened, it will be closed. Only for debugging
+purpose.
 
 -------------------------------------------------------------------------------
 The *:YcmCompleter* command
@@ -1654,7 +1656,7 @@ For example:
   call youcompleteme#GetErrorCount()
 <
 Both this function and |youcompleteme#GetWarningCount| can be useful when
-integrating YCM with other Vim plugins. For example, a lightline [45] user
+integrating YCM with other Vim plugins. For example, a lightline [46] user
 could add a diagnostics section to their statusline which would display the
 number of errors and warnings.
 
@@ -1999,7 +2001,7 @@ from the 'tagfiles()' Vim function which examines the 'tags' Vim option. See
 
 YCM will re-index your tags files if it detects that they have been modified.
 
-The only supported tag format is the Exuberant Ctags format [46]. The format
+The only supported tag format is the Exuberant Ctags format [47]. The format
 from "plain" ctags is NOT supported. Ctags needs to be called with the '--
 fields=+l' option (that's a lowercase 'L', not a one) because YCM needs the
 'language:<lang>' field in the tags output.
@@ -2036,7 +2038,7 @@ handy; it's a way of sending data from Vim to your 'FlagsForFile' function in
 your '.ycm_extra_conf.py' file.
 
 This option is supposed to be a list of VimScript expression strings that are
-evaluated for every request to the 'ycmd' server and then passed to your
+evaluated for every request to the ycmd server [34] and then passed to your
 'FlagsForFile' function as a 'client_data' keyword argument.
 
 For instance, if you set this option to "['v:version']", your 'FlagsForFile'
@@ -2065,7 +2067,7 @@ YCM will by default search for an appropriate Python interpreter on your
 system. You can use this option to override that behavior and force the use of
 a specific interpreter of your choosing.
 
-NOTE: This interpreter is only used for the 'ycmd' server. The YCM client
+NOTE: This interpreter is only used for the ycmd server [34]. The YCM client
 running inside Vim always uses the Python interpreter that's embedded inside
 Vim.
 
@@ -2076,7 +2078,7 @@ Default: "''"
 -------------------------------------------------------------------------------
 The *g:ycm_server_keep_logfiles* option
 
-When this option is set to '1', the 'ycmd' completion server will keep the
+When this option is set to '1', the ycmd completion server [34] will keep the
 logfiles around after shutting down (they are deleted on shutdown by default).
 
 To see where the logfiles are, call |:YcmDebugInfo|.
@@ -2088,9 +2090,9 @@ Default: '0'
 -------------------------------------------------------------------------------
 The *g:ycm_server_log_level* option
 
-The logging level that the 'ycmd' completion server uses. Valid values are the
-following, from most verbose to least verbose: - 'debug' - 'info' - 'warning' -
-'error' - 'critical'
+The logging level that the ycmd completion server [34] uses. Valid values are
+the following, from most verbose to least verbose: - 'debug' - 'info' -
+'warning' - 'error' - 'critical'
 
 Note that 'debug' is _very_ verbose.
 
@@ -2366,7 +2368,7 @@ It's also possible to use a regular expression as a trigger. You have to prefix
 your trigger with 're!' to signify it's a regex trigger. For instance,
 're!\w+\.' would only trigger after the '\w+\.' regex matches.
 
-NOTE: The regex syntax is **NOT** Vim's, it's Python's [47].
+NOTE: The regex syntax is **NOT** Vim's, it's Python's [48].
 
 Default: '[see next line]'
 >
@@ -2436,7 +2438,7 @@ The *g:ycm_python_binary_path* option
 
 This option specifies the Python interpreter to use to run the jedi [6]
 completion library. Specify the python interpreter to use to get completions.
-By default the python under which [ycmd][] runs is used ([ycmd][] only runs
+By default the python under which ycmd [34] runs is used (ycmd [34] only runs
 under Python 2.6 or 2.7).
 
 Default: "''"
@@ -2452,7 +2454,7 @@ FAQ ~
 I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't ~
 
 YCM was rewritten to use a client-server architecture where most of the logic
-is in the 'ycmd' server. So the magic 'vim' module you could have previously
+is in the ycmd server [34]. So the magic 'vim' module you could have previously
 imported in your '.ycm_extra_conf.py' files doesn't exist anymore.
 
 To be fair, importing the magic 'vim' module in extra conf files was never
@@ -2508,10 +2510,10 @@ to the message log if it encounters problems. It's likely you misconfigured
 something and YCM is complaining about it.
 
 Also, you may want to run the |:YcmDebugInfo| command; it will make YCM spew
-out various debugging information, including the 'ycmd' logfile paths and the
-compile flags for the current file if the file is a C-family language file and
-you have compiled in Clang support. Logfiles can be automatically opened in the
-editor using the |:YcmToggleLogs| command.
+out various debugging information, including the ycmd [34] logfile paths and
+the compile flags for the current file if the file is a C-family language file
+and you have compiled in Clang support. Logfiles can be automatically opened in
+the editor using the |:YcmToggleLogs| command.
 
 -------------------------------------------------------------------------------
 *youcompleteme-sometimes-it-takes-much-longer-to-get-semantic-completions-than-normal*
@@ -2573,7 +2575,7 @@ I have a Homebrew Python and/or MacVim; can't compile/SIGABRT when starting ~
 
 You should probably run 'brew rm python; brew install python' to get the latest
 fixes that should make YCM work with such a configuration. Also rebuild Macvim
-then. If you still get problems with this, see issue #18 [48] for suggestions.
+then. If you still get problems with this, see issue #18 [49] for suggestions.
 
 -------------------------------------------------------------------------------
       *youcompleteme-vim-segfaults-when-i-use-semantic-completer-in-ruby-files*
@@ -2658,15 +2660,15 @@ YCM does not read identifiers from my tags files ~
 
 First, put 'let g:ycm_collect_identifiers_from_tags_files = 1' in your vimrc.
 
-Make sure you are using Exuberant Ctags [49] to produce your tags files since
-the only supported tag format is the Exuberant Ctags format [46]. The format
+Make sure you are using Exuberant Ctags [50] to produce your tags files since
+the only supported tag format is the Exuberant Ctags format [47]. The format
 from "plain" ctags is NOT supported. The output of 'ctags --version' should
 list "Exuberant Ctags".
 
 Ctags needs to be called with the '--fields=+l' (that's a lowercase 'L', not a
 one) option because YCM needs the 'language:<lang>' field in the tags output.
 
-NOTE: Exuberant Ctags [49] by default sets language tag for '*.h' files as
+NOTE: Exuberant Ctags [50] by default sets language tag for '*.h' files as
 'C++'. If you have C (not C++) project, consider giving parameter '--
 langmap=c:.c.h' to ctags to see tags from '*.h' files.
 
@@ -2737,7 +2739,7 @@ and similar, then just update to Vim 7.4.314 (or later) and they'll go away.
                                                             *vim-sub-autoclose*
 Nasty bugs happen if I have the 'vim-autoclose' plugin installed ~
 
-Use the delimitMate [50] plugin instead. It does the same thing without
+Use the delimitMate [51] plugin instead. It does the same thing without
 conflicting with YCM.
 
 -------------------------------------------------------------------------------
@@ -2745,7 +2747,7 @@ conflicting with YCM.
 Is there some sort of YCM mailing list? I have questions ~
 
 If you have questions about the plugin or need help, please use the ycm-users
-[51] mailing list, _don't_ create issues on the tracker. The tracker is for bug
+[52] mailing list, _don't_ create issues on the tracker. The tracker is for bug
 reports and feature requests.
 
 -------------------------------------------------------------------------------
@@ -2799,7 +2801,7 @@ mismatch in assumptions causes performance problems since Syntastic code isn't
 optimized for this use case of constant diagnostic refreshing.
 
 Poor support for this use case also led to crash bugs in Vim caused by
-Syntastic-Vim interactions (issue #593 [52]) and other problems, like random
+Syntastic-Vim interactions (issue #593 [53]) and other problems, like random
 Vim flickering. Attempts were made to resolve these issues in Syntastic, but
 ultimately some of them failed (for various reasons).
 
@@ -2835,13 +2837,13 @@ paths, prepend '-isystem' to each individual path and append them all to the
 list of flags you return from your 'FlagsForFile' function in your
 '.ycm_extra_conf.py' file.
 
-See issue #303 [53] for details.
+See issue #303 [54] for details.
 
 -------------------------------------------------------------------------------
-                                  *youcompleteme-install-ycm-with-neobundle-54*
-Install YCM with NeoBundle [54] ~
+                                  *youcompleteme-install-ycm-with-neobundle-55*
+Install YCM with NeoBundle [55] ~
 
-NeoBundle [54] can do the compilation for you; just add the following to your
+NeoBundle [55] can do the compilation for you; just add the following to your
 vimrc:
 >
   NeoBundle 'Valloric/YouCompleteMe', {
@@ -2885,7 +2887,7 @@ When I start vim I get a runtime error saying 'R6034 An application has made ~
 an attempt to load the C runtime library incorrectly.' ~
 
 CMake and other things seem to screw up the PATH with their own msvcrXX.dll
-versions. [55] Add the following to the very top of your vimrc to remove these
+versions. [56] Add the following to the very top of your vimrc to remove these
 entries from the path.
 >
   python << EOF
@@ -2910,7 +2912,7 @@ entries from the path.
             *youcompleteme-i-hear-that-ycm-only-supports-python-2-is-that-true*
 I hear that YCM only supports Python 2, is that true? ~
 
-No. The Vim client and the [ycmd][] server only run under Python 2 but if you
+No. The Vim client and the ycmd server [34] only run under Python 2 but if you
 work on a Python 3 project then just set the |g:ycm_python_binary_path| to the
 Python interpreter you use for your project and you will get completions for
 that version of Python.
@@ -2920,17 +2922,17 @@ that version of Python.
 Contributor Code of Conduct ~
 
 Please note that this project is released with a Contributor Code of Conduct
-[56]. By participating in this project you agree to abide by its terms.
+[57]. By participating in this project you agree to abide by its terms.
 
 ===============================================================================
                                                         *youcompleteme-contact*
 Contact ~
 
 If you have questions about the plugin or need help, please use the ycm-users
-[51] mailing list.
+[52] mailing list.
 
 If you have bug reports or feature suggestions, please use the issue tracker
-[57].
+[58].
 
 The latest version of the plugin is available at
 http://valloric.github.io/YouCompleteMe/.
@@ -2941,10 +2943,10 @@ The author's homepage is http://val.markovic.io.
                                                         *youcompleteme-license*
 License ~
 
-This software is licensed under the GPL v3 license [58]. © 2015 YouCompleteMe
+This software is licensed under the GPL v3 license [59]. © 2015 YouCompleteMe
 contributors
 
-  Image: Bitdeli Badge [59]
+  Image: Bitdeli Badge [60]
 
 ===============================================================================
                                                      *youcompleteme-references*
@@ -2983,32 +2985,33 @@ References ~
 [31] http://vimhelp.appspot.com/starting.txt.html#vimrc
 [32] http://llvm.org/releases/download.html
 [33] https://github.com/Valloric/YouCompleteMe#options
-[34] https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py
-[35] http://clang.llvm.org/docs/JSONCompilationDatabase.html
-[36] https://github.com/rizsotto/Bear
-[37] https://github.com/rdnetto/YCM-Generator
-[38] http://ternjs.net/doc/manual.html#configuration
-[39] http://ternjs.net/doc/manual.html#server
-[40] http://ternjs.net/doc/manual.html#plugins
-[41] https://www.rust-lang.org/downloads.html
-[42] http://eclim.org/
-[43] https://github.com/Valloric/ycmd/blob/master/ycmd/completers/completer.py
-[44] https://github.com/Valloric/ListToggle
-[45] https://github.com/itchyny/lightline.vim
-[46] http://ctags.sourceforge.net/FORMAT
-[47] https://docs.python.org/2/library/re.html#regular-expression-syntax
-[48] https://github.com/Valloric/YouCompleteMe/issues/18
-[49] http://ctags.sourceforge.net/
-[50] https://github.com/Raimondi/delimitMate
-[51] https://groups.google.com/forum/?hl=en#!forum/ycm-users
-[52] https://github.com/Valloric/YouCompleteMe/issues/593
-[53] https://github.com/Valloric/YouCompleteMe/issues/303
-[54] https://github.com/Shougo/neobundle.vim
-[55] http://stackoverflow.com/questions/14552348/runtime-error-r6034-in-embedded-python-application/34696022
-[56] https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
-[57] https://github.com/Valloric/YouCompleteMe/issues?state=open
-[58] http://www.gnu.org/copyleft/gpl.html
-[59] https://bitdeli.com/free
-[60] https://d2weczhvl823v0.cloudfront.net/Valloric/youcompleteme/trend.png
+[34] https://github.com/Valloric/ycmd
+[35] https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py
+[36] http://clang.llvm.org/docs/JSONCompilationDatabase.html
+[37] https://github.com/rizsotto/Bear
+[38] https://github.com/rdnetto/YCM-Generator
+[39] http://ternjs.net/doc/manual.html#configuration
+[40] http://ternjs.net/doc/manual.html#server
+[41] http://ternjs.net/doc/manual.html#plugins
+[42] https://www.rust-lang.org/downloads.html
+[43] http://eclim.org/
+[44] https://github.com/Valloric/ycmd/blob/master/ycmd/completers/completer.py
+[45] https://github.com/Valloric/ListToggle
+[46] https://github.com/itchyny/lightline.vim
+[47] http://ctags.sourceforge.net/FORMAT
+[48] https://docs.python.org/2/library/re.html#regular-expression-syntax
+[49] https://github.com/Valloric/YouCompleteMe/issues/18
+[50] http://ctags.sourceforge.net/
+[51] https://github.com/Raimondi/delimitMate
+[52] https://groups.google.com/forum/?hl=en#!forum/ycm-users
+[53] https://github.com/Valloric/YouCompleteMe/issues/593
+[54] https://github.com/Valloric/YouCompleteMe/issues/303
+[55] https://github.com/Shougo/neobundle.vim
+[56] http://stackoverflow.com/questions/14552348/runtime-error-r6034-in-embedded-python-application/34696022
+[57] https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
+[58] https://github.com/Valloric/YouCompleteMe/issues?state=open
+[59] http://www.gnu.org/copyleft/gpl.html
+[60] https://bitdeli.com/free
+[61] https://d2weczhvl823v0.cloudfront.net/Valloric/youcompleteme/trend.png
 
 vim: ft=help


### PR DESCRIPTION
Found this while reading the documentation. There is no `ycmd` reference so it is displayed as `[ycmd][]`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1990)
<!-- Reviewable:end -->
