### PR TITLE
Added necessary dependencies for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Vim installed by running `vim --version`.
 
 FreeBSD 10.x comes with clang compiler but not the libraries needed to install.
 
-    pkg install llvm38 boost-all boost-python-libs clang38
+    pkg install llvm38 boost-all boost-python-libs clang38 py27-requests py27-frozendict py27-future
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/llvm38/lib/
 
 Install YouCompleteMe with [Vundle][].


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

With FreeBSD there is no libclang available as binary package. The easiest possible solution is to compile it by hand. As YCM is already capable to do that that on other platforms there was just one case with and url missing to make it work under FreeBSD as well.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

Found several threads where people had an issue "future not found" or something alike. On FreeBSD those libs do not get installed together with the default python installation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2357)
<!-- Reviewable:end -->
