### PR TITLE
[READY] Update ycmd. Update docs for GetTypeImprecise and GetDocImprecise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ install:
 script:
   - ci/travis/travis_script.sh
 env:
+  global:
+    # Travis can run out of RAM, so we need to be careful here.
+    - YCM_CORES=3
   matrix:
     - YCM_PYTHON_VERSION=2.7 YCM_FLAKE8=true
     # Since 3.0.4, Flake8 is not working anymore on Python 2.6.
@@ -30,6 +33,7 @@ addons:
     packages:
      - cmake-data
      - cmake
+     - g++-4.8
      - ninja-build
      # Everything below is a Python build dep (though it depends on Python
      # version). We need them because pyenv builds Python.

--- a/README.md
+++ b/README.md
@@ -1307,6 +1307,19 @@ NOTE: Causes re-parsing of the current translation unit.
 
 Supported in filetypes: `c, cpp, objc, objcpp, javascript, typescript`
 
+#### The `GetTypeImprecise` subcommand
+
+WARNING: This command trades correctness for speed!
+
+Same as the `GetType` command except that it doesn't recompile the file with
+libclang before looking up nodes in the AST. This can be very useful when you're
+editing files that take long to compile but you know that you haven't made any
+changes since the last parse that would lead to incorrect type. When you're
+just browsing around your codebase, this command can spare you quite a bit of
+latency.
+
+Supported in filetypes: `c, cpp, objc, objcpp`
+
 #### The `GetParent` subcommand
 
 Echos the semantic parent of the point under the cursor.
@@ -1350,6 +1363,19 @@ under the cursor. Depending on the file type, this includes things like:
 
 Supported in filetypes: `c, cpp, objc, objcpp, cs, python, typescript,
 javascript`
+
+#### The `GetDocImprecise` subcommand
+
+WARNING: This command trades correctness for speed!
+
+Same as the `GetDoc` command except that it doesn't recompile the file with
+libclang before looking up nodes in the AST. This can be very useful when you're
+editing files that take long to compile but you know that you haven't made any
+changes since the last parse that would lead to incorrect docs. When you're
+just browsing around your codebase, this command can spare you quite a bit of
+latency.
+
+Supported in filetypes: `c, cpp, objc, objcpp`
 
 ### Refactoring and FixIt Commands
 

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -1,5 +1,15 @@
 # Linux-specific installation
 
+# We can't use sudo, so we have to approximate the behaviour of setting the
+# default system compiler.
+
+mkdir ${HOME}/bin
+
+ln -s /usr/bin/g++-4.8 ${HOME}/bin/c++
+ln -s /usr/bin/gcc-4.8 ${HOME}/bin/cc
+
+export PATH=${HOME}/bin:${PATH}
+
 # In order to work with ycmd, python *must* be built as a shared library. This
 # is set via the PYTHON_CONFIGURE_OPTS option.
 export PYTHON_CONFIGURE_OPTS="--enable-shared"

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -59,8 +59,10 @@ Contents ~
    8. The |GoToImplementationElseDeclaration| subcommand
   2. Semantic Information Commands |youcompleteme-semantic-information-commands|
    1. The |GetType| subcommand
-   2. The |GetParent| subcommand
-   3. The |GetDoc| subcommand
+   2. The |GetTypeImprecise| subcommand
+   3. The |GetParent| subcommand
+   4. The |GetDoc| subcommand
+   5. The |GetDocImprecise| subcommand
   3. Refactoring and FixIt Commands  |youcompleteme-refactoring-fixit-commands|
    1. The |FixIt| subcommand
    2. The 'RefactorRename <new name>' subcommand      |RefactorRename-new-name|
@@ -1581,6 +1583,20 @@ NOTE: Causes re-parsing of the current translation unit.
 Supported in filetypes: 'c, cpp, objc, objcpp, javascript, typescript'
 
 -------------------------------------------------------------------------------
+The *GetTypeImprecise* subcommand
+
+WARNING: This command trades correctness for speed!
+
+Same as the |GetType| command except that it doesn't recompile the file with
+libclang before looking up nodes in the AST. This can be very useful when
+you're editing files that take long to compile but you know that you haven't
+made any changes since the last parse that would lead to incorrect type. When
+you're just browsing around your codebase, this command can spare you quite a
+bit of latency.
+
+Supported in filetypes: 'c, cpp, objc, objcpp'
+
+-------------------------------------------------------------------------------
 The *GetParent* subcommand
 
 Echos the semantic parent of the point under the cursor.
@@ -1623,6 +1639,20 @@ under the cursor. Depending on the file type, this includes things like:
 
 Supported in filetypes: 'c, cpp, objc, objcpp, cs, python, typescript,
 javascript'
+
+-------------------------------------------------------------------------------
+The *GetDocImprecise* subcommand
+
+WARNING: This command trades correctness for speed!
+
+Same as the |GetDoc| command except that it doesn't recompile the file with
+libclang before looking up nodes in the AST. This can be very useful when
+you're editing files that take long to compile but you know that you haven't
+made any changes since the last parse that would lead to incorrect docs. When
+you're just browsing around your codebase, this command can spare you quite a
+bit of latency.
+
+Supported in filetypes: 'c, cpp, objc, objcpp'
 
 -------------------------------------------------------------------------------
                                      *youcompleteme-refactoring-fixit-commands*


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Updates ycmd submodule to latest (see below), and updates the subcommand documentation to cover `GetDocImprecise` and the new `GetTypeImprecise`.

Other user-visible changes being included (Release notes):
- PR 590: Enable KeepGoing option when creating translation units in Clang completer
- PR 595: Fix default include paths for macOS Sierra
- PR 596: Fix javascript subcommand errors for relative paths.
- Fix for #607
- PR 609: Support GetTypeQuick completer subcommand in clang completer
- PR 615: Rename GetDocQuick subcommand to GetDocImprecise


Text in the subcommand documentation is deliberately almost identical to `GoToImprecise`

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2359)
<!-- Reviewable:end -->
