### PR TITLE
[READY] Catch ReadTimeout exception on requests

### DIFF
--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -23,11 +23,12 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+from requests.exceptions import ReadTimeout
 import vim
+
 from ycmd.responses import ServerError
 from ycm.client.base_request import ( BaseRequest, BuildRequestData,
                                       HandleServerException )
-
 from ycm import vimsupport
 from ycmd.utils import ToUnicode
 
@@ -56,7 +57,7 @@ class CommandRequest( BaseRequest ):
     try:
       self._response = self.PostDataToHandler( request_data,
                                                'run_completer_command' )
-    except ServerError as e:
+    except ( ServerError, ReadTimeout ) as e:
       HandleServerException( e )
 
 

--- a/python/ycm/client/completer_available_request.py
+++ b/python/ycm/client/completer_available_request.py
@@ -23,6 +23,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+from requests.exceptions import ReadTimeout
+
 from ycm.client.base_request import ( BaseRequest, BuildRequestData,
                                       HandleServerException )
 from ycmd.responses import ServerError
@@ -40,7 +42,7 @@ class CompleterAvailableRequest( BaseRequest ):
     try:
       self._response = self.PostDataToHandler( request_data,
                                                'semantic_completion_available' )
-    except ServerError as e:
+    except ( ServerError, ReadTimeout ) as e:
       HandleServerException( e )
 
 

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -23,6 +23,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+from requests.exceptions import ReadTimeout
+
 from ycmd.utils import ToUnicode
 from ycm.client.base_request import ( BaseRequest, JsonFromFuture,
                                       HandleServerException,
@@ -59,7 +61,7 @@ class CompletionRequest( BaseRequest ):
         HandleServerException( MakeServerException( e ) )
 
       return JsonFromFuture( self._response_future )[ 'completions' ]
-    except ServerError as e:
+    except ( ServerError, ReadTimeout ) as e:
       HandleServerException( e )
     return []
 

--- a/python/ycm/client/event_notification.py
+++ b/python/ycm/client/event_notification.py
@@ -23,6 +23,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+from requests.exceptions import ReadTimeout
+
 from ycm import vimsupport
 from ycmd.responses import UnknownExtraConf, ServerError
 from ycm.client.base_request import ( BaseRequest, BuildRequestData,
@@ -66,7 +68,7 @@ class EventNotification( BaseRequest ):
             _LoadExtraConfFile( e.extra_conf_file )
           else:
             _IgnoreExtraConfFile( e.extra_conf_file )
-    except ServerError as e:
+    except ( ServerError, ReadTimeout ) as e:
       HandleServerException( e )
 
     return self._cached_response if self._cached_response else []
@@ -76,9 +78,11 @@ def SendEventNotificationAsync( event_name, extra_data = None ):
   event = EventNotification( event_name, extra_data )
   event.Start()
 
+
 def _LoadExtraConfFile( filepath ):
   BaseRequest.PostDataToHandler( { 'filepath': filepath },
                                  'load_extra_conf_file' )
+
 
 def _IgnoreExtraConfFile( filepath ):
   BaseRequest.PostDataToHandler( { 'filepath': filepath },


### PR DESCRIPTION
In PR #2016, we have changed the way we are catching exceptions on requests by only catching the `ServerError` instead of all exceptions, which is great for debugging purposes. However, due to this change, we don't catch the exception from a timed out request, leading to a ugly traceback in Vim. This PR fixes that.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2029)
<!-- Reviewable:end -->
