### PR TITLE
[READY] install: refine ouput on error

### DIFF
--- a/install.py
+++ b/install.py
@@ -24,8 +24,12 @@ DIR_OF_OLD_LIBS = p.join( DIR_OF_THIS_SCRIPT, 'python' )
 
 def CheckCall( args, **kwargs ):
   try:
+    python_binary = args[0]
+    build_file = args[1]
+    print("Building ycmd using [%s] with python binary [%s]:" % build_file, python_binary)
     subprocess.check_call( args, **kwargs )
   except subprocess.CalledProcessError as error:
+    print("\nException raised while building ycmd:\n" + str(error))
     sys.exit( error.returncode )
 
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

Before this patch a traceback was shown when subprocess call, that runs
`build.py`, failed. The reason of the error is the output of the build
script rather the `CalledProcessError` exception that only shows
`build.py` failed with a specific `python` version.

This modifications is intended to separate the output of the build
process that gives the user a more specific reason of the error. And
below that the command run.

Before:

```
Please install CMake and retry.
Traceback (most recent call last):
  File "install.py", line 44, in <module>
    Main()
  File "install.py", line 33, in Main
    subprocess.check_call( [ python_binary, build_file ] + sys.argv[1:] )
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['path/to/python', u'path/to/build.py']' returned non-zero exit status 1
```

After:

```
Building ycmd using [path/to/build.py] with python binary at [path/to/python]:
Error message from build.py...

Exception raised:
Command '['path/to/python', u'path/to/build.py']' returned non-zero exit status 1
```

Signed-off-by: Gergő Nagy <grigori.grant@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2417)
<!-- Reviewable:end -->
