### PR TITLE
Use JoinLinesAsUnicode in GetUnsavedAndCurrentBufferData().

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1407,7 +1407,7 @@ def GetUnsavedAndCurrentBufferData_EncodedUnicodeCharsInBuffers_test( *args ):
   mock_buffer = MagicMock()
   mock_buffer.name = os.path.realpath( 'filename' )
   mock_buffer.number = 1
-  mock_buffer.__iter__.return_value = [ u'abc', ToBytes( u'fДa' ) ]
+  mock_buffer.__iter__.return_value = [ ToBytes ( u'abc' ), ToBytes( u'fДa' ) ]
 
   with patch( 'vim.buffers', [ mock_buffer ] ):
     assert_that( vimsupport.GetUnsavedAndCurrentBufferData(),

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -30,7 +30,7 @@ import tempfile
 import json
 import re
 from collections import defaultdict
-from ycmd.utils import ToUnicode, ToBytes
+from ycmd.utils import ToUnicode, ToBytes, JoinLinesAsUnicode
 from ycmd import user_options_store
 
 BUFFER_COMMAND_MAP = { 'same-buffer'      : 'edit',
@@ -125,7 +125,7 @@ def GetUnsavedAndCurrentBufferData():
 
     buffers_data[ GetBufferFilepath( buffer_object ) ] = {
       # Add a newline to match what gets saved to disk. See #1455 for details.
-      'contents': '\n'.join( ToUnicode( x ) for x in buffer_object ) + '\n',
+      'contents': JoinLinesAsUnicode( buffer_object ) + '\n',
       'filetypes': FiletypesForBuffer( buffer_object )
     }
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ x ] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ x ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ x ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.

Rationale: Tests are in https://github.com/Valloric/ycmd/pull/617.  This does not change any behavior in YCM itself, only makes things go faster.

- [ x ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

GetUnsavedAndCurrentBufferData() is invoked on every kepress.  On a large file (15+k loc), using this new function takes kepress latency down to <10ms from ~100ms.

The function used here is added to ycmd in https://github.com/Valloric/ycmd/pull/617.  I will update this PR to include a ycmd submodule update if and when that PR is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2370)
<!-- Reviewable:end -->
