### PR TITLE
[READY] Rename ycmd python option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1898,7 +1898,7 @@ Default: `[]`
 let g:ycm_extra_conf_vim_data = []
 ```
 
-### The `g:ycm_path_to_python_interpreter` option
+### The `g:ycm_server_python_interpreter` option
 
 YCM will by default search for an appropriate Python interpreter on your system.
 You can use this option to override that behavior and force the use of a
@@ -1911,7 +1911,7 @@ Vim.
 Default: `''`
 
 ```viml
-let g:ycm_path_to_python_interpreter = ''
+let g:ycm_server_python_interpreter = ''
 ```
 
 ### The `g:ycm_server_keep_logfiles` option
@@ -2351,7 +2351,7 @@ If building for Python 3 but loading in Python 2:
 ImportError: dynamic module does not define init function (initycm_core)
 ```
 
-Setting the `g:ycm_path_to_python_interpreter` option to force the use of a
+Setting the `g:ycm_server_python_interpreter` option to force the use of a
 specific Python interpreter for `ycmd` is usually the easiest way to solve the
 problem. Common values for that option are `/usr/bin/python` and
 `/usr/bin/python3`.

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -96,7 +96,7 @@ Contents ~
   19. The |g:ycm_collect_identifiers_from_tags_files| option
   20. The |g:ycm_seed_identifiers_with_syntax| option
   21. The |g:ycm_extra_conf_vim_data| option
-  22. The |g:ycm_path_to_python_interpreter| option
+  22. The |g:ycm_server_python_interpreter| option
   23. The |g:ycm_server_keep_logfiles| option
   24. The |g:ycm_server_log_level| option
   25. The |g:ycm_auto_start_csharp_server| option
@@ -846,8 +846,8 @@ will notify you to recompile it. You should then rerun the install process.
    -g typescript' after successfully installing nodejs and npm [22].
 
 9. JavaScript support: Install nodejs and npm [22]. Then navigate to
-   'YouCompleteMe/third_party/ycmd/third_party/tern' and run 'npm install
-   --production'
+   'YouCompleteMe/third_party/ycmd/third_party/tern_runtime' and run 'npm
+   install --production'
 
 10. Rust support: Install rustc and cargo [23]. Navigate to
     'YouCompleteMe/third_party/ycmd/third_party/racerd' and run 'cargo
@@ -2159,7 +2159,7 @@ Default: '[]'
   let g:ycm_extra_conf_vim_data = []
 <
 -------------------------------------------------------------------------------
-The *g:ycm_path_to_python_interpreter* option
+The *g:ycm_server_python_interpreter* option
 
 YCM will by default search for an appropriate Python interpreter on your
 system. You can use this option to override that behavior and force the use of
@@ -2171,7 +2171,7 @@ Vim.
 
 Default: "''"
 >
-  let g:ycm_path_to_python_interpreter = ''
+  let g:ycm_server_python_interpreter = ''
 <
 -------------------------------------------------------------------------------
 The *g:ycm_server_keep_logfiles* option
@@ -2584,7 +2584,7 @@ If building for Python 3 but loading in Python 2:
 >
   ImportError: dynamic module does not define init function (initycm_core)
 <
-Setting the |g:ycm_path_to_python_interpreter| option to force the use of a
+Setting the |g:ycm_server_python_interpreter| option to force the use of a
 specific Python interpreter for 'ycmd' is usually the easiest way to solve the
 problem. Common values for that option are '/usr/bin/python' and
 '/usr/bin/python3'.

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -126,8 +126,9 @@ let g:ycm_server_keep_logfiles =
 let g:ycm_extra_conf_vim_data =
       \ get( g:, 'ycm_extra_conf_vim_data', [] )
 
-let g:ycm_path_to_python_interpreter =
-      \ get( g:, 'ycm_path_to_python_interpreter', '' )
+let g:ycm_server_python_interpreter =
+      \ get( g:, 'ycm_server_python_interpreter',
+      \ get( g:, 'ycm_path_to_python_interpreter', '' ) )
 
 let g:ycm_show_diagnostics_ui =
       \ get( g:, 'ycm_show_diagnostics_ui',

--- a/python/ycm/paths.py
+++ b/python/ycm/paths.py
@@ -54,13 +54,13 @@ def Memoize( obj ):
 def PathToPythonInterpreter():
   from ycmd import utils
 
-  python_interpreter = vim.eval( 'g:ycm_path_to_python_interpreter' )
+  python_interpreter = vim.eval( 'g:ycm_server_python_interpreter' )
 
   if python_interpreter:
     if IsPythonVersionCorrect( python_interpreter ):
       return python_interpreter
 
-    raise RuntimeError( "Path in 'g:ycm_path_to_python_interpreter' option "
+    raise RuntimeError( "Path in 'g:ycm_server_python_interpreter' option "
                         "does not point to a valid Python 2.6+ or 3.3+." )
 
   # On UNIX platforms, we use sys.executable as the Python interpreter path.
@@ -86,7 +86,7 @@ def PathToPythonInterpreter():
     return python_interpreter
 
   raise RuntimeError( "Cannot find Python 2.6+ or 3.3+. You can set its path "
-                      "using the 'g:ycm_path_to_python_interpreter' "
+                      "using the 'g:ycm_server_python_interpreter' "
                       "option." )
 
 

--- a/python/ycm/test_utils.py
+++ b/python/ycm/test_utils.py
@@ -61,7 +61,7 @@ def MockGetBufferWindowNumber( buffer_number ):
 def MockVimEval( value ):
   if value == "g:ycm_min_num_of_chars_for_completion":
     return 0
-  if value == "g:ycm_path_to_python_interpreter":
+  if value == "g:ycm_server_python_interpreter":
     return ''
   if value == "tempname()":
     return '_TEMP_FILE_'


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

As requested in https://github.com/Valloric/YouCompleteMe/issues/2052#issuecomment-195631106 I'm sending this PR. I've marked it as WIP because I've renamed only the `ycmd` option and that is because keeping the backward compatibility here was straight forward since is a client only option. For the jedihttp option instead I would like some opinion on how to procede: should we keep the backward compatibility here on the client or should we make the backward compatibility layer on the ycmd side? Keeping it here would be easier but it would mean that other clients should implement this theirself. Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2054)
<!-- Reviewable:end -->
