### PR TITLE
[READY] Do not send request in OnFileReadyToParse function if server is down

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -256,10 +256,11 @@ class YouCompleteMe( object ):
 
 
   def OnFileReadyToParse( self ):
-    self._omnicomp.OnFileReadyToParse( None )
-
     if not self.IsServerAlive():
       self._NotifyUserIfServerCrashed()
+      return
+
+    self._omnicomp.OnFileReadyToParse( None )
 
     extra_data = {}
     self._AddTagsFilesIfNeeded( extra_data )


### PR DESCRIPTION
Even if `ycmd` process is terminated, YCM will try to send the `event_notification` request in `OnFileReadyToParse` function, blocking Vim for one second if the server crashed at the start (because of [this request](https://github.com/Valloric/YouCompleteMe/blob/master/python/ycm/client/base_request.py#L222)) or resulting in a traceback with  `ConnectionError` exception otherwise. This will happen for the `InsertLeave`, `CursorMoved`, `CursorHold`, `BufferVisit` events, making Vim almost unusable.

This is fixed by returning early if the process is terminated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2041)
<!-- Reviewable:end -->
