### PR TITLE
[READY] Avoid evaluating Vim globals in Python

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -294,27 +294,8 @@ def ConvertDiagnosticsToQfList( diagnostics ):
   return [ ConvertDiagnosticToQfFormat( x ) for x in diagnostics ]
 
 
-# Given a dict like {'a': 1}, loads it into Vim as if you ran 'let g:a = 1'
-# When |overwrite| is True, overwrites the existing value in Vim.
-def LoadDictIntoVimGlobals( new_globals, overwrite = True ):
-  extend_option = '"force"' if overwrite else '"keep"'
-
-  # We need to use json.dumps because that won't use the 'u' prefix on strings
-  # which Vim would bork on.
-  vim.eval( 'extend( g:, {0}, {1})'.format( json.dumps( new_globals ),
-                                            extend_option ) )
-
-
-# Changing the returned dict will NOT change the value in Vim.
-def GetReadOnlyVimGlobals( force_python_objects = False ):
-  if force_python_objects:
-    return vim.eval( 'g:' )
-
-  try:
-    # vim.vars is fairly new so it might not exist
-    return vim.vars
-  except:
-    return vim.eval( 'g:' )
+def GetVimGlobalsKeys():
+  return vim.eval( 'keys( g: )' )
 
 
 def VimExpressionToPythonType( vim_expression ):
@@ -491,8 +472,8 @@ def EchoTextVimWidth( text ):
 
   EchoText( truncated_text, False )
 
-  vim.command( 'let &ruler = {0}'.format( old_ruler ) )
-  vim.command( 'let &showcmd = {0}'.format( old_showcmd ) )
+  SetVariableValue( '&ruler', old_ruler )
+  SetVariableValue( '&showcmd', old_showcmd )
 
 
 def EscapeForVim( text ):
@@ -514,7 +495,7 @@ def VariableExists( variable ):
 
 
 def SetVariableValue( variable, value ):
-  vim.command( "let {0} = '{1}'".format( variable, EscapeForVim( value ) ) )
+  vim.command( "let {0} = {1}".format( variable, json.dumps( value ) ) )
 
 
 def GetVariableValue( variable ):


### PR DESCRIPTION
### Problem

See the commit message and issue #2127.

### How to reproduce

Make Vim to use Python 3 for YCM by either using Vim with only Python 3 support or by editing the `s:UsingPython2` function in `autoload/youcompleteme.vim` to always return 0.
Create the following `vimrc`:
```
set nocompatible

set runtimepath+=~/.vim/bundle/YouCompleteMe

set encoding=utf8

filetype plugin indent on

let g:dummy_variable = '€'[0]
```
and start Vim with it. The following error will occur:
```
YouCompleteMe unavailable: 'utf-8' codec can't decode byte 0xe2 in position 0: unexpected end of data
```
with the traceback in `:messages`:
```python
Traceback (most recent call last):
  File "<string>", line 24, in <module>
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\setup.py", line 49, in SetUpYCM
    base.LoadJsonDefaultsIntoVim()
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\base.py", line 60, in LoadJsonDefaultsIntoVim
    vimsupport.LoadDictIntoVimGlobals( vim_defaults, overwrite = False )
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\vimsupport.py", line 305, in LoadDictIntoVimGlobals
    extend_option ) )
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 0: unexpected end of data
```

### Solution

Do not evaluate the Vim globals when loading the YCM default options into Vim and when building the options for the ycmd server.

Depending on the number of global variables and custom YCM options, this may be slower or faster than the current code but by a negligible margin (~1ms).

Fixes #2127 and #2150.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2151)
<!-- Reviewable:end -->
