### PR TITLE
[READY] Update Clang version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,10 +516,10 @@ process.
     **Download the latest version of `libclang`**. Clang is an open-source
     compiler that can compile C/C++/Objective-C/Objective-C++. The `libclang`
     library it provides is used to power the YCM semantic completion engine for
-    those languages. YCM is designed to work with libclang version 3.6 or
-    higher, but can in theory work with any 3.2+ version as well.
+    those languages. YCM is designed to work with libclang version 3.8 or
+    higher.
 
-    You can use the system libclang _only if you are sure it is version 3.3 or
+    You can use the system libclang _only if you are sure it is version 3.8 or
     higher_, otherwise don't. Even if it is, we recommend using the [official
     binaries from llvm.org][clang-download] if at all possible. Make sure you
     download the correct archive file for your OS.
@@ -2524,13 +2524,9 @@ undefined symbol: clang_CompileCommands_dispose
 ```
 
 This means that Vim is trying to load a `libclang.so` that is too old. You need
-at least a 3.2 libclang. Some distros ship with a system `libclang.so` that
-identifies itself as 3.2 but is not; it was cut from the upstream sources before
-the official 3.2 release and some API changes (like the addition of the
-CompileCommands API) were added after their cut.
-
-So just go through the installation guide and make sure you are using a correct
-`libclang.so`. I recommend downloading prebuilt binaries from llvm.org.
+at least a 3.8 libclang. Just go through the installation guide and make sure
+you are using a correct `libclang.so`. We recommend downloading prebuilt
+binaries from llvm.org.
 
 
 ### I get `Fatal Python error: PyThreadState_Get: no current thread` on startup

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -729,10 +729,10 @@ will notify you to recompile it. You should then rerun the install process.
    **Download the latest version of 'libclang'**. Clang is an open-source
    compiler that can compile C/C++/Objective-C/Objective-C++. The 'libclang'
    library it provides is used to power the YCM semantic completion engine
-   for those languages. YCM is designed to work with libclang version 3.6 or
-   higher, but can in theory work with any 3.2+ version as well.
+   for those languages. YCM is designed to work with libclang version 3.8 or
+   higher.
 
-   You can use the system libclang _only if you are sure it is version 3.3
+   You can use the system libclang _only if you are sure it is version 3.8
    or higher_, otherwise don't. Even if it is, we recommend using the
    official binaries from llvm.org [32] if at all possible. Make sure you
    download the correct archive file for your OS.
@@ -2773,13 +2773,9 @@ crashes:
   undefined symbol: clang_CompileCommands_dispose
 <
 This means that Vim is trying to load a 'libclang.so' that is too old. You need
-at least a 3.2 libclang. Some distros ship with a system 'libclang.so' that
-identifies itself as 3.2 but is not; it was cut from the upstream sources
-before the official 3.2 release and some API changes (like the addition of the
-CompileCommands API) were added after their cut.
-
-So just go through the installation guide and make sure you are using a correct
-'libclang.so'. I recommend downloading prebuilt binaries from llvm.org.
+at least a 3.8 libclang. Just go through the installation guide and make sure
+you are using a correct 'libclang.so'. We recommend downloading prebuilt
+binaries from llvm.org.
 
 -------------------------------------------------------------------------------
                      *Fatal-Python-error:-PyThreadState_Get:-no-current-thread*


### PR DESCRIPTION
Since PR Valloric/ycmd#353, Clang version must be at least 3.8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2099)
<!-- Reviewable:end -->
