### PR TITLE
[READY] Move test_utils.py file to tests folder

### DIFF
--- a/python/ycm/client/tests/command_request_test.py
+++ b/python/ycm/client/tests/command_request_test.py
@@ -23,7 +23,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import ExtendedMock, MockVimModule
+from ycm.tests.test_utils import ExtendedMock, MockVimModule
 MockVimModule()
 
 import json

--- a/python/ycm/client/tests/completion_request_test.py
+++ b/python/ycm/client/tests/completion_request_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 YouCompleteMe Contributors
+# Copyright (C) 2015-2016 YouCompleteMe Contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -24,7 +24,7 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 
 from nose.tools import eq_
-from ycm.test_utils import MockVimModule
+from ycm.tests.test_utils import MockVimModule
 vim_mock = MockVimModule()
 
 from .. import completion_request

--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -23,7 +23,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import MockVimModule
+from ycm.tests.test_utils import MockVimModule
 MockVimModule()
 
 import functools

--- a/python/ycm/tests/base_test.py
+++ b/python/ycm/tests/base_test.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 #
-# Copyright (C) 2013  Google Inc.
+# Copyright (C) 2013 Google Inc.
+#               2016 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -29,7 +30,7 @@ import contextlib
 from nose.tools import eq_, ok_
 from mock import patch
 
-from ycm.test_utils import MockVimModule
+from ycm.tests.test_utils import MockVimModule
 vim_mock = MockVimModule()
 from ycm import base
 

--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -23,7 +23,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import ExtendedMock, MockVimModule, VimBuffer
+from ycm.tests.test_utils import ExtendedMock, MockVimModule, VimBuffer
 MockVimModule()
 
 import contextlib

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -30,10 +30,9 @@ from mock import patch, call
 from nose.tools import eq_
 from hamcrest import contains_string
 
-from ycm.test_utils import MockVimModule, ExtendedMock
+from ycm.tests.test_utils import ExpectedFailure, ExtendedMock, MockVimModule
 MockVimModule()
 
-from ycm.test_utils import ExpectedFailure
 from ycm.tests import YouCompleteMeInstance
 
 from ycmd.utils import ToBytes
@@ -52,9 +51,9 @@ def ToBytesOnPY2( data ):
 
 
 def BuildRequest( line_num, column_num, contents ):
-  # Note: it would be nice to use ycmd.test_utils.BuildRequest directly here,
-  # but we can't import ycmd.test_utils because that in turn imports ycm_core,
-  # which would cause our "ycm_core not imported" test to fail.
+  # Note: it would be nice to use ycmd.tests.test_utils.BuildRequest directly
+  # here, but we can't import ycmd.tests.test_utils because that in turn imports
+  # ycm_core, which would cause our "ycm_core not imported" test to fail.
   return {
     'line_num': line_num,
     'column_num': column_num,

--- a/python/ycm/tests/paths_test.py
+++ b/python/ycm/tests/paths_test.py
@@ -23,7 +23,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import MockVimModule
+from ycm.tests.test_utils import MockVimModule
 MockVimModule()
 
 from nose.tools import ok_

--- a/python/ycm/tests/postcomplete_test.py
+++ b/python/ycm/tests/postcomplete_test.py
@@ -25,7 +25,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import MockVimModule
+from ycm.tests.test_utils import MockVimModule
 MockVimModule()
 
 import contextlib

--- a/python/ycm/tests/syntax_parse_test.py
+++ b/python/ycm/tests/syntax_parse_test.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2013  Google Inc.
+# Copyright (C) 2013 Google Inc.
+#               2016 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -23,7 +24,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import MockVimModule
+from ycm.tests.test_utils import MockVimModule
 MockVimModule()
 
 import os

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2011, 2012  Google Inc.
+# Copyright (C) 2011-2012 Google Inc.
+#               2016      YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -182,7 +183,7 @@ def MockVimModule():
   mock module, to ensure that the state of the vim mock is returned before the
   next test. That is:
 
-    from ycm.test_utils import MockVimModule
+    from ycm.tests.test_utils import MockVimModule
     from mock import patch
 
     # Do this once
@@ -209,7 +210,7 @@ class ExtendedMock( MagicMock ):
   callable is called with a precise set of calls in a precise order.
 
   Example Usage:
-    from ycm.test_utils import ExtendedMock
+    from ycm.tests.test_utils import ExtendedMock
     @patch( 'test.testing', new_callable = ExtendedMock, ... )
     def my_test( test_testing ):
       ...

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (C) 2015 YouCompleteMe contributors
+# Copyright (C) 2015-2016 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -25,8 +25,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import ( ExtendedMock, MockVimCommand, VimBuffer,
-                             MockVimModule )
+from ycm.tests.test_utils import ( ExtendedMock, MockVimCommand, VimBuffer,
+                                   MockVimModule )
 MockVimModule()
 
 from ycm import vimsupport

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -23,7 +23,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycm.test_utils import MockVimModule
+from ycm.tests.test_utils import MockVimModule
 MockVimModule()
 
 import sys


### PR DESCRIPTION
We don't want `test_utils.py` to appear in the coverage reports. Instead of blacklisting it in `.coveragerc`, we move it to the tests folder.

This will decrease coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2389)
<!-- Reviewable:end -->
