### PR TITLE
[READY] Fix traceback when syntax files contain unicode characters

### DIFF
--- a/python/ycm/syntax_parse.py
+++ b/python/ycm/syntax_parse.py
@@ -89,7 +89,7 @@ def SyntaxKeywordsForCurrentBuffer():
   vim.command( 'redir => b:ycm_syntax' )
   vim.command( 'silent! syntax list' )
   vim.command( 'redir END' )
-  syntax_output = vimsupport.GetVariableValue( 'b:ycm_syntax' )
+  syntax_output = vimsupport.VimExpressionToPythonType( 'b:ycm_syntax' )
   return _KeywordsFromSyntaxListOutput( syntax_output )
 
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -500,7 +500,7 @@ def EscapeForVim( text ):
 
 
 def CurrentFiletypes():
-  return vim.eval( "&filetype" ).split( '.' )
+  return VimExpressionToPythonType( "&filetype" ).split( '.' )
 
 
 def FiletypesForBuffer( buffer_object ):


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fixes https://github.com/Valloric/YouCompleteMe/issues/2036

I'm submitting this without tests for now because it's probably quite important, and adding tests is going to be quite time consuming because we somehow need to mock out the output of `:syntax list` with unicode chars, etc.

I have tested manually and got people experiencing the issue to also confirm that it fixes it.

I've also surveyed other uses of `vim.eval` that return string and wrapped them in a `ToUnicode` where there is a possibility of it not working. This is much more speculative, so feel free to say ditch this and just fix the issue at hand.

Also, of course feel free to say we can't merge this without tests, which is also valid :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2037)
<!-- Reviewable:end -->
