### PR TITLE
FixIt buffer-numbering adjustment for Neovim

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -623,7 +623,8 @@ def ReplaceChunks( chunks ):
     ( buffer_num, close_window ) = _OpenFileInSplitIfNeeded( filepath )
 
     ReplaceChunksInBuffer( chunks_by_file[ filepath ],
-                           vim.buffers[ buffer_num ],
+                           [ buf for buf in vim.buffers
+                             if buf.number == buffer_num ][0],
                            locations )
 
     # When opening tons of files, we don't want to have a split for each new


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

## Why this change is necessary and useful

Mimics `if_python`'s `vim.buffers` sequence behavior when issuing `:YcmCompleter FixIt` in Neovim. More in [last section](#rationale).

## Steps to reproduce:
- [ ] 1) Bug and patch only applicable to Neovim. Link/copy minimal vimrc below into dir containing `bundle/YouCompleteMe`. Run: `nvim -u minimal_vimrc -i NONE`

```   
" MINIMAL DEBUG NVIMRC
" --------------------
set nocompatible

let s:vimhome = fnamemodify(expand("$MYVIMRC"), ":p:h")
let s:ycmdir = expand(s:vimhome . '/bundle/YouCompleteMe')

" Clean &rtp and add ycm plugin dir:
set runtimepath=$VIMRUNTIME
execute "set runtimepath+=" . s:ycmdir

" YCM globals:
let g:ycm_server_keep_logfiles = 1
let g:ycm_server_log_level = 'debug'
let g:ycm_global_ycm_extra_conf = expand(s:ycmdir . '/third_party/ycmd/examples/.ycm_extra_conf.py')

filetype plugin indent on

set hidden
set nobackup
set noundofile
syntax enable
```

- [ ] 2) Edit any file belonging to a `FixIt`-supported filetype. An easy choice is: `**/YouCompleteMe/third_party/ycmd/examples/samples/some_cpp.cpp`. Instead of spawning `YcmToggleLogs` in a split, rely on `/tmp/ycm_temp` for this demo: the added buffer hinders reproducibility.
- [ ] 3) Force or find a flagged diagnostic advertising a fix-it. Anything will do:  e.g., `printf("%d", atan(1) * 4);` should trigger a `-Wformat` error in c.  Running `:YcmCompleter FixIt` should produce something like this:

```  
/tmp/ycm_temp/server_*_stderr.log
---------------------------------
2016-05-09 00:38:47,285 - INFO - Received health request
2016-05-09 00:38:47,293 - INFO - Received event notification
2016-05-09 00:38:47,293 - DEBUG - Event name: BufferVisit
2016-05-09 00:38:47,302 - INFO - Received event notification
2016-05-09 00:38:47,303 - DEBUG - Event name: FileReadyToParse
2016-05-09 00:38:47,303 - INFO - Adding buffer identifiers for file:
... repeats last few 2x more times ...
/home/user1/.vim/bundle/YouCompleteMe/third_party/ycmd/examples/samples/some_cpp.cpp
2016-05-09 00:38:47,341 - INFO - Received filetype completion available request
2016-05-09 00:39:18,035 - INFO - Received defined subcommands request
2016-05-09 00:39:19,509 - INFO - Received command request
2016-05-09 00:41:00,581 - INFO - Received event notification
2016-05-09 00:41:00,582 - DEBUG - Event name: BufferUnload

:messages
---------
Error detected while processing function <SNR>26_CompleterCommand[18]..provider#python#Call:
line   18:
IndexError('list index out of range',)
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/neovim/msgpack_rpc/session.py", line 185, in handler
	rv = self._request_cb(name, args)
  File "/usr/lib/python2.7/site-packages/neovim/api/nvim.py", line 151, in filter_requ est_cb
	result = request_cb(self._from_nvim(name), args)
  File "/usr/lib/python2.7/site-packages/neovim/plugin/host.py", line 74, in _on_reque st
	rv = handler(*args)
  File "/usr/lib/python2.7/site-packages/neovim/plugin/script_host.py", line 75, in py thon_execute
	exec(script, self.module.__dict__)
  File "<string>", line 1, in <module>
IndexError: list index out of range

:scriptnames
------------
. . .
26: ~/.vim/bundle/YouCompleteMe/autoload/youcompleteme.vim
. . .
```

- [ ]  4) Apply patch (to regular Vim, as well). Attempt to break via multiple splits and tabs containing fix-its alongside special buffer types, etc. Hopefully, these hokey/half-ass, end-user-style testing measures will suffice. Though if need be, perhaps the original contributor of the FixIt feature has a harness ready to go. Otherwise, I'd have to defer to those with actual QA and/or Python/C-API knowhow to suggest a more methodical/rigorous/precise approach.


## OS and version info

  - `NVIM 0.1.4` from Neovim's stable branch in both Arch (`4.5.1-1-ARCH`, pkg
    from dist repo) and Fedora 23 (`4.4.8-300.fc23.x86_64`, pkg from Neovim's
    officially endorsed Copr repo). Python 2/3 modules provided by Pip.
  - The sole classic Vim version tested (after patching with this PR, of course)
    was `7.4.1689` with `+python3` on Ubuntu 16.04 (`4.4.0-22`, `vim-gnome`
    pkg from dist repo).
  - All YCMs were installed by running `./install.py --clang-completer`.
  - `vim --version` output can be provided upon request.


## <a name="rationale">Rationale</a>

It appears Neovim's `api.common.RemoteSequence` [class][] implements `__getitem__` in a way that comports with Python's traditional sequence/slice behavior while deviating from Vim's [approach][] of using [buffer numbers][] as indices/keys. This was basically the topic of a year-old (but apparently still active) issues-[thread][] regarding compatibility in Neovim. And while it's surely not in YCM's interest to start playing whack-a-mole with every last quirk of Neovim's, it's possible some attention might be warranted here -- seeing as nothing decisive on the matter appears forthcoming from the Neovim camp. Hopefully, sufficient numbers of Neovim users who've encountered this [error] appreciate the FixIt feature enough to constitute more than a corner-case minority.


<!-- Sources -->

[class]: https://github.com/neovim/python-client/blob/master/neovim/api/common.py#L137
    "normal pythonic slice behavior"

[thread]: https://github.com/neovim/neovim/issues/2823
    "vim.buffers change in neovim"

[error]: https://github.com/vim/vim/blob/master/src/if_py_both.h#L2311
    "list index out of range"

[approach]: https://github.com/vim/vim/blob/master/src/if_py_both.h#L6403
    "if_py_both.h"

[buffer numbers]: https://github.com/vim/vim/blob/master/src/if_py_both.h#L5277
    "Buffer list object"

<!-- vim:ft=markdown:
-->


[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2158)
<!-- Reviewable:end -->
