### PR TITLE
[READY] Add --all option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ The following additional language support options are available:
 - Rust support: install [rustc and cargo][rust-install] and add
   `--racer-completer` to `./install.py`
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a `--all` flag.  So, to
+install with all language features, ensure `npm`, `go`, `mono`, `rust`,
+and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-        --tern-completer --racer-completer
+    ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -242,12 +242,12 @@ The following additional language support options are available:
 - Rust support: install [rustc and cargo][rust-install] and add
   `--racer-completer` to `./install.py`
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a `--all` flag.  So, to
+install with all language features, ensure `npm`, `go`, `mono`, `rust`,
+and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-        --tern-completer --racer-completer
+    ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -300,12 +300,12 @@ The following additional language support options are available:
 - Rust support: install [rustc and cargo][rust-install] and add
   `--racer-completer` to `./install.py`
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a `--all` flag.  So, to
+install with all language features, ensure `npm`, `go`, `mono`, `rust`,
+and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-        --tern-completer --racer-completer
+    ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -372,11 +372,12 @@ The following additional language support options are available:
 - Rust support: install [rustc and cargo][rust-install] and add
   `--racer-completer` to `install.py`.
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your `%PATH%`, then:
+To simply compile with everything enabled, there's a `--all` flag.  So, to
+install with all language features, ensure `npm`, `go`, `mono`, `rust`,
+and `typescript` API are installed and in your `%PATH%`, then simply run:
 
     cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-    python install.py --clang-completer --omnisharp-completer --gocode-completer --tern-completer --racer-completer
+    python install.py --all
 
 You can specify the Microsoft Visual C++ (MSVC) version using the `--msvc`
 option. YCM officially supports MSVC 11 (Visual Studio 2012), 12 (2013), and 14
@@ -437,12 +438,12 @@ The following additional language support options are available:
 - Rust support: install [rustc and cargo][rust-install] and add
   `--racer-completer` to `./install.py`
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a `--all` flag.  So, to
+install with all language features, ensure `npm`, `go`, `mono`, `rust`,
+and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-        --tern-completer --racer-completer
+    ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -170,8 +170,8 @@ Image: Build Status [1] Image: Build status [3]
 - Installation
 
   - Mac OS X
-  - Ubuntu
-  - Fedora
+  - Ubuntu Linux x64
+  - Fedora Linux x64
   - Windows
   - FreeBSD/OpenBSD
   - Full Installation Guide
@@ -370,12 +370,12 @@ The following additional language support options are available:
 - Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a '--all' flag. So, to
+install with all language features, ensure 'npm', 'go', 'mono', 'rust', and
+'typescript' API are installed and in your 'PATH', then simply run:
 >
   cd ~/.vim/bundle/YouCompleteMe
-  ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-      --tern-completer --racer-completer
+  ./install.py --all
 <
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -434,12 +434,12 @@ The following additional language support options are available:
 - Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a '--all' flag. So, to
+install with all language features, ensure 'npm', 'go', 'mono', 'rust', and
+'typescript' API are installed and in your 'PATH', then simply run:
 >
   cd ~/.vim/bundle/YouCompleteMe
-  ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-      --tern-completer --racer-completer
+  ./install.py --all
 <
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -498,12 +498,12 @@ The following additional language support options are available:
 - Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a '--all' flag. So, to
+install with all language features, ensure 'npm', 'go', 'mono', 'rust', and
+'typescript' API are installed and in your 'PATH', then simply run:
 >
   cd ~/.vim/bundle/YouCompleteMe
-  ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-      --tern-completer --racer-completer
+  ./install.py --all
 <
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -576,11 +576,12 @@ The following additional language support options are available:
 - Rust support: install rustc and cargo [23] and add '--racer-completer' to
   'install.py'.
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your '%PATH%', then:
+To simply compile with everything enabled, there's a '--all' flag. So, to
+install with all language features, ensure 'npm', 'go', 'mono', 'rust', and
+'typescript' API are installed and in your '%PATH%', then simply run:
 >
   cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-  python install.py --clang-completer --omnisharp-completer --gocode-completer --tern-completer --racer-completer
+  python install.py --all
 <
 You can specify the Microsoft Visual C++ (MSVC) version using the '--msvc'
 option. YCM officially supports MSVC 11 (Visual Studio 2012), 12 (2013), and 14
@@ -646,12 +647,12 @@ The following additional language support options are available:
 - Rust support: install rustc and cargo [23] and add '--racer-completer' to
   './install.py'
 
-For example, to install with all language features, ensure npm, go, mono, rust,
-and typescript API are installed and in your PATH, then:
+To simply compile with everything enabled, there's a '--all' flag. So, to
+install with all language features, ensure 'npm', 'go', 'mono', 'rust', and
+'typescript' API are installed and in your 'PATH', then simply run:
 >
   cd ~/.vim/bundle/YouCompleteMe
-  ./install.py --clang-completer --omnisharp-completer --gocode-completer \
-      --tern-completer --racer-completer
+  ./install.py --all
 <
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

I use the `--all` flag for every build. I know this is probably a flag that's more useful for YCM contributors than most users, but it makes sense to document it.

# No tests

It's only an update to the README, so I just tested it by eyeballing the output.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2027)
<!-- Reviewable:end -->
