### PR TITLE
[READY] Templates for new issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+# Issue Prelude
+
+**Please complete these steps and check these boxes (by putting an `x` inside
+the brackets) _before_ filing your issue:**
+
+- [ ] I have read and understood YCM's [CONTRIBUTING][cont] document.
+- [ ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
+- [ ] I have read and understood YCM's [README][readme], **especially the
+  [Frequently Asked Questions][faq] section.**
+- [ ] I have searched YCM's issue tracker to find issues similar to the one I'm
+  about to report and couldn't find an answer to my problem. ([Example Google
+  search.][search])
+- [ ] If filing a bug report, I have included the output of `vim --version`.
+- [ ] If filing a bug report, I have included the output of `:YcmDebugInfo`.
+- [ ] If filing a bug report, I have included the output of
+  `:YcmToggleLogs stderr`.
+- [ ] If filing a bug report, I have included which OS (including specific OS
+  version) I am using.
+- [ ] If filing a bug report, I have included a minimal test case that reproduces
+  my issue.
+- [ ] **I understand this is an open-source project staffed by volunteers and
+  that any help I receive is a selfless, heartfelt _gift_ of their free time. I
+  know I am not entitled to anything and will be polite and courteous.**
+- [ ] **I understand my issue may be closed if it becomes obvious I didn't
+  actually perform all of these steps.**
+
+Thank you for adhering to this process! It ensures your issue is resolved
+quickly and that neither your nor our time is needlessly wasted.
+
+# Issue Details
+
+[If filing a bug report, please include **a list of steps** that describe how to
+reproduce the bug you are experiencing. Also include test code if relevant.]
+
+[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
+[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
+[readme]: https://github.com/Valloric/YouCompleteMe/blob/master/README.md
+[faq]: https://github.com/Valloric/YouCompleteMe/blob/master/README.md#faq
+[search]: https://www.google.com/search?q=site%3Ahttps%3A%2F%2Fgithub.com%2FValloric%2FYouCompleteMe%2Fissues%20python%20mac

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# PR Prelude
+
+Thank you for working on YCM! :)
+
+**Please complete these steps and check these boxes (by putting an `x` inside
+the brackets) _before_ filing your PR:**
+
+- [ ] I have read and understood YCM's [CONTRIBUTING][cont] document.
+- [ ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
+- [ ] I have included tests for the changes in my PR. If not, I have included a
+  rationale for why I haven't.
+- [ ] **I understand my PR may be closed if it becomes obvious I didn't
+  actually perform all of these steps.**
+
+# Why this change is necessary and useful
+
+[Please explain **in detail** why the changes in this PR are needed.]
+
+[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
+[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Using GitHub's new issue and PR templates. Should in theory help cut down on issues that
- don't include enough info to even ascertain what the problem is,
- are user error,
- ask questions that are already answered in the docs, usually in several places.

The above types of issues are ~95% of all issues we get.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2003)
<!-- Reviewable:end -->
