### PR TITLE
[WIP] Send column as codepoint index to ycmd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = https://github.com/ross/requests-futures
 [submodule "third_party/ycmd"]
 	path = third_party/ycmd
-	url = https://github.com/Valloric/ycmd
+	url = https://github.com/micbou/ycmd
+	branch = utf-8

--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -61,10 +61,15 @@ def LoadJsonDefaultsIntoVim():
 
 
 def CompletionStartColumn():
-  return ( request_wrap.CompletionStartColumn(
-      vimsupport.CurrentLineContents(),
+  current_line = vimsupport.CurrentLineContents()
+  start_column = request_wrap.CompletionStartColumn(
+      current_line,
       vimsupport.CurrentColumn() + 1,
-      vimsupport.CurrentFiletypes()[ 0 ] ) - 1 )
+      vimsupport.CurrentFiletypes()[ 0 ] ) - 1
+
+  # start_column is codepoint indexed. We need to return it as a byte index
+  # using Vim encoding.
+  return len( current_line[ :start_column ].encode( vimsupport.GetEncoding() ) )
 
 
 def CurrentIdentifierFinished():

--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -92,14 +92,14 @@ def MockArbitraryBuffer( filetype, native_available = True ):
   with patch( 'vim.current' ) as vim_current:
     def VimEval( value ):
       """Local mock of the vim.eval() function, used to ensure we get the
-      correct behvaiour"""
+      correct behavior"""
 
       if value == '&omnifunc':
         # The omnicompleter is not required here
         return ''
 
       if value == 'getbufvar(0, "&mod")':
-        # Ensure that we actually send the even to the server
+        # Ensure that we actually send the event to the server
         return 1
 
       if value == 'getbufvar(0, "&ft")' or value == '&filetype':
@@ -128,7 +128,8 @@ def MockArbitraryBuffer( filetype, native_available = True ):
     with patch( 'vim.buffers', [ current_buffer ] ):
       with patch( 'vim.current.buffer', current_buffer ):
         with patch( 'vim.eval', side_effect=VimEval ):
-          yield
+          with patch( 'ycm.vimsupport.CurrentColumn', return_value = 2 ):
+            yield
 
 
 @contextlib.contextmanager

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+#
 # Copyright (C) 2016 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
@@ -26,22 +28,139 @@ from builtins import *  # noqa
 from ycm.test_utils import MockVimModule
 MockVimModule()
 
+import contextlib
+import functools
+import os
 import sys
-from mock import MagicMock
-from hamcrest import assert_that, is_in, is_not
+from mock import MagicMock, patch
+from hamcrest import ( assert_that, contains_inanyorder, has_entries, is_in,
+                       is_not )
 
 from ycm.youcompleteme import YouCompleteMe
+from ycmd import user_options_store
+from ycmd.utils import ToBytes, ReadFile
+
+# The default options which are only relevant to the client, not the server and
+# thus are not part of default_options.json, but are required for a working
+# YouCompleteMe object.
+DEFAULT_CLIENT_OPTIONS = {
+  'server_log_level': 'debug',
+  'extra_conf_vim_data': [],
+}
 
 
-class YouCompleteMe_test():
-
-  def setUp( self ):
-    self.ycm = YouCompleteMe( MagicMock( spec_set = dict ) )
-
-
-  def tearDown( self ):
-    self.ycm.OnVimLeave()
+def CompletionEntryMatcher( word, menu ):
+  return has_entries( { 'word': word,
+                        'menu': menu,
+                        'dup': 1,
+                        'empty': 1 } )
 
 
-  def YcmCoreNotImported_test( self ):
-    assert_that( 'ycm_core', is_not( is_in( sys.modules ) ) )
+@contextlib.contextmanager
+def MockBuffer( contents, line, column, filetype, encoding ):
+  """Mock a Vim buffer with contents, cursor at (line, column), filetype, and
+  encoding. Line and column are 1-based. Column is byte indexed."""
+  def VimEval( value ):
+    """Minimal mock of the vim.eval() function to run the tests."""
+
+    # Called by OnFileReadyToParse in OmniCompleter class.
+    if value == '&omnifunc':
+      return ''
+
+    # Called by CurrentFiletypes in NativeFiletypeCompletionAvailable.
+    if value == '&filetype':
+      return filetype
+
+    # Called by GetEncoding in ToUnicodeWithVimEncoding.
+    if value == '&encoding':
+      return encoding
+
+    # Called by BufferModified in GetUnsavedAndCurrentBufferData.
+    if value == 'getbufvar(0, "&ft")':
+      return filetype
+
+    # Called by FiletypesForBuffer in GetUnsavedAndCurrentBufferData.
+    if value == 'getbufvar(0, "&mod")':
+      return 1
+
+    raise ValueError( 'Unexpected evaluation' )
+
+  vim_contents = [ ToBytes( l ) for l in contents.splitlines() ]
+
+  vim_current = MagicMock()
+  vim_current.window.cursor = ( line, column )
+  vim_current.line = vim_contents[ line - 1 ]
+
+  current_buffer = MagicMock()
+  current_buffer.name = 'TEST_BUFFER'
+  current_buffer.number = 0
+  current_buffer.__iter__.return_value = vim_contents
+
+  with patch( 'vim.current', vim_current ):
+    with patch( 'vim.buffers', [ current_buffer ] ):
+      with patch( 'vim.current.buffer', current_buffer ):
+        with patch( 'vim.eval', side_effect=VimEval ):
+          yield
+
+
+def SetUpYcm( test ):
+  @functools.wraps( test )
+  def Wrapper( *args, **kwargs ):
+    try:
+      options = dict( user_options_store.DefaultOptions() )
+      options.update( DEFAULT_CLIENT_OPTIONS )
+      user_options_store.SetAll( options )
+      ycm = YouCompleteMe( user_options_store.GetAll() )
+      test( ycm, *args, **kwargs )
+    finally:
+      # Write ycmd logs to nosetests stdout.
+      if os.path.exists( ycm._server_stderr ):
+        sys.stdout.write( ReadFile( ycm._server_stderr ) )
+      if os.path.exists( ycm._server_stdout ):
+        sys.stdout.write( ReadFile( ycm._server_stdout ) )
+      ycm.OnVimLeave()
+  return Wrapper
+
+
+@SetUpYcm
+def YouCompleteMe_YcmCoreNotImported_test( ycm ):
+  assert_that( 'ycm_core', is_not( is_in( sys.modules ) ) )
+
+
+def RunCompletionTest( ycm, test ):
+  vim_buffer = test[ 'buffer' ]
+  with MockBuffer( vim_buffer[ 'contents' ],
+                   vim_buffer[ 'line' ],
+                   vim_buffer[ 'column' ],
+                   vim_buffer[ 'filetype' ],
+                   vim_buffer[ 'encoding' ] ):
+    ycm.OnFileReadyToParse()
+    ycm.CreateCompletionRequest()
+    request = ycm.GetCurrentCompletionRequest()
+    request.Start()
+    while not request.Done():
+      pass
+    assert_that( request.Response(), test[ 'expect' ][ 'completions' ] )
+
+
+@SetUpYcm
+def YouCompleteMe_CreateCompletionRequest_MultibyteLine_test( ycm ):
+  RunCompletionTest( ycm, {
+    'description': 'Completion works properly on multibyte line. '
+                   'See issue #1378.',
+    'buffer': {
+      'contents': """identifier
+中文 = id
+""",
+      'line': 2,
+      'column': 12,
+      'filetype': 'dummy_filetype',
+      'encoding': 'utf8'
+    },
+    'expect': {
+      'completions': contains_inanyorder(
+        CompletionEntryMatcher( 'id', '[ID]' ),
+        CompletionEntryMatcher( 'identifier', '[ID]' )
+      )
+    }
+  } )


### PR DESCRIPTION
Currently, we are sending to ycmd the buffer contents as unicode (with `utf-8` encoding) but the cursor column as byte index (which is what Vim gives us). This inconsistency is causing issue #1378 and probably others. It also forces us to do convoluted things in [`CompletionStartColumn` function](https://github.com/Valloric/ycmd/blob/master/ycmd/request_wrap.py#L98) to work around this.

With this PR, we are now consistent by sending the cursor column as codepoint index depending on Vim encoding and by still sending the buffer contents as unicode but with Vim encoding. This fixes #1378 and improves support for Vim encoding different from `utf8` (for example, `latin1` is the default on Windows).

This PR adds the needed structure to test completions: currently, one test (based on issue #1378) is  using it but new tests can easily be added. Also add two tests for the `CurrentColumn` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2073)
<!-- Reviewable:end -->
