### PR TITLE
[READY] Rewrite SetUpPython function

### DIFF
--- a/python/ycm/paths.py
+++ b/python/ycm/paths.py
@@ -20,9 +20,10 @@ import sys
 import vim
 import functools
 import re
-from ycmd import utils
 
 DIR_OF_CURRENT_SCRIPT = os.path.dirname( os.path.abspath( __file__ ) )
+DIR_OF_YCMD = os.path.join( DIR_OF_CURRENT_SCRIPT, '..', '..', 'third_party',
+                            'ycmd' )
 
 WIN_PYTHON_PATH = os.path.join( sys.exec_prefix, 'python.exe' )
 PYTHON_BINARY_REGEX = re.compile( r'python(2(\.[67])?)?(.exe)?$' )
@@ -42,6 +43,8 @@ def Memoize( obj ):
 
 @Memoize
 def PathToPythonInterpreter():
+  from ycmd import utils
+
   python_interpreter = vim.eval( 'g:ycm_path_to_python_interpreter' )
 
   if python_interpreter:
@@ -82,6 +85,8 @@ def EndsWithPython( path ):
 
 def IsPythonVersionCorrect( path ):
   """Check if given path is the Python interpreter version 2.6 or 2.7."""
+  from ycmd import utils
+
   if not EndsWithPython( path ):
     return False
 
@@ -95,10 +100,8 @@ def IsPythonVersionCorrect( path ):
 
 
 def PathToServerScript():
-  return os.path.join( DIR_OF_CURRENT_SCRIPT, '..', '..', 'third_party',
-                       'ycmd', 'ycmd' )
+  return os.path.join( DIR_OF_YCMD, 'ycmd' )
 
 
 def PathToCheckCoreVersion():
-  return os.path.join( DIR_OF_CURRENT_SCRIPT, '..', '..', 'third_party',
-                       'ycmd', 'check_core_version.py' )
+  return os.path.join( DIR_OF_YCMD, 'check_core_version.py' )

--- a/python/ycm/setup.py
+++ b/python/ycm/setup.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2016 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import os
+import paths
+
+
+def SetUpSystemPaths():
+  sys.path.insert( 0, os.path.join( paths.DIR_OF_YCMD ) )
+
+  from ycmd import server_utils as su
+  su.AddNearestThirdPartyFoldersToSysPath( paths.DIR_OF_CURRENT_SCRIPT )
+  # We need to import ycmd's third_party folders as well since we import and
+  # use ycmd code in the client.
+  su.AddNearestThirdPartyFoldersToSysPath( su.__file__ )
+
+
+def SetUpYCM():
+  import base
+  from ycmd import user_options_store, utils
+  from youcompleteme import YouCompleteMe
+
+  base.LoadJsonDefaultsIntoVim()
+
+  user_options_store.SetAll( base.BuildServerConf() )
+
+  popen_args = [ paths.PathToPythonInterpreter(),
+                 paths.PathToCheckCoreVersion() ]
+
+  if utils.SafePopen( popen_args ).wait() == 2:
+    raise RuntimeError( 'YCM support libs too old, PLEASE RECOMPILE.' )
+
+  return YouCompleteMe( user_options_store.GetAll() )


### PR DESCRIPTION
This PR fixes issue #1726 by moving most of SetUpPython logic to its own module and using a try-catch-else block at the end of the function. It also prevents Python backtraces in Vim (which are really annoying) for common exceptions (`RuntimeError` and `ImportError`).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/1994)
<!-- Reviewable:end -->
