### PR TITLE
OnFileReadyToParse triggered too many times

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -90,7 +90,7 @@ function! youcompleteme#Enable()
     " the user does :enew and then :set ft=something, we need to run buf init
     " code again.
     autocmd BufReadPre * call s:OnBufferReadPre( expand( '<afile>:p' ) )
-    autocmd BufRead,BufEnter,FileType * call s:OnBufferVisit()
+    autocmd BufRead,FileType * call s:OnBufferVisit()
     autocmd BufUnload * call s:OnBufferUnload( expand( '<afile>:p' ) )
     autocmd CursorHold,CursorHoldI * call s:OnCursorHold()
     autocmd InsertLeave * call s:OnInsertLeave()


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

I'm not familiar enough with the codebase to be confident in any changes I make so feel free to lay into the change as this is very specific to the tern completer.

The problem is reproduced by using the tern completer, fire up Vim, download a thirdparty lib from anywhere (I used moment js):

`import moment from './lib/moment';`

Attempt to autocomplete suggestions for moment:

`moment.`

Suggestions are correct.

Hold down the up or down arrow keys for around 10 seconds - each time we move from one suggestion to another suggestion BufEnter is being triggered. 

Attempt to autocomplete suggestions again for moment and the results will be from the object type. This is arguably a ternjs threading issue - which I've raised with them [here](https://github.com/ternjs/tern/issues/811) but I don't believe we need to be sending down 100s of notifications as we scroll through suggestions.

The issue is reproducible on macvim and gvim. 

An alternate solution is to remove [this line](https://github.com/Valloric/YouCompleteMe/blob/871387bd2a2ed9270ccc17ed63dde99c840deab5/autoload/youcompleteme.vim#L448)

But that solution seems like it may break other things so I've removed BufEnter as it seems to me the intention is to trigger it only when we enter a buffer (which should be covered by BufRead/FileType *)

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

Commit message:

'autocmd BufEnter' triggers the OnFileReadyToParse function everytime we scroll completion suggestions.

This spams Ycmd and in turn spams the Tern server or other completer and causes incorrect suggestions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2265)
<!-- Reviewable:end -->
