### PR TITLE
Provide config to bypass vim autoload

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -130,10 +130,12 @@ let g:ycm_disable_for_files_larger_than_kb =
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 if has( 'vim_starting' ) " loading at startup
-  augroup youcompletemeStart
-    autocmd!
-    autocmd VimEnter * call youcompleteme#Enable()
-  augroup END
+  if !exists( "g:skip_youcompleteme_autoload" )
+    augroup youcompletemeStart
+      autocmd!
+      autocmd VimEnter * call youcompleteme#Enable()
+    augroup END
+  endif
 else " manual loading with :packadd
   call youcompleteme#Enable()
 endif


### PR DESCRIPTION
This PR addresses some of the user frustration in #2085 and #2071 and is something I've really enjoyed having.

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The current `plugin/youcompleteme.vim` registers the autoload to execute during the `VimEnter` stage. But even `VimEnter` must complete before the user can begin editing a buffer. Because of this the YCM vim setup dominates the boot time of even vim configs that leverage dozens of plugins. Executing `youcompleteme#Enable()` can take hundreds of milliseconds even on a modern piece of hardware.

This change allows users to disable the default autoloading if they wish so that they can execute `youcompleteme#Enable()` at a more appropriate time and get to an editable buffer faster. It's an advanced user feature, for sure, but I can't think of a better way to allow extremely fast startup time while also using YCM, can you?

No automated tests added because the viml doesn't appear to be tested. The change seems to work well, however.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2260)
<!-- Reviewable:end -->
