### PR TITLE
[READY] Do not disable YCM when Vim is started in diff mode

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -54,11 +54,6 @@ endfunction
 
 
 function! youcompleteme#Enable()
-  " When vim is in diff mode, don't run
-  if &diff
-    return
-  endif
-
   call s:SetUpBackwardsCompatibility()
 
   " This can be 0 if YCM libs are old or -1 if an exception occured while


### PR DESCRIPTION
Since we don't really know why YCM is disabled when Vim is started in diff mode (the [relevant commit](https://github.com/Valloric/YouCompleteMe/commit/a6d5979b0847a8629861c8252d1e93c2b9a00297) is 4 years old) and I couldn't find any issues with YCM enabled in this mode, I propose to revert this commit.

See issue #2104 and [relevant thread on ycm-users list](https://groups.google.com/forum/?hl=en#!topic/ycm-users/cdqPJH5QrBs).

Fixes issue #2104.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2106)
<!-- Reviewable:end -->
