### PR TITLE
[READY] Update miscellaneous commands in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,8 +872,7 @@ JavaScript project, you can do one of the following:
   [ycmd server][ycmd] (`:YcmRestartServer`)
 - change Vim's working directory (`:cd /path/to/new/project`), open a JavaScript
   file (or set filetype to JavaScript) and restart the Tern server using YCM
-  completer subcommands `:YcmCompleter StopServer` and `:YcmCompleter
-  StartServer`.
+  completer subcommand `:YcmCompleter RestartServer`.
 
 #### Tips and tricks
 
@@ -1444,32 +1443,6 @@ These commands are for general administration, rather than IDE-like features.
 They cover things like the semantic engine server instance and compilation
 flags.
 
-#### The `ClearCompilationFlagCache` subcommand
-
-YCM caches the flags it gets from the `FlagsForFile` function in your
-`ycm_extra_conf.py` file if you return them with the `do_cache` parameter set to
-`True`. The cache is in memory and is never invalidated (unless you restart Vim
-of course).
-
-This command clears that cache entirely. YCM will then re-query your
-`FlagsForFile` function as needed in the future.
-
-Supported in filetypes: `c, cpp, objc, objcpp`
-
-#### The `StartServer` subcommand
-
-Starts the semantic-engine-as-localhost-server for those semantic engines that
-work as separate servers that YCM talks to.
-
-Supported in filetypes: `cs, go, javascript, rust`
-
-#### The `StopServer` subcommand
-
-Stops the semantic-engine-as-localhost-server for those semantic engines that
-work as separate servers that YCM talks to.
-
-Supported in filetypes: `cs, go, javascript, rust`
-
 #### The `RestartServer` subcommand
 
 Restarts the semantic-engine-as-localhost-server for those semantic engines that
@@ -1482,7 +1455,19 @@ python binary to use to restart the Python semantic engine.
 :YcmCompleter RestartServer /usr/bin/python3.4
 ```
 
-Supported in filetypes: `cs, python, rust`
+Supported in filetypes: `cs, go, javascript, python, rust, typescript`
+
+#### The `ClearCompilationFlagCache` subcommand
+
+YCM caches the flags it gets from the `FlagsForFile` function in your
+`ycm_extra_conf.py` file if you return them with the `do_cache` parameter set to
+`True`. The cache is in memory and is never invalidated (unless you restart Vim
+of course).
+
+This command clears that cache entirely. YCM will then re-query your
+`FlagsForFile` function as needed in the future.
+
+Supported in filetypes: `c, cpp, objc, objcpp`
 
 #### The `ReloadSolution` subcommand
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -66,11 +66,9 @@ Contents ~
    2. The 'RefactorRename <new name>' subcommand      |RefactorRename-new-name|
    3. Multi-file Refactor                   |youcompleteme-multi-file-refactor|
   4. Miscellaneous Commands              |youcompleteme-miscellaneous-commands|
-   1. The |ClearCompilationFlagCache| subcommand
-   2. The |StartServer| subcommand
-   3. The |StopServer| subcommand
-   4. The |RestartServer| subcommand
-   5. The |ReloadSolution| subcommand
+   1. The |RestartServer| subcommand
+   2. The |ClearCompilationFlagCache| subcommand
+   3. The |ReloadSolution| subcommand
  8. Functions                                         |youcompleteme-functions|
   1. The |youcompleteme#GetErrorCount| function
   2. The |youcompleteme#GetWarningCount| function
@@ -1128,8 +1126,7 @@ project, you can do one of the following:
 
 - change Vim's working directory (':cd /path/to/new/project'), open a
   JavaScript file (or set filetype to JavaScript) and restart the Tern server
-  using YCM completer subcommands ':YcmCompleter StopServer' and
-  ':YcmCompleter StartServer'.
+  using YCM completer subcommand ':YcmCompleter RestartServer'.
 
 -------------------------------------------------------------------------------
                                                     *youcompleteme-tips-tricks*
@@ -1731,6 +1728,19 @@ They cover things like the semantic engine server instance and compilation
 flags.
 
 -------------------------------------------------------------------------------
+The *RestartServer* subcommand
+
+Restarts the semantic-engine-as-localhost-server for those semantic engines
+that work as separate servers that YCM talks to.
+
+An additional optional argument may be supplied for Python, specifying the
+python binary to use to restart the Python semantic engine.
+>
+  :YcmCompleter RestartServer /usr/bin/python3.4
+<
+Supported in filetypes: 'cs, go, javascript, python, rust, typescript'
+
+-------------------------------------------------------------------------------
 The *ClearCompilationFlagCache* subcommand
 
 YCM caches the flags it gets from the 'FlagsForFile' function in your
@@ -1742,35 +1752,6 @@ This command clears that cache entirely. YCM will then re-query your
 'FlagsForFile' function as needed in the future.
 
 Supported in filetypes: 'c, cpp, objc, objcpp'
-
--------------------------------------------------------------------------------
-The *StartServer* subcommand
-
-Starts the semantic-engine-as-localhost-server for those semantic engines that
-work as separate servers that YCM talks to.
-
-Supported in filetypes: 'cs, go, javascript, rust'
-
--------------------------------------------------------------------------------
-The *StopServer* subcommand
-
-Stops the semantic-engine-as-localhost-server for those semantic engines that
-work as separate servers that YCM talks to.
-
-Supported in filetypes: 'cs, go, javascript, rust'
-
--------------------------------------------------------------------------------
-The *RestartServer* subcommand
-
-Restarts the semantic-engine-as-localhost-server for those semantic engines
-that work as separate servers that YCM talks to.
-
-An additional optional argument may be supplied for Python, specifying the
-python binary to use to restart the Python semantic engine.
->
-  :YcmCompleter RestartServer /usr/bin/python3.4
-<
-Supported in filetypes: 'cs, python, rust'
 
 -------------------------------------------------------------------------------
 The *ReloadSolution* subcommand


### PR DESCRIPTION
With PR https://github.com/Valloric/ycmd/pull/506, we removed the `StartServer` subcommand in favor of the `RestartServer` one and we hid the `StopServer` subcommand from the user. Update the documentation to reflect this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2346)
<!-- Reviewable:end -->
