### PR TITLE
[WIP] Getters for semantic tokens and skipped ranges.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/ross/requests-futures
 [submodule "third_party/ycmd"]
 	path = third_party/ycmd
-	url = https://github.com/Valloric/ycmd
+	url = https://github.com/davits/ycmd

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -142,6 +142,10 @@ def GetCurrentBufferFilepath():
   return GetBufferFilepath( vim.current.buffer )
 
 
+def GetCurrentBufferNumber():
+  return vim.current.buffer.number
+
+
 def BufferIsVisible( buffer_number ):
   if buffer_number < 0:
     return False

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -636,10 +636,16 @@ class YouCompleteMe( object ):
       request_data = {
         'filepath': vimsupport.GetBufferFilepath( buffer ),
         'filetypes': vimsupport.FiletypesForBuffer( buffer ),
-        'start_line': start_line,
-        'start_column': start_column,
-        'end_line': end_line,
-        'end_column': end_column,
+        'range': {
+          'start': {
+            'line_num': start_line,
+            'column_num': start_column,
+          },
+          'end': {
+            'line_num': end_line,
+            'column_num': end_column,
+          },
+        }
       }
       response = BaseRequest.PostDataToHandler( request_data,
                                                 'semantic_tokens',

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -641,9 +641,10 @@ class YouCompleteMe( object ):
         'end_line': end_line,
         'end_column': end_column,
       }
-      return BaseRequest.PostDataToHandler( request_data,
-                                            'semantic_tokens',
-                                            timeout )
+      response = BaseRequest.PostDataToHandler( request_data,
+                                                'semantic_tokens',
+                                                timeout )
+      return response[ 'tokens' ]
     except ServerError as e:
       if 'Still parsing' in str( e ):
         return 'Parsing'
@@ -661,9 +662,10 @@ class YouCompleteMe( object ):
         'filepath': vimsupport.GetBufferFilepath( buffer ),
         'filetypes': vimsupport.FiletypesForBuffer( buffer ),
       }
-      return BaseRequest.PostDataToHandler( request_data,
-                                            'skipped_ranges',
-                                            timeout )
+      response = BaseRequest.PostDataToHandler( request_data,
+                                                'skipped_ranges',
+                                                timeout )
+      return response[ 'skipped_ranges' ]
     except ServerError as e:
       if 'Still parsing' in str( e ):
         return 'Parsing'


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**
- [x ] I have read and understood YCM's [CONTRIBUTING](https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md) document.
- [x ] I have read and understood YCM's [CODE_OF_CONDUCT](https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

This is a concept of how tokens should/could be supported on YCM side.
So basically YCM should provide an easy way to get tokens from ycmd without user getting involved into client server relations.

You can test how everything works with this plugin: https://github.com/davits/DyeVim , just put it after YCM in rtp, no other configuration needed.

I am also thinking on a way to block "Already parsing" requests triggering "File Ready" callbacks, and as a side effect fix the problem when YcmDiags command does nothing when file is already being parsed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2244)

<!-- Reviewable:end -->
