### PR TITLE
Add g:ycm_goto_list_height option

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -833,7 +833,7 @@ endfunction
 function! youcompleteme#OpenGoToList()
   set lazyredraw
   cclose
-  execute 'belowright copen 3'
+  execute 'belowright copen ' . g:ycm_goto_list_height
   set nolazyredraw
   au WinLeave <buffer> q  " automatically leave, if an option is chosen
   redraw!

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2542,6 +2542,15 @@ Default: 1000
   let g:ycm_disable_for_files_larger_than_kb = 1000
 <
 -------------------------------------------------------------------------------
+The g:ycm_goto_list_height option
+
+Defines the height of the quickfix window when 'GoTo*' commands are run.
+
+Default: 3
+>
+  let g:ycm_goto_list_height = 3
+<
+-------------------------------------------------------------------------------
 The *g:ycm_python_binary_path* option
 
 This option specifies the Python interpreter to use to run the jedi [6]

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -164,6 +164,9 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
+let g:ycm_goto_list_height =
+      \ get( g:, 'ycm_goto_list_height', 3 )
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 augroup youcompletemeStart


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Lets users define the height of the quickfix list when using `GoTo*` commands. Currently the set height of 3 seems a bit small when the default is usually 10, and the assumption is that others would have different preferences as well as to what it should be set at.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2101)
<!-- Reviewable:end -->
