### PR TITLE
[READY] Implement shutdown handler

### DIFF
--- a/python/ycm/client/shutdown_request.py
+++ b/python/ycm/client/shutdown_request.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2016 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from requests.exceptions import ReadTimeout
+
+from ycm.client.base_request import BaseRequest
+
+TIMEOUT_SECONDS = 0.1
+
+
+class ShutdownRequest( BaseRequest ):
+  def __init__( self ):
+    super( BaseRequest, self ).__init__()
+
+
+  def Start( self ):
+    try:
+      self.PostDataToHandler( {},
+                              'shutdown',
+                              TIMEOUT_SECONDS )
+    except ReadTimeout:
+      pass
+
+
+  def Response( self ):
+    return self._response
+
+
+def SendShutdownRequest():
+  request = ShutdownRequest()
+  # This is a blocking call.
+  request.Start()

--- a/python/ycm/test_utils.py
+++ b/python/ycm/test_utils.py
@@ -47,18 +47,6 @@ BWIPEOUT_REGEX = re.compile( r"^(?:silent! )bwipeout!? ([0-9]+)$" )
 # https://github.com/Valloric/YouCompleteMe/pull/1694
 VIM_MOCK = MagicMock()
 
-# The default options which are only relevant to the client, not the server and
-# thus are not part of default_options.json, but are required for a working
-# YouCompleteMe or OmniCompleter object.
-DEFAULT_CLIENT_OPTIONS = {
-  'server_log_level': 'info',
-  'extra_conf_vim_data': [],
-  'show_diagnostics_ui': 1,
-  'enable_diagnostic_signs': 1,
-  'enable_diagnostic_highlighting': 0,
-  'always_populate_location_list': 0,
-}
-
 
 def MockGetBufferNumber( buffer_filename ):
   for buffer in VIM_MOCK.buffers:

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -33,11 +33,10 @@ from hamcrest import contains_string
 from ycm.test_utils import MockVimModule, ExtendedMock
 MockVimModule()
 
-from ycm.test_utils import DEFAULT_CLIENT_OPTIONS, ExpectedFailure
 from ycm.omni_completer import OmniCompleter
-from ycm.youcompleteme import YouCompleteMe
+from ycm.test_utils import ExpectedFailure
+from ycm.tests.server_test import MakeUserOptions, Server_test
 
-from ycmd import user_options_store
 from ycmd.utils import ToBytes
 from ycmd.request_wrap import RequestWrap
 
@@ -75,23 +74,7 @@ def BuildRequestWrap( line_num, column_num, contents ):
   return RequestWrap( BuildRequest( line_num, column_num, contents ) )
 
 
-def MakeUserOptions( custom_options = {} ):
-  options = dict( user_options_store.DefaultOptions() )
-  options.update( DEFAULT_CLIENT_OPTIONS )
-  options.update( custom_options )
-  return options
-
-
-class OmniCompleter_test( object ):
-
-  def setUp( self ):
-    # We need a server instance for FilterAndSortCandidates
-    self._server_state = YouCompleteMe( MakeUserOptions() )
-
-
-  def tearDown( self ):
-    self._server_state.OnVimLeave()
-
+class OmniCompleter_test( Server_test ):
 
   def OmniCompleter_GetCompletions_Cache_List_test( self ):
     omni_completer = OmniCompleter( MakeUserOptions( {

--- a/python/ycm/tests/postcomplete_tests.py
+++ b/python/ycm/tests/postcomplete_tests.py
@@ -33,9 +33,9 @@ from hamcrest import assert_that, empty
 from mock import MagicMock, DEFAULT, patch
 from nose.tools import eq_, ok_
 
-from ycmd.utils import ToBytes
 from ycm import vimsupport
-from ycm.youcompleteme import YouCompleteMe
+from ycm.tests.server_test import Server_test
+from ycmd.utils import ToBytes
 
 
 def GetVariableValue_CompleteItemIs( word, abbr = None, menu = None,
@@ -66,15 +66,7 @@ def BuildCompletion( namespace = None, insertion_text = 'Test',
   }
 
 
-class PostComplete_test():
-
-  def setUp( self ):
-    self.ycm = YouCompleteMe( MagicMock( spec_set = dict ) )
-
-
-  def tearDown( self ):
-    self.ycm.OnVimLeave()
-
+class PostComplete_test( Server_test ):
 
   @contextlib.contextmanager
   def _SetupForCsharpCompletionDone( self, completions ):
@@ -84,34 +76,34 @@ class PostComplete_test():
         request = MagicMock()
         request.Done = MagicMock( return_value = True )
         request.RawResponse = MagicMock( return_value = completions )
-        self.ycm._latest_completion_request = request
+        self._server_state._latest_completion_request = request
         yield
 
 
   @patch( 'ycm.vimsupport.CurrentFiletypes', return_value = [ 'cs' ] )
   def GetCompleteDoneHooks_ResultOnCsharp_test( self, *args ):
-    result = self.ycm.GetCompleteDoneHooks()
+    result = self._server_state.GetCompleteDoneHooks()
     eq_( 1, len( list( result ) ) )
 
 
   @patch( 'ycm.vimsupport.CurrentFiletypes', return_value = [ 'txt' ] )
   def GetCompleteDoneHooks_EmptyOnOtherFiletype_test( self, *args ):
-    result = self.ycm.GetCompleteDoneHooks()
+    result = self._server_state.GetCompleteDoneHooks()
     eq_( 0, len( list( result ) ) )
 
 
   @patch( 'ycm.vimsupport.CurrentFiletypes', return_value = [ 'txt' ] )
   def OnCompleteDone_WithActionCallsIt_test( self, *args ):
     action = MagicMock()
-    self.ycm._complete_done_hooks[ 'txt' ] = action
-    self.ycm.OnCompleteDone()
+    self._server_state._complete_done_hooks[ 'txt' ] = action
+    self._server_state.OnCompleteDone()
 
     ok_( action.called )
 
 
   @patch( 'ycm.vimsupport.CurrentFiletypes', return_value = [ 'txt' ] )
   def OnCompleteDone_NoActionNoError_test( self, *args ):
-    self.ycm.OnCompleteDone()
+    self._server_state.OnCompleteDone()
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -119,7 +111,8 @@ class PostComplete_test():
           GetVariableValue_CompleteItemIs( 'Test' ) )
   def FilterToCompletedCompletions_NewVim_MatchIsReturned_test( self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     eq_( list( result ), completions )
 
 
@@ -129,7 +122,7 @@ class PostComplete_test():
   def FilterToCompletedCompletions_NewVim_ShortTextDoesntRaise_test( self,
                                                                      *args ):
     completions = [ BuildCompletion( insertion_text = 'AAA' ) ]
-    self.ycm._FilterToMatchingCompletions( completions, False )
+    self._server_state._FilterToMatchingCompletions( completions, False )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -138,7 +131,8 @@ class PostComplete_test():
   def FilterToCompletedCompletions_NewVim_ExactMatchIsReturned_test( self,
                                                                      *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     eq_( list( result ), completions )
 
 
@@ -148,7 +142,8 @@ class PostComplete_test():
   def FilterToCompletedCompletions_NewVim_NonMatchIsntReturned_test( self,
                                                                      *args ):
     completions = [ BuildCompletion( insertion_text = 'A' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     assert_that( list( result ), empty() )
 
 
@@ -157,7 +152,8 @@ class PostComplete_test():
           GetVariableValue_CompleteItemIs( '†es†' ) )
   def FilterToCompletedCompletions_NewVim_Unicode_test( self, *args ):
     completions = [ BuildCompletion( insertion_text = '†es†' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     eq_( list( result ), completions )
 
 
@@ -165,7 +161,8 @@ class PostComplete_test():
   @patch( 'ycm.vimsupport.TextBeforeCursor', return_value = '   Test' )
   def FilterToCompletedCompletions_OldVim_MatchIsReturned_test( self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     eq_( list( result ), completions )
 
 
@@ -174,7 +171,7 @@ class PostComplete_test():
   def FilterToCompletedCompletions_OldVim_ShortTextDoesntRaise_test( self,
                                                                      *args ):
     completions = [ BuildCompletion( insertion_text = 'AAA' ) ]
-    self.ycm._FilterToMatchingCompletions( completions, False )
+    self._server_state._FilterToMatchingCompletions( completions, False )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = False )
@@ -182,7 +179,8 @@ class PostComplete_test():
   def FilterToCompletedCompletions_OldVim_ExactMatchIsReturned_test( self,
                                                                      *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     eq_( list( result ), completions )
 
 
@@ -191,7 +189,8 @@ class PostComplete_test():
   def FilterToCompletedCompletions_OldVim_NonMatchIsntReturned_test( self,
                                                                      *args ):
     completions = [ BuildCompletion( insertion_text = 'A' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     assert_that( list( result ), empty() )
 
 
@@ -199,7 +198,8 @@ class PostComplete_test():
   @patch( 'ycm.vimsupport.TextBeforeCursor', return_value = 'Uniçø∂¢' )
   def FilterToCompletedCompletions_OldVim_Unicode_test( self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Uniçø∂¢' ) ]
-    result = self.ycm._FilterToMatchingCompletions( completions, False )
+    result = self._server_state._FilterToMatchingCompletions( completions,
+                                                              False )
     assert_that( list( result ), empty() )
 
 
@@ -208,7 +208,7 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_OldVim_MatchIsReturned_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, True )
 
@@ -218,7 +218,8 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_OldVim_ShortTextDoesntRaise_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = "AAA" ) ]
-    self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText( completions )
+    self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
+                                                               completions )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = False )
@@ -226,7 +227,7 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_OldVim_ExactMatchIsntReturned_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, False )
 
@@ -236,7 +237,7 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_OldVim_NonMatchIsntReturned_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = 'A' ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, False )
 
@@ -246,7 +247,7 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_OldVim_Unicode_test(
     self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Uniçø∂¢' ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, True )
 
@@ -258,7 +259,7 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_NewVim_MatchIsReturned_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, True )
 
@@ -270,7 +271,8 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_NewVim_ShortTextDoesntRaise_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = 'AAA' ) ]
-    self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText( completions )
+    self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
+                                                                completions )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -280,7 +282,7 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_NewVim_ExactMatchIsntReturned_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = 'Test' ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, False )
 
@@ -292,7 +294,7 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_NewVim_NonMatchIsntReturned_test( # noqa
     self, *args ):
     completions = [ BuildCompletion( insertion_text = "A" ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, False )
 
@@ -304,27 +306,27 @@ class PostComplete_test():
   def HasCompletionsThatCouldBeCompletedWithMoreText_NewVim_Unicode_test(
     self, *args ):
     completions = [ BuildCompletion( insertion_text = "Uniçø∂¢" ) ]
-    result = self.ycm._HasCompletionsThatCouldBeCompletedWithMoreText(
+    result = self._server_state._HasCompletionsThatCouldBeCompletedWithMoreText(
                                                                 completions )
     eq_( result, True )
 
 
   def GetRequiredNamespaceImport_ReturnNoneForNoExtraData_test( self ):
-    eq_( None, self.ycm._GetRequiredNamespaceImport( {} ) )
+    eq_( None, self._server_state._GetRequiredNamespaceImport( {} ) )
 
 
   def GetRequiredNamespaceImport_ReturnNamespaceFromExtraData_test( self ):
     namespace = 'A_NAMESPACE'
-    eq_( namespace, self.ycm._GetRequiredNamespaceImport(
+    eq_( namespace, self._server_state._GetRequiredNamespaceImport(
       BuildCompletion( namespace )
     ) )
 
 
   def GetCompletionsUserMayHaveCompleted_ReturnEmptyIfNotDone_test( self ):
     with self._SetupForCsharpCompletionDone( [] ):
-      self.ycm._latest_completion_request.Done = MagicMock(
+      self._server_state._latest_completion_request.Done = MagicMock(
         return_value = False )
-      eq_( [], self.ycm.GetCompletionsUserMayHaveCompleted() )
+      eq_( [], self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -334,7 +336,7 @@ class PostComplete_test():
     self, *args ):
     completions = [ BuildCompletion( None ) ]
     with self._SetupForCsharpCompletionDone( completions ):
-      eq_( [], self.ycm.GetCompletionsUserMayHaveCompleted() )
+      eq_( [], self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = False )
@@ -343,7 +345,7 @@ class PostComplete_test():
     completions = [ BuildCompletion( None ) ]
     with self._SetupForCsharpCompletionDone( completions ):
       with patch( 'ycm.vimsupport.TextBeforeCursor', return_value = '   Te' ):
-        eq_( [], self.ycm.GetCompletionsUserMayHaveCompleted() )
+        eq_( [], self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -354,7 +356,8 @@ class PostComplete_test():
     with self._SetupForCsharpCompletionDone( completions ):
       with patch( 'ycm.vimsupport.GetVariableValue',
                   GetVariableValue_CompleteItemIs( *info[ 1: ] ) ):
-        eq_( completions, self.ycm.GetCompletionsUserMayHaveCompleted() )
+        eq_( completions,
+             self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -367,7 +370,7 @@ class PostComplete_test():
       with patch( 'ycm.vimsupport.GetVariableValue',
                   GetVariableValue_CompleteItemIs( *info[ 1: ] ) ):
         eq_( [ completions[ 0 ] ],
-               self.ycm.GetCompletionsUserMayHaveCompleted() )
+               self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -379,7 +382,7 @@ class PostComplete_test():
     with self._SetupForCsharpCompletionDone( completions ):
       with patch( 'ycm.vimsupport.GetVariableValue',
                   GetVariableValue_CompleteItemIs( *info[ 1: ] ) ):
-        eq_( [], self.ycm.GetCompletionsUserMayHaveCompleted() )
+        eq_( [], self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = True )
@@ -389,7 +392,8 @@ class PostComplete_test():
     self, *args ):
     completions = [ BuildCompletion( None ) ]
     with self._SetupForCsharpCompletionDone( completions ):
-      eq_( completions, self.ycm.GetCompletionsUserMayHaveCompleted() )
+      eq_( completions,
+           self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = False )
@@ -397,13 +401,14 @@ class PostComplete_test():
     self, *args ):
     completions = [ BuildCompletion( None ) ]
     with self._SetupForCsharpCompletionDone( completions ):
-      eq_( completions, self.ycm.GetCompletionsUserMayHaveCompleted() )
+      eq_( completions,
+           self._server_state.GetCompletionsUserMayHaveCompleted() )
 
 
   @patch( 'ycm.vimsupport.VimVersionAtLeast', return_value = False )
   def PostCompleteCsharp_EmptyDoesntInsertNamespace_test( self, *args ):
     with self._SetupForCsharpCompletionDone( [] ):
-      self.ycm._OnCompleteDone_Csharp()
+      self._server_state._OnCompleteDone_Csharp()
       ok_( not vimsupport.InsertNamespace.called )
 
 
@@ -412,7 +417,7 @@ class PostComplete_test():
     self, *args ):
     completions = [ BuildCompletion( None ) ]
     with self._SetupForCsharpCompletionDone( completions ):
-      self.ycm._OnCompleteDone_Csharp()
+      self._server_state._OnCompleteDone_Csharp()
       ok_( not vimsupport.InsertNamespace.called )
 
 
@@ -421,7 +426,7 @@ class PostComplete_test():
     namespace = 'A_NAMESPACE'
     completions = [ BuildCompletion( namespace ) ]
     with self._SetupForCsharpCompletionDone( completions ):
-      self.ycm._OnCompleteDone_Csharp()
+      self._server_state._OnCompleteDone_Csharp()
       vimsupport.InsertNamespace.assert_called_once_with( namespace )
 
 
@@ -435,5 +440,5 @@ class PostComplete_test():
       BuildCompletion( namespace2 ),
     ]
     with self._SetupForCsharpCompletionDone( completions ):
-      self.ycm._OnCompleteDone_Csharp()
+      self._server_state._OnCompleteDone_Csharp()
       vimsupport.InsertNamespace.assert_called_once_with( namespace2 )

--- a/python/ycm/tests/server_test.py
+++ b/python/ycm/tests/server_test.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2016 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from ycm.test_utils import MockVimModule
+MockVimModule()
+
+import requests
+import time
+
+from ycm.client.base_request import BaseRequest
+from ycm.youcompleteme import YouCompleteMe
+from ycmd import user_options_store
+
+# The default options which are only relevant to the client, not the server and
+# thus are not part of default_options.json, but are required for a working
+# YouCompleteMe or OmniCompleter object.
+DEFAULT_CLIENT_OPTIONS = {
+  'server_log_level': 'info',
+  'extra_conf_vim_data': [],
+  'show_diagnostics_ui': 1,
+  'enable_diagnostic_signs': 1,
+  'enable_diagnostic_highlighting': 0,
+  'always_populate_location_list': 0,
+}
+
+
+def MakeUserOptions( custom_options = {} ):
+  options = dict( user_options_store.DefaultOptions() )
+  options.update( DEFAULT_CLIENT_OPTIONS )
+  options.update( custom_options )
+  return options
+
+
+class Server_test():
+
+  def _IsReady( self ):
+    return BaseRequest.GetDataFromHandler( 'ready' )
+
+
+  def _WaitUntilReady( self, timeout = 5 ):
+    total_slept = 0
+    while True:
+      try:
+        if total_slept > timeout:
+          raise RuntimeError( 'Waited for the server to be ready '
+                              'for {0} seconds, aborting.'.format(
+                                timeout ) )
+
+        if self._IsReady():
+          return
+      except requests.exceptions.ConnectionError:
+        pass
+      finally:
+        time.sleep( 0.1 )
+        total_slept += 0.1
+
+
+  def setUp( self ):
+    self._server_state = YouCompleteMe( MakeUserOptions() )
+    self._WaitUntilReady()
+
+
+  def tearDown( self ):
+    self._server_state.OnVimLeave()

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -27,21 +27,12 @@ from ycm.test_utils import MockVimModule
 MockVimModule()
 
 import sys
-from mock import MagicMock
 from hamcrest import assert_that, is_in, is_not
 
-from ycm.youcompleteme import YouCompleteMe
+from ycm.tests.server_test import Server_test
 
 
-class YouCompleteMe_test():
-
-  def setUp( self ):
-    self.ycm = YouCompleteMe( MagicMock( spec_set = dict ) )
-
-
-  def tearDown( self ):
-    self.ycm.OnVimLeave()
-
+class YouCompleteMe_test( Server_test ):
 
   def YcmCoreNotImported_test( self ):
     assert_that( 'ycm_core', is_not( is_in( sys.modules ) ) )


### PR DESCRIPTION
This PR depends on https://github.com/Valloric/ycmd/pull/282.

We don't want to block Vim exit if the server takes too much time to answer the shutdown request so we use a timeout of 100ms for this request. In my experience, it takes ~5ms.

The `YcmStopServer` command only exists for testing purpose. It will be removed in the final version of this PR.

Fixes #876.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2245)
<!-- Reviewable:end -->
