### PR TITLE
Added snippet for ycm_rust_src_path from rustup

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,13 @@ locate it.
 let g:ycm_rust_src_path = '/usr/local/rust/rustc-1.5.0/src'
 ```
 
+[Rustup][rustup] users (since `0.6.3`) could add `rust-src` component with `rustup component add rust-src` for appropriate toolchains (autoupdated along with `rustc` and `cargo` managed by `rustup`) and use such snippet:
+
+```viml
+" getting `rust-src` rustup component path for current rustc version
+let g:ycm_rust_src_path = substitute(system('rustc --print sysroot'), '\n\+$', '', '') . '/lib/rustlib/src/rust/src'
+```
+
 ### Python Semantic Completion
 
 Completion and GoTo commands work out of the box with no additional
@@ -2934,6 +2941,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [racer]: https://github.com/phildawes/racer
 [rust-install]: https://www.rust-lang.org/
 [rust-src]: https://www.rust-lang.org/downloads.html
+[rustup]: https://github.com/rust-lang-nursery/rustup.rs
 [add-msbuild-to-path]: http://stackoverflow.com/questions/6319274/how-do-i-run-msbuild-from-the-command-line-using-windows-sdk-7-1
 [identify-R6034-cause]: http://stackoverflow.com/questions/14552348/runtime-error-r6034-in-embedded-python-application/34696022
 [ccoc]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
# PR Prelude

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**
- [x] I have read and understood YCM's [CONTRIBUTING](https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT](https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**
# Why this change is necessary and useful

[rustup](https://github.com/rust-lang-nursery/rustup.rs) is one of the preferred install methods for rust libraries developers and ones who use rust cross-compilation features to make switch between rust versions (stable/beta/nightly) and/or rust targets easy. Previous method was [multirust](https://github.com/brson/multirust) but it became deprecated now.

When `rustup` is used it allows per-directory rust channel override, so different projects can use different rust version (and rust sources too). It currently allows fetching `rust-src` (with `rustup component add rust-src` for currently selected toolchain). Added viml snippet allows YCM user to switch `g:ycm_rust_src_path` to current rust toolchain override source without editing `~/.vimrc` just by starting `vim` from project directory hierarchy for which override is set. It also supports default `rustup` toolchain of course.

This PR doesn't contain any tests since it affects only docs (`README.md`).

Added dynamic viml snippet for getting `ycm_rust_src_path` from `rust-src` component for `rustc` installed via [rustup](https://github.com/rust-lang-nursery/rustup.rs).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2379)

<!-- Reviewable:end -->
