### PR TITLE
Add caveat for non-Vundle installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ local binary folder (for example `/usr/local/bin/mvim`) and then symlink it:
 
     ln -s /usr/local/bin/mvim vim
 
-Install YouCompleteMe with [Vundle][].
+Install YouCompleteMe with [Vundle][]. 
+
+**NOTE:** If you are using a different plugin manager such as [vim-plug][], replace all references to `~/.vim/bundle/...` with `~/.vim/plugged/...` or wherever your default plugin location is.
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_core library APIs have changed (happens
@@ -218,6 +220,8 @@ installed by running `vim --version`. If the version is too old, you may need to
 
 Install YouCompleteMe with [Vundle][].
 
+**NOTE:** If you are using a different plugin manager such as [vim-plug][], replace all references to `~/.vim/bundle/...` with `~/.vim/plugged/...` or wherever your default plugin location is.
+
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_core library APIs have changed (happens
 rarely), YCM will notify you to recompile it. You should then rerun the install
@@ -279,6 +283,8 @@ by running `vim --version`. If the version is too old, you may need to [compile
 Vim from source][vim-build] (don't worry, it's easy).
 
 Install YouCompleteMe with [Vundle][].
+
+**NOTE:** If you are using a different plugin manager such as [vim-plug][], replace all references to `~/.vim/bundle/...` with `~/.vim/plugged/...` or wherever your default plugin location is.
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_core library APIs have changed (happens
@@ -347,6 +353,8 @@ using a 64-bit client. [Daily updated copies of 32-bit and 64-bit Vim with
 Python 2 and Python 3 support][vim-win-download] are available.
 
 Install YouCompleteMe with [Vundle][].
+
+**NOTE:** If you are using a different plugin manager such as [vim-plug][], replace all references to `~/.vim/bundle/...` with `~/.vim/plugged/...` or wherever your default plugin location is.
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_core library APIs have changed (happens
@@ -426,6 +434,8 @@ FreeBSD 10.x comes with clang compiler but not the libraries needed to install.
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/llvm38/lib/
 
 Install YouCompleteMe with [Vundle][].
+
+**NOTE:** If you are using a different plugin manager such as [vim-plug][], replace all references to `~/.vim/bundle/...` with `~/.vim/plugged/...` or wherever your default plugin location is.
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_core library APIs have changed (happens
@@ -2882,6 +2892,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [Clang]: http://clang.llvm.org/
 [vundle]: https://github.com/VundleVim/Vundle.vim#about
 [pathogen]: https://github.com/tpope/vim-pathogen#pathogenvim
+[vim-plug]: https://github.com/junegunn/vim-plug
 [clang-download]: http://llvm.org/releases/download.html
 [brew]: http://brew.sh
 [cmake-download]: https://cmake.org/download/


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

I switched from Vundle to vim-plug a while back, but when I was following the steps for the install again, I didn't think twice about the location of my packages. Since I actually still had YouCompleteMe in my `~/.vim/bundle/` directory, nothing seemed off, and I wasted a bit of time until I realized that I was just in the wrong directory. I only noticed this when I stumbled upon an issue where another person made the same exact mistake, so I figured it could be a fairly common careless mistake.

Given that vim-plug is becoming a very popular package manager, I figured adding a note to the documentation might save future folks the trouble. In terms of where to add it, putting it in each OS type seemed like the most obvious remedy, but other suggestions are welcome too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2390)
<!-- Reviewable:end -->
