### PR TITLE
[READY] Improve extraction of keywords from syntax list

### DIFF
--- a/python/ycm/tests/syntax_parse_test.py
+++ b/python/ycm/tests/syntax_parse_test.py
@@ -43,10 +43,10 @@ def KeywordsFromSyntaxListOutput_PythonSyntax_test():
     'bytearray', 'IndexError', 'all', 'help', 'vars', 'SyntaxError', 'global',
     'elif', 'unicode', 'sorted', 'memoryview', 'isinstance', 'except',
     'nonlocal', 'NameError', 'finally', 'BytesWarning', 'dict', 'IOError',
-    'pass', 'oct', 'match', 'bin', 'SystemExit', 'return', 'StandardError',
-    'format', 'TabError', 'break', 'next', 'not', 'UnicodeDecodeError',
-    'False', 'RuntimeWarning', 'list', 'iter', 'try', 'reload', 'Warning',
-    'round', 'dir', 'cmp', 'set', 'bytes', 'UnicodeTranslateError', 'intern',
+    'pass', 'oct', 'bin', 'SystemExit', 'return', 'StandardError', 'format',
+    'TabError', 'break', 'next', 'not', 'UnicodeDecodeError', 'False',
+    'RuntimeWarning', 'list', 'iter', 'try', 'reload', 'Warning', 'round',
+    'dir', 'cmp', 'set', 'bytes', 'UnicodeTranslateError', 'intern',
     'issubclass', 'yield', 'Ellipsis', 'hash', 'locals', 'BufferError',
     'slice', 'for', 'FloatingPointError', 'sum', 'VMSError', 'getattr', 'abs',
     'print', 'import', 'True', 'FutureWarning', 'ImportWarning', 'None',
@@ -77,8 +77,8 @@ def KeywordsFromSyntaxListOutput_PythonSyntax_test():
 def KeywordsFromSyntaxListOutput_CppSyntax_test():
   expected_keywords = (
     'int_fast32_t', 'FILE', 'size_t', 'bitor', 'typedef', 'const', 'struct',
-    'uint8_t', 'fpos_t', 'thread_local', 'unsigned', 'uint_least16_t', 'match',
-    'do', 'intptr_t', 'uint_least64_t', 'return', 'auto', 'void', '_Complex',
+    'uint8_t', 'fpos_t', 'thread_local', 'unsigned', 'uint_least16_t', 'do',
+    'intptr_t', 'uint_least64_t', 'return', 'auto', 'void', '_Complex',
     'break', '_Alignof', 'not', 'using', '_Static_assert', '_Thread_local',
     'public', 'uint_fast16_t', 'this', 'continue', 'char32_t', 'int16_t',
     'intmax_t', 'static', 'clock_t', 'sizeof', 'int_fast64_t', 'mbstate_t',
@@ -108,7 +108,7 @@ def KeywordsFromSyntaxListOutput_JavaSyntax_test():
   expected_keywords = (
     'code', 'text', 'cols', 'datetime', 'disabled', 'shape', 'codetype', 'alt',
     'compact', 'style', 'valuetype', 'short', 'finally', 'continue', 'extends',
-    'valign', 'match', 'bordercolor', 'do', 'return', 'rel', 'rules', 'void',
+    'valign', 'bordercolor', 'do', 'return', 'rel', 'rules', 'void',
     'nohref', 'abbr', 'background', 'scrolling', 'instanceof', 'name',
     'summary', 'try', 'default', 'noshade', 'coords', 'dir', 'frame', 'usemap',
     'ismap', 'static', 'hspace', 'vlink', 'for', 'selected', 'rev', 'vspace',
@@ -273,25 +273,25 @@ def ExtractKeywordsFromGroup_KeywordStarts_test():
   assert_that( syntax_parse._ExtractKeywordsFromGroup(
                  syntax_parse.SyntaxGroup( '', [
                    'foo bar',
-                   'transparent boo baa',
+                   'contained boo baa',
                    'zoo goo',
                  ] ) ),
-               contains_inanyorder( 'foo', 'bar', 'zoo', 'goo' ) )
+               contains_inanyorder( 'foo', 'bar', 'boo', 'baa', 'zoo', 'goo' ) )
 
 
 def ExtractKeywordsFromGroup_KeywordMiddle_test():
   assert_that( syntax_parse._ExtractKeywordsFromGroup(
                  syntax_parse.SyntaxGroup( '', [
-                   'foo oneline bar',
+                   'foo contained bar',
                    'zoo goo'
                  ] ) ),
-               contains_inanyorder( 'foo', 'bar', 'zoo', 'goo' ) )
+               contains_inanyorder( 'foo', 'contained', 'bar', 'zoo', 'goo' ) )
 
 
 def ExtractKeywordsFromGroup_KeywordAssign_test():
   assert_that( syntax_parse._ExtractKeywordsFromGroup(
                  syntax_parse.SyntaxGroup( '', [
-                   'foo end=zoo((^^//)) bar',
+                   'nextgroup=zoo skipwhite foo bar',
                    'zoo goo',
                  ] ) ),
                contains_inanyorder( 'foo', 'bar', 'zoo', 'goo' ) )
@@ -300,10 +300,19 @@ def ExtractKeywordsFromGroup_KeywordAssign_test():
 def ExtractKeywordsFromGroup_KeywordAssignAndMiddle_test():
   assert_that( syntax_parse._ExtractKeywordsFromGroup(
                  syntax_parse.SyntaxGroup( '', [
-                   'foo end=zoo((^^//)) transparent bar',
+                   'nextgroup=zoo foo skipnl bar',
                    'zoo goo',
                  ] ) ),
-               contains_inanyorder( 'foo', 'bar', 'zoo', 'goo' ) )
+               contains_inanyorder( 'foo', 'skipnl', 'bar', 'zoo', 'goo' ) )
+
+
+def ExtractKeywordsFromGroup_KeywordWithoutNextgroup_test():
+  assert_that( syntax_parse._ExtractKeywordsFromGroup(
+                 syntax_parse.SyntaxGroup( '', [
+                   'skipempty foo bar',
+                   'zoo goo',
+                 ] ) ),
+               contains_inanyorder( 'skipempty', 'foo', 'bar', 'zoo', 'goo' ) )
 
 
 def ExtractKeywordsFromGroup_ContainedSyntaxArgAllowed_test():


### PR DESCRIPTION
This PR is an attempt at improving the extraction of keywords from Vim syntax files. Current approach is to go through the `syntax list` output and:
  - ignore lines where the first word is a reserved keyword for syntax highlighting except for `contained`;
  - ignore all words used by Vim as arguments in the syntax commands;
  - add remaining words to the list of identifiers.

The main issue with this approach is that syntax arguments that could be valid language keywords are always ignored. There is also a bug where the `match` keyword is extracted while not being a language keyword (see the Python, C++, and Java tests).
With the new approach, we try to ignore Vim keywords only when necessary, that is:
  - ignore `syntax match` (fix the `match` keyword bug) and `syntax region` commands: they mostly contain arguments, syntax groups and regular expressions;
  - ignore  `nextgroup=` if in first position and subsequent arguments `skipempty`, `skipwhite`, and `skipnl`;
  - ignore `contained` argument if in first position;
  - add remaining words to the list of identifiers.

This strategy is based on observations of the `syntax list` output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2274)
<!-- Reviewable:end -->
