### PR TITLE
[READY] Fix errors with Vim versions prior to 7.4.107 when UltiSnips is not loaded

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -700,6 +700,16 @@ class YouCompleteMe( object ):
 
   def _AddUltiSnipsDataIfNeeded( self, extra_data ):
     # See :h UltiSnips#SnippetsInCurrentScope.
+
+    # Errors when evaluating Vim expressions are not caught by Python
+    # try/except blocks prior to Vim 7.4.107. We check that the UltiSnips
+    # function exists for these versions.
+    # TODO: remove this when bumping version requirement to 7.4.107 or greater.
+    if ( not vimsupport.VimVersionAtLeast( "7.4.107" ) and
+         not vimsupport.GetBoolValue(
+           "exists( '*UltiSnips#SnippetsInCurrentScope' )" ) ):
+      return
+
     try:
       vim.eval( 'UltiSnips#SnippetsInCurrentScope( 1 )' )
     except vim.error:


### PR DESCRIPTION
When UltiSnips is not loaded and the Vim version is older than 7.4.107, the following errors:
```viml
E117: Unknown function: UltiSnips#SnippetsInCurrentScope
E15: Invalid expression: UltiSnips#SnippetsInCurrentScope( 1 )
```
will occur each time a buffer is visited. This happens because we rely on a `try/except` block to catch these errors when evaluating the `UltiSnips#SnippetsInCurrentScope` function and [such blocks are not working prior to Vim 7.4.107](https://github.com/vim/vim/commit/9fee7d4729af19e7ce4950ede8de358c5eeb3772). We handle this by checking that the function exists for these versions of Vim.

Fixes #2335.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2337)
<!-- Reviewable:end -->
