### PR TITLE
Avoid setting omnifunc when not allowed

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -500,11 +500,7 @@ endfunction
 
 
 function! s:SetOmnicompleteFunc()
-  if !s:AllowedToCompleteInCurrentFile()
-    return
-  endif
-
-  if s:Pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
+  if s:AllowedToCompleteInCurrentFile() && s:Pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
     let &omnifunc = 'youcompleteme#OmniComplete'
     let &l:omnifunc = 'youcompleteme#OmniComplete'
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -500,6 +500,10 @@ endfunction
 
 
 function! s:SetOmnicompleteFunc()
+  if !s:AllowedToCompleteInCurrentFile()
+    return
+  endif
+
   if s:Pyeval( 'ycm_state.NativeFiletypeCompletionUsable()' )
     let &omnifunc = 'youcompleteme#OmniComplete'
     let &l:omnifunc = 'youcompleteme#OmniComplete'


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**
- [x] I have read and understood YCM's [CONTRIBUTING](https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT](https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**
# Why this change is necessary and useful

When the current file is not allowed, this function does nothing really useful.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2072)

<!-- Reviewable:end -->
