### PR TITLE
Support lazy loading with :packadd.

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -165,10 +165,14 @@ let g:ycm_disable_for_files_larger_than_kb =
 
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
-augroup youcompletemeStart
-  autocmd!
-  autocmd VimEnter * call youcompleteme#Enable()
-augroup END
+if has( 'vim_starting' ) " loading at startup
+  augroup youcompletemeStart
+    autocmd!
+    autocmd VimEnter * call youcompleteme#Enable()
+  augroup END
+else " manual loading with :packadd
+  call youcompleteme#Enable()
+endif
 
 " This is basic vim plugin boilerplate
 call s:restore_cpo()


### PR DESCRIPTION
- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Vim recently has introduced a new feature called 'packages', which
permits, among the rest, to disable automatic loading a plugin at
startup. Plugins that are disabled at startup may be manually loaded
during a session using `:packadd` (see `:h packages`, `:h :packadd`).
Of course, a plugin that is loaded after startup cannot rely on VimEnter
events.

In order to support lazy loading YCM, check whether YCM is sourced
during startup or at a later time. In the former case, define an
autocommand as before; in the latter case, enable YCM immediately.

Why would one want to load YCM lazily? I use YCM only for certain file
types (Python), and I prefer not to have pop up menus appearing
all the time for other file types. In my workflow, I may enable YCM only
if I start Vim for Python coding sessions.

Tests not included because the change is in VimScript code only, and
testing this feature is not trivial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2084)
<!-- Reviewable:end -->
