### PR TITLE
Added 'ycm_disable_startup_warning' option

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -24,20 +24,27 @@ function! s:restore_cpo()
   unlet s:save_cpo
 endfunction
 
+let g:ycm_disable_startup_warning =
+      \ get( g:, 'ycm_disable_startup_warning', 0 )
+
 if exists( "g:loaded_youcompleteme" )
   call s:restore_cpo()
   finish
 elseif v:version < 704 || (v:version == 704 && !has('patch143'))
-  echohl WarningMsg |
-        \ echomsg "YouCompleteMe unavailable: requires Vim 7.4.143+" |
-        \ echohl None
+  if g:ycm_disable_startup_warning == 0
+    echohl WarningMsg |
+          \ echomsg "YouCompleteMe unavailable: requires Vim 7.4.143+" |
+          \ echohl None
+  endif
   call s:restore_cpo()
   finish
 elseif !has( 'python' ) && !has( 'python3' )
-  echohl WarningMsg |
-        \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .
-        \ "Python (2.6+ or 3.3+) support" |
-        \ echohl None
+  if g:ycm_disable_startup_warning == 0
+    echohl WarningMsg |
+          \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .
+          \ "Python (2.6+ or 3.3+) support" |
+          \ echohl None
+  endif
   call s:restore_cpo()
   finish
 endif


### PR DESCRIPTION
I use vim in several hosts, home pc, office, embedded devices, servers... I keep all the configurations in an unique vimrc, shared between hosts via git. Some hosts are missing python or have an old unsupported version of vim. In these cases I want to suppress the startup warnings, like "YouCompleteMe unavailable: requires Vim 7.4.143+".

This is why I've added the option: `g:ycm_disable_startup_warning`.

Adding to `vimrc` this line will suppress startup warnings:

```
let g:ycm_disable_startup_warning = 1
```

Obviously, the default behavior is to show warnings.

I didn't write any test because this feature is trivial and I don't know how to simulate the wrong version of vim or python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2369)
<!-- Reviewable:end -->
