### PR TITLE
[READY] Fix LookupError exception when opening a file

### DIFF
--- a/python/ycm/tests/syntax_parse_test.py
+++ b/python/ycm/tests/syntax_parse_test.py
@@ -30,12 +30,13 @@ import os
 from nose.tools import eq_
 from hamcrest import assert_that, has_items
 from ycm import syntax_parse
+from ycmd.utils import ReadFile
 
 
 def ContentsOfTestFile( test_file ):
   dir_of_script = os.path.dirname( os.path.abspath( __file__ ) )
   full_path_to_test_file = os.path.join( dir_of_script, 'testdata', test_file )
-  return open( full_path_to_test_file ).read()
+  return ReadFile( full_path_to_test_file )
 
 
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -851,7 +851,9 @@ def WriteToPreviewWindow( message ):
 def CheckFilename( filename ):
   """Check if filename is openable."""
   try:
-    open( filename ).close()
+    # We don't want to check for encoding issues when trying to open the file
+    # so we open it in binary mode.
+    open( filename, mode = 'rb' ).close()
   except TypeError:
     raise RuntimeError( "'{0}' is not a valid filename".format( filename ) )
   except IOError as error:


### PR DESCRIPTION
Fixes #2159.

I think the issue is caused by `locale.getpreferredencoding()` returning an empty string on some configurations (especially on OS X with Python 2). This is [the value used by default when no encoding is specified](https://docs.python.org/2/library/io.html?highlight=open#io.open). The same error is raised if we do:
```python
open( 'some_file', encoding = '' )
```

For references, similar issues: https://github.com/Valloric/ycmd/issues/395, https://github.com/Valloric/ycmd/issues/419

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2160)
<!-- Reviewable:end -->
