### PR TITLE
[READY] use ToUnicode to wrap GetBufferFilepath and win.buffer.name

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1297,7 +1297,7 @@ def JumpToLocation_BufferFilePathContainsUTF8Word_test():
   mock_buffer = MockBuffer( [
     'line1',
     'line2',
-  ], '中/single_file'.encode( 'utf-8' ), 1 )
+  ], ToBytes( '中/single_file' ), 1 )
 
   with patch( "vim.current.buffer", mock_buffer ):
     vimsupport.JumpToLocation( '中/single_file', 1, 1 )
@@ -1310,7 +1310,7 @@ def JumpToLocation_BufferWithoutNameWhenCWDContainsUTF8Word_test():
   ], '', 1 )
 
   with patch( "vim.current.buffer", mock_buffer ):
-    with patch( "os.getcwd", new = lambda: 'aa中bb'.encode( 'utf-8' ) ):
+    with patch( "os.getcwd", new = lambda: ToBytes( 'aa中bb' ) ):
       filename = os.path.join( 'aa中bb', str( mock_buffer.number ) )
       vimsupport.JumpToLocation( filename, 1, 1 )
 
@@ -1322,7 +1322,7 @@ def TryJumpLocationInOpenedTab_BufferNameContainsUTF8Word_test( vim_window,
   mock_buffer = MockBuffer( [
     'line1',
     'line2',
-  ], '中/single_file'.encode( 'utf-8' ), 1 )
+  ], ToBytes( '中/single_file' ), 1 )
 
   tabpages = [ vim_tabpage ]
   vim_tabpage.windows = [ vim_window ]

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1291,3 +1291,46 @@ def VimExpressionToPythonType_ObjectPassthrough_test( *args ):
 def VimExpressionToPythonType_GeneratorPassthrough_test( *args ):
   gen = ( x**2 for x in [ 1, 2, 3 ] )
   eq_( vimsupport.VimExpressionToPythonType( gen ), gen )
+
+
+def JumpToLocation_1_test():
+  class AnBuffer():
+    name = '中/ab.py'.encode( 'utf8' )
+    # name = '中/ab.py'
+
+  # UnicodeWarning
+  with patch( "vim.current.buffer", AnBuffer ):
+    vimsupport.JumpToLocation( '中/ab.py', 1, 1 )
+
+
+def JumpToLocation_2_test():
+  class AnBuffer():
+    name = None
+    # name = '中/ab.py'
+    number = 1
+
+  # :enew
+  chinese_dir = 'aaa中bbb'
+  if not os.path.isdir( chinese_dir ):
+    os.mkdir( chinese_dir )
+  os.chdir( chinese_dir )
+  try:
+    with patch( "vim.current.buffer", AnBuffer ):
+      vimsupport.JumpToLocation( '中/ab.py', 1, 1 )
+  finally:
+    os.chdir( '..' )
+    os.rmdir( chinese_dir )
+
+
+def TryJumpLocationInOpenedTab_test():
+  class Tabs():
+    class Win():
+      class buffer():
+        name = '中/ab.py'.encode( 'utf8' )
+        # name = '中/ab.py'
+
+    windows = [ Win ]
+
+  # UnicodeWarning
+  with patch( "vim.tabpages", [ Tabs ] ):
+    vimsupport.TryJumpLocationInOpenedTab( '中/ab.py', 1, 1 )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1295,7 +1295,7 @@ def VimExpressionToPythonType_GeneratorPassthrough_test( *args ):
 
 def JumpToLocation_1_test():
   class AnBuffer():
-    name = '中/ab.py'.encode( 'utf8' )
+    name = '中/ab.py'.encode( 'utf-8' )
     # name = '中/ab.py'
 
   # UnicodeWarning
@@ -1306,31 +1306,31 @@ def JumpToLocation_1_test():
 def JumpToLocation_2_test():
   class AnBuffer():
     name = None
-    # name = '中/ab.py'
     number = 1
 
   # :enew
   chinese_dir = 'aaa中bbb'
+  # chinese_dir = 'aaabbb'
   if not os.path.isdir( chinese_dir ):
     os.mkdir( chinese_dir )
   os.chdir( chinese_dir )
   try:
     with patch( "vim.current.buffer", AnBuffer ):
-      vimsupport.JumpToLocation( '中/ab.py', 1, 1 )
+      vimsupport.JumpToLocation( os.getcwd().decode( 'utf-8' ) + '/1', 1, 1 )
   finally:
     os.chdir( '..' )
     os.rmdir( chinese_dir )
 
 
 def TryJumpLocationInOpenedTab_test():
-  class Tabs():
+  class Tab():
     class Win():
       class buffer():
-        name = '中/ab.py'.encode( 'utf8' )
+        name = '中/ab.py'.encode( 'utf-8' )
         # name = '中/ab.py'
 
     windows = [ Win ]
 
   # UnicodeWarning
-  with patch( "vim.tabpages", [ Tabs ] ):
+  with patch( "vim.tabpages", [ Tab ] ):
     vimsupport.TryJumpLocationInOpenedTab( '中/ab.py', 1, 1 )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -154,10 +154,10 @@ def GetBufferFilepath( buffer_object ):
   # buffer name so we use the buffer number for that. Also, os.getcwd() throws
   # an exception when the CWD has been deleted so we handle that.
   try:
-    folder_path = os.getcwd()
+    folder_path = ToUnicode( os.getcwd() )
   except OSError:
     folder_path = tempfile.gettempdir()
-  return ToUnicode( os.path.join( folder_path, str( buffer_object.number ) ) )
+  return os.path.join( folder_path, str( buffer_object.number ) )
 
 
 def UnplaceSignInBuffer( buffer_number, sign_id ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -23,7 +23,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from future.utils import iterkeys
+from future.utils import iterkeys, PY2
 import vim
 import os
 import tempfile
@@ -154,7 +154,7 @@ def GetBufferFilepath( buffer_object ):
   # buffer name so we use the buffer number for that. Also, os.getcwd() throws
   # an exception when the CWD has been deleted so we handle that.
   try:
-    folder_path = ToUnicode( os.getcwd() )
+    folder_path = os.getcwdu() if PY2 else os.getcwd()
   except OSError:
     folder_path = tempfile.gettempdir()
   return os.path.join( folder_path, str( buffer_object.number ) )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -149,7 +149,7 @@ def BufferIsVisible( buffer_number ):
 
 def GetBufferFilepath( buffer_object ):
   if buffer_object.name:
-    return buffer_object.name
+    return ToUnicode( buffer_object.name )
   # Buffers that have just been created by a command like :enew don't have any
   # buffer name so we use the buffer number for that. Also, os.getcwd() throws
   # an exception when the CWD has been deleted so we handle that.
@@ -157,7 +157,7 @@ def GetBufferFilepath( buffer_object ):
     folder_path = os.getcwd()
   except OSError:
     folder_path = tempfile.gettempdir()
-  return os.path.join( folder_path, str( buffer_object.number ) )
+  return ToUnicode( os.path.join( folder_path, str( buffer_object.number ) ) )
 
 
 def UnplaceSignInBuffer( buffer_number, sign_id ):
@@ -352,7 +352,7 @@ def TryJumpLocationInOpenedTab( filename, line, column ):
 
   for tab in vim.tabpages:
     for win in tab.windows:
-      if win.buffer.name == filepath:
+      if ToUnicode( win.buffer.name ) == filepath:
         vim.current.tabpage = tab
         vim.current.window = win
         vim.current.window.cursor = ( line, column - 1 )


### PR DESCRIPTION
- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**
# Why this change is necessary and useful

some str attr of module vim is not unicode, but str.
and some attr doesn't wrapped by ToUnicode.
edit a py file which's path includes chinese words,
a error mesg shows 100 percent when i use YcmCompleter Goto.
the error locates method TryJumpLocationInOpenedTab or JumpToLocation in vimsupport.py
in vimsupport.py, someone has used ToUnicode to wrap some str like vim.current.line
but GetBufferFilepath() and win.buffer.name missed. so i just wrap it, then it works fine.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2090)

<!-- Reviewable:end -->
