### PR TITLE
Make it more clear that install.py require python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,13 @@ for details.
 Compiling YCM **with** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --clang-completer
 
 Compiling YCM **without** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py
 
 The following additional language support options are available:
@@ -189,6 +191,7 @@ install with all language features, ensure `npm`, `go`, `mono`, `rust`,
 and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
@@ -225,11 +228,13 @@ python3-dev`.
 Compiling YCM **with** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --clang-completer
 
 Compiling YCM **without** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py
 
 The following additional language support options are available:
@@ -248,6 +253,7 @@ install with all language features, ensure `npm`, `go`, `mono`, `rust`,
 and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
@@ -284,11 +290,13 @@ python3-devel`.
 Compiling YCM **with** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --clang-completer
 
 Compiling YCM **without** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py
 
 The following additional language support options are available:
@@ -307,6 +315,7 @@ install with all language features, ensure `npm`, `go`, `mono`, `rust`,
 and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
@@ -355,11 +364,13 @@ C-family languages.
 Compiling YCM **with** semantic support for C-family languages:
 
     cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
+    # with python2:
     install.py --clang-completer
 
 Compiling YCM **without** semantic support for C-family languages:
 
     cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
+    # with python2:
     install.py
 
 The following additional language support options are available:
@@ -379,6 +390,7 @@ install with all language features, ensure `npm`, `go`, `mono`, `rust`,
 and `typescript` API are installed and in your `%PATH%`, then simply run:
 
     cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
+    # with python2:
     python install.py --all
 
 You can specify the Microsoft Visual C++ (MSVC) version using the `--msvc`
@@ -422,11 +434,13 @@ Install dependencies and CMake: `sudo pkg_add llvm boost cmake`
 Compiling YCM **with** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --clang-completer --system-libclang --system-boost
 
 Compiling YCM **without** semantic support for C-family languages:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --system-boost
 
 The following additional language support options are available:
@@ -445,6 +459,7 @@ install with all language features, ensure `npm`, `go`, `mono`, `rust`,
 and `typescript` API are installed and in your `PATH`, then simply run:
 
     cd ~/.vim/bundle/YouCompleteMe
+    # with python2:
     ./install.py --all
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

Installation won't actually fail when running with python3. It will just result in YCM not working.

I just wasted half an hour on this. This is my attempt to make sure no1 else has the same error.

I finally figured out the YCM server wouldn't run with this error:
`ImportError: dynamic module does not define init function (initycm_core)`

Which was caused by running the installation from python3. Which is stated only in this issue:
https://github.com/Valloric/YouCompleteMe/issues/6