### PR TITLE
[READY] Use deleted buffer instead of current buffer when sending BufferUnload event notification

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -154,19 +154,28 @@ class BaseRequest( object ):
   hmac_secret = ''
 
 
-def BuildRequestData( include_buffer_data = True ):
+def BuildRequestData( filepath = None ):
+  """Build request for the current buffer or the buffer corresponding to
+  |filepath| if specified."""
+  current_filepath = vimsupport.GetCurrentBufferFilepath()
+
+  if filepath and current_filepath != filepath:
+    # Cursor position is irrelevant when filepath is not the current buffer.
+    return {
+      'filepath': filepath,
+      'line_num': 1,
+      'column_num': 1,
+      'file_data': vimsupport.GetUnsavedAndSpecifiedBufferData( filepath )
+    }
+
   line, column = vimsupport.CurrentLineAndColumn()
-  filepath = vimsupport.GetCurrentBufferFilepath()
-  request_data = {
+
+  return {
+    'filepath': current_filepath,
     'line_num': line + 1,
     'column_num': column + 1,
-    'filepath': filepath
+    'file_data': vimsupport.GetUnsavedAndSpecifiedBufferData( current_filepath )
   }
-
-  if include_buffer_data:
-    request_data[ 'file_data' ] = vimsupport.GetUnsavedAndCurrentBufferData()
-
-  return request_data
 
 
 def JsonFromFuture( future ):

--- a/python/ycm/client/event_notification.py
+++ b/python/ycm/client/event_notification.py
@@ -32,15 +32,16 @@ from ycm.client.base_request import ( BaseRequest, BuildRequestData,
 
 
 class EventNotification( BaseRequest ):
-  def __init__( self, event_name, extra_data = None ):
+  def __init__( self, event_name, filepath = None, extra_data = None ):
     super( EventNotification, self ).__init__()
     self._event_name = event_name
+    self._filepath = filepath
     self._extra_data = extra_data
     self._cached_response = None
 
 
   def Start( self ):
-    request_data = BuildRequestData()
+    request_data = BuildRequestData( self._filepath )
     if self._extra_data:
       request_data.update( self._extra_data )
     request_data[ 'event_name' ] = self._event_name
@@ -74,8 +75,10 @@ class EventNotification( BaseRequest ):
     return self._cached_response if self._cached_response else []
 
 
-def SendEventNotificationAsync( event_name, extra_data = None ):
-  event = EventNotification( event_name, extra_data )
+def SendEventNotificationAsync( event_name,
+                                filepath = None,
+                                extra_data = None ):
+  event = EventNotification( event_name, filepath, extra_data )
   event.Start()
 
 

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1403,15 +1403,17 @@ def OpenFilename_test( vim_current, vim_command ):
 
 @patch( 'ycm.vimsupport.BufferModified', side_effect = [ True ] )
 @patch( 'ycm.vimsupport.FiletypesForBuffer', side_effect = [ [ 'cpp' ] ] )
-def GetUnsavedAndCurrentBufferData_EncodedUnicodeCharsInBuffers_test( *args ):
+def GetUnsavedAndSpecifiedBufferData_EncodedUnicodeCharsInBuffers_test( *args ):
+  filepath = os.path.realpath( 'filename' )
+
   mock_buffer = MagicMock()
-  mock_buffer.name = os.path.realpath( 'filename' )
+  mock_buffer.name = filepath
   mock_buffer.number = 1
   mock_buffer.__iter__.return_value = [ ToBytes ( u'abc' ), ToBytes( u'fДa' ) ]
 
   with patch( 'vim.buffers', [ mock_buffer ] ):
-    assert_that( vimsupport.GetUnsavedAndCurrentBufferData(),
-                 has_entry( mock_buffer.name,
+    assert_that( vimsupport.GetUnsavedAndSpecifiedBufferData( filepath ),
+                 has_entry( filepath,
                             has_entry( u'contents', u'abc\nfДa\n' ) ) )
 
 

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -25,14 +25,15 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import ExtendedMock, MockVimModule, MockVimCommand
+from ycm.test_utils import ( ExtendedMock, MockVimCommand, VimBuffer,
+                             MockVimModule )
 MockVimModule()
 
 from ycm import vimsupport
 from nose.tools import eq_
 from hamcrest import assert_that, calling, raises, none, has_entry
 from mock import MagicMock, call, patch
-from ycmd.utils import ToBytes, ToUnicode
+from ycmd.utils import ToBytes
 import os
 import json
 
@@ -705,34 +706,6 @@ def ReplaceChunksInBuffer_UnsortedChunks_test():
   AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
 
 
-class MockBuffer( object ):
-  """An object that looks like a vim.buffer object, enough for ReplaceChunk to
-  generate a location list"""
-
-  def __init__( self, lines, name, number ):
-    self.lines = lines
-    self.name = name
-    self.number = number
-
-
-  def __getitem__( self, index ):
-    """ Return the bytes for a given line at index |index| """
-    return self.lines[ index ]
-
-
-  def __len__( self ):
-    return len( self.lines )
-
-
-  def __setitem__( self, key, value ):
-    return self.lines.__setitem__( key, value )
-
-
-  def GetLines( self ):
-    """ Return the contents of the buffer as a list of unicode strings"""
-    return [ ToUnicode( x ) for x in self.lines ]
-
-
 @patch( 'ycm.vimsupport.VariableExists', return_value = False )
 @patch( 'ycm.vimsupport.SetFittingHeightForCurrentWindow' )
 @patch( 'ycm.vimsupport.GetBufferNumberForFilename',
@@ -758,11 +731,14 @@ def ReplaceChunks_SingleFile_Open_test( vim_command,
     _BuildChunk( 1, 1, 2, 1, 'replacement', 'single_file' )
   ]
 
-  result_buffer = MockBuffer( [
-    'line1',
-    'line2',
-    'line3',
-  ], 'single_file', 1 )
+  result_buffer = VimBuffer(
+    'single_file',
+    contents = [
+      'line1',
+      'line2',
+      'line3'
+    ]
+  )
 
   with patch( 'vim.buffers', [ None, result_buffer, None ] ):
     vimsupport.ReplaceChunks( chunks )
@@ -845,11 +821,14 @@ def ReplaceChunks_SingleFile_NotOpen_test( vim_command,
     _BuildChunk( 1, 1, 2, 1, 'replacement', 'single_file' )
   ]
 
-  result_buffer = MockBuffer( [
-    'line1',
-    'line2',
-    'line3',
-  ], 'single_file', 1 )
+  result_buffer = VimBuffer(
+    'single_file',
+    contents = [
+      'line1',
+      'line2',
+      'line3'
+    ]
+  )
 
   with patch( 'vim.buffers', [ None, result_buffer, None ] ):
     vimsupport.ReplaceChunks( chunks )
@@ -954,11 +933,14 @@ def ReplaceChunks_User_Declines_To_Open_File_test(
     _BuildChunk( 1, 1, 2, 1, 'replacement', 'single_file' )
   ]
 
-  result_buffer = MockBuffer( [
-    'line1',
-    'line2',
-    'line3',
-  ], 'single_file', 1 )
+  result_buffer = VimBuffer(
+    'single_file',
+    contents = [
+      'line1',
+      'line2',
+      'line3'
+    ]
+  )
 
   with patch( 'vim.buffers', [ None, result_buffer, None ] ):
     vimsupport.ReplaceChunks( chunks )
@@ -1031,11 +1013,14 @@ def ReplaceChunks_User_Aborts_Opening_File_test(
     _BuildChunk( 1, 1, 2, 1, 'replacement', 'single_file' )
   ]
 
-  result_buffer = MockBuffer( [
-    'line1',
-    'line2',
-    'line3',
-  ], 'single_file', 1 )
+  result_buffer = VimBuffer(
+    'single_file',
+    contents = [
+      'line1',
+      'line2',
+      'line3'
+    ]
+  )
 
   with patch( 'vim.buffers', [ None, result_buffer, None ] ):
     assert_that( calling( vimsupport.ReplaceChunks ).with_args( chunks ),
@@ -1114,15 +1099,23 @@ def ReplaceChunks_MultiFile_Open_test( vim_command,
     _BuildChunk( 2, 1, 2, 1, 'second_file_replacement ', '2_another_file' ),
   ]
 
-  first_file = MockBuffer( [
-    'line1',
-    'line2',
-    'line3',
-  ], '1_first_file', 22 )
-  another_file = MockBuffer( [
-    'another line1',
-    'ACME line2',
-  ], '2_another_file', 19 )
+  first_file = VimBuffer(
+    '1_first_file',
+    number = 22,
+    contents = [
+      'line1',
+      'line2',
+      'line3',
+    ]
+  )
+  another_file = VimBuffer(
+    '2_another_file',
+    number = 19,
+    contents = [
+      'another line1',
+      'ACME line2',
+    ]
+  )
 
   vim_buffers = [ None ] * 23
   vim_buffers[ 22 ] = first_file
@@ -1222,9 +1215,10 @@ def _BuildChunk( start_line,
 
 @patch( 'vim.eval', new_callable = ExtendedMock )
 def AddDiagnosticSyntaxMatch_ErrorInMiddleOfLine_test( vim_eval ):
-  current_buffer = MockBuffer( [
-    'Highlight this error please'
-  ], 'some_file', 1 )
+  current_buffer = VimBuffer(
+    'some_file',
+    contents = [ 'Highlight this error please' ]
+  )
 
   with patch( 'vim.current.buffer', current_buffer ):
     vimsupport.AddDiagnosticSyntaxMatch( 1, 16, 1, 21 )
@@ -1235,9 +1229,10 @@ def AddDiagnosticSyntaxMatch_ErrorInMiddleOfLine_test( vim_eval ):
 
 @patch( 'vim.eval', new_callable = ExtendedMock )
 def AddDiagnosticSyntaxMatch_WarningAtEndOfLine_test( vim_eval ):
-  current_buffer = MockBuffer( [
-    'Highlight this warning'
-  ], 'some_file', 1 )
+  current_buffer = VimBuffer(
+    'some_file',
+    contents = [ 'Highlight this warning' ]
+  )
 
   with patch( 'vim.current.buffer', current_buffer ):
     vimsupport.AddDiagnosticSyntaxMatch( 1, 16, 1, 23, is_error = False )
@@ -1339,31 +1334,42 @@ def CheckFilename_test():
 
 
 def BufferIsVisibleForFilename_test():
-  buffers = [
-    {
-      'number': 1,
-      'filename': os.path.realpath( 'visible_filename' ),
-      'window': 1
-    },
-    {
-      'number': 2,
-      'filename': os.path.realpath( 'hidden_filename' ),
-    }
+  vim_buffers = [
+    VimBuffer(
+      os.path.realpath( 'visible_filename' ),
+      number = 1,
+      window = 1
+    ),
+    VimBuffer(
+      os.path.realpath( 'hidden_filename' ),
+      number = 2,
+      window = None
+    )
   ]
 
-  with patch( 'vim.buffers', buffers ):
+  with patch( 'vim.buffers', vim_buffers ):
     eq_( vimsupport.BufferIsVisibleForFilename( 'visible_filename' ), True )
     eq_( vimsupport.BufferIsVisibleForFilename( 'hidden_filename' ), False )
     eq_( vimsupport.BufferIsVisibleForFilename( 'another_filename' ), False )
 
 
-@patch( 'ycm.vimsupport.GetBufferNumberForFilename',
-        side_effect = [ 2, 5, -1 ] )
 @patch( 'vim.command',
         side_effect = MockVimCommand,
         new_callable = ExtendedMock )
 def CloseBuffersForFilename_test( vim_command, *args ):
-  vimsupport.CloseBuffersForFilename( 'some_filename' )
+  vim_buffers = [
+    VimBuffer(
+      os.path.realpath( 'some_filename' ),
+      number = 2
+    ),
+    VimBuffer(
+      os.path.realpath( 'some_filename' ),
+      number = 5
+    )
+  ]
+
+  with patch( 'vim.buffers', vim_buffers ):
+    vimsupport.CloseBuffersForFilename( 'some_filename' )
 
   vim_command.assert_has_exact_calls( [
     call( 'silent! bwipeout! 2' ),
@@ -1401,17 +1407,12 @@ def OpenFilename_test( vim_current, vim_command ):
   ] )
 
 
-@patch( 'ycm.vimsupport.BufferModified', side_effect = [ True ] )
-@patch( 'ycm.vimsupport.FiletypesForBuffer', side_effect = [ [ 'cpp' ] ] )
-def GetUnsavedAndSpecifiedBufferData_EncodedUnicodeCharsInBuffers_test( *args ):
+def GetUnsavedAndSpecifiedBufferData_EncodedUnicodeCharsInBuffers_test():
   filepath = os.path.realpath( 'filename' )
+  contents = [ ToBytes( u'abc' ), ToBytes( u'fДa' ) ]
+  vim_buffer = VimBuffer( filepath, contents = contents )
 
-  mock_buffer = MagicMock()
-  mock_buffer.name = filepath
-  mock_buffer.number = 1
-  mock_buffer.__iter__.return_value = [ ToBytes ( u'abc' ), ToBytes( u'fДa' ) ]
-
-  with patch( 'vim.buffers', [ mock_buffer ] ):
+  with patch( 'vim.buffers', [ vim_buffer ] ):
     assert_that( vimsupport.GetUnsavedAndSpecifiedBufferData( filepath ),
                  has_entry( filepath,
                             has_entry( u'contents', u'abc\nfДa\n' ) ) )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -116,14 +116,17 @@ def BufferModified( buffer_object ):
   return bool( int( GetBufferOption( buffer_object, 'mod' ) ) )
 
 
-def GetUnsavedAndCurrentBufferData():
+def GetUnsavedAndSpecifiedBufferData( including_filepath ):
+  """Build part of the request containing the contents and filetypes of all
+  dirty buffers as well as the buffer with filepath |including_filepath|."""
   buffers_data = {}
   for buffer_object in vim.buffers:
+    buffer_filepath = GetBufferFilepath( buffer_object )
     if not ( BufferModified( buffer_object ) or
-             buffer_object == vim.current.buffer ):
+             buffer_filepath == including_filepath ):
       continue
 
-    buffers_data[ GetBufferFilepath( buffer_object ) ] = {
+    buffers_data[ buffer_filepath ] = {
       # Add a newline to match what gets saved to disk. See #1455 for details.
       'contents': JoinLinesAsUnicode( buffer_object ) + '\n',
       'filetypes': FiletypesForBuffer( buffer_object )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -311,16 +311,18 @@ class YouCompleteMe( object ):
     self._AddSyntaxDataIfNeeded( extra_data )
     self._AddExtraConfDataIfNeeded( extra_data )
 
-    self._latest_file_parse_request = EventNotification( 'FileReadyToParse',
-                                                          extra_data )
+    self._latest_file_parse_request = EventNotification(
+      'FileReadyToParse', extra_data = extra_data )
     self._latest_file_parse_request.Start()
 
 
   def OnBufferUnload( self, deleted_buffer_file ):
     if not self.IsServerAlive():
       return
-    SendEventNotificationAsync( 'BufferUnload',
-                                { 'unloaded_buffer': deleted_buffer_file } )
+    SendEventNotificationAsync(
+      'BufferUnload',
+      filepath = deleted_buffer_file,
+      extra_data = { 'unloaded_buffer': deleted_buffer_file } )
 
 
   def OnBufferVisit( self ):
@@ -328,7 +330,7 @@ class YouCompleteMe( object ):
       return
     extra_data = {}
     self._AddUltiSnipsDataIfNeeded( extra_data )
-    SendEventNotificationAsync( 'BufferVisit', extra_data )
+    SendEventNotificationAsync( 'BufferVisit', extra_data = extra_data )
 
 
   def OnInsertLeave( self ):


### PR DESCRIPTION
When deleting a buffer, we use the current buffer to send the `BufferUnload` event notification request to ycmd instead of the buffer being deleted. This is an issue when the current buffer is not of the same filetype as the deleted one. In this case, three different scenarios may occur:
 - the current buffer filetype is not allowed: no request is sent to the ycmd server. The `OnBufferUnload` method from the completer corresponding to the filetype of the deleted buffer is not called. If the filetype is a C-family language, the translation unit is not destroyed. If it is TypeScript, we don't tell TSServer to close the file (not really an issue unless the file is modified elsewhere);
 - the current buffer filetype has no semantic support in ycmd: the request is sent to the ycmd server but no semantic completer is used. Same result;
 - the current buffer filetype has semantic support in ycmd: the `OnBufferUnload` method from the wrong completer is called in ycmd. LibClang and TSServer are able to cope with that and ignore the file. Same result in definitive.

The solution is obvious: build the request for the deleted buffer in this case. However, this involves more changes than expected because the code was written with the assumption that requests are always for the current buffer.

The `include_buffer_data` parameter from `BuildRequestData` was removed as it is always used with its default value.

This fix may alleviate issue https://github.com/Valloric/YouCompleteMe/issues/2232 in the sense that it now gives a reliable way to limit memory usage by deleting buffers in the case of multiple TUs.

Next step is to update PR https://github.com/Valloric/ycmd/pull/542 by removing the `unloaded_buffer` parameter from ycmd API then remove it from the `BufferUnload` request in YCM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2367)
<!-- Reviewable:end -->
