### PR TITLE
Fix InsertNamespace

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1531,3 +1531,34 @@ def SelectFromList_Negative_test( vim_eval ):
   assert_that( calling( vimsupport.SelectFromList ).with_args( 'test',
                                                                [ 'a', 'b' ] ),
                raises( RuntimeError, vimsupport.NO_SELECTION_MADE_MSG ) )
+
+
+@patch( 'ycm.vimsupport.VariableExists', return_value = False )
+@patch( 'ycm.vimsupport.SearchInCurrentBuffer', return_value = 0 )
+@patch( 'vim.current' )
+def InsertNamespace_insert_test( vim_current, *args ):
+  contents = [ 'var taco = Math' ]
+  vim_current.buffer = VimBuffer( '', contents = contents )
+
+  vimsupport.InsertNamespace( 'System' )
+
+  expected_buffer = [ 'using System;',
+                      'var taco = Math' ]
+  AssertBuffersAreEqualAsBytes( expected_buffer, vim_current.buffer )
+
+
+@patch( 'ycm.vimsupport.VariableExists', return_value = False )
+@patch( 'ycm.vimsupport.SearchInCurrentBuffer', return_value = 1 )
+@patch( 'vim.current' )
+def InsertNamespace_append_test( vim_current, *args ):
+  contents = [ 'using System;', '', 'var taco;', 'var salad = new List']
+  vim_current.buffer = VimBuffer( '', contents = contents )
+
+  vimsupport.InsertNamespace( 'System.Collections' )
+
+  expected_buffer = [ 'using System;',
+                      'using System.Collections;',
+                      '',
+                      'var taco;',
+                      'var salad = new List' ]
+  AssertBuffersAreEqualAsBytes( expected_buffer, vim_current.buffer )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1537,28 +1537,41 @@ def SelectFromList_Negative_test( vim_eval ):
 @patch( 'ycm.vimsupport.SearchInCurrentBuffer', return_value = 0 )
 @patch( 'vim.current' )
 def InsertNamespace_insert_test( vim_current, *args ):
-  contents = [ 'var taco = Math' ]
+  contents = [ '',
+               'namespace Taqueria {',
+               '',
+               '  int taco = Math' ]
   vim_current.buffer = VimBuffer( '', contents = contents )
 
   vimsupport.InsertNamespace( 'System' )
 
   expected_buffer = [ 'using System;',
-                      'var taco = Math' ]
+                      '',
+                      'namespace Taqueria {',
+                      '',
+                      '  int taco = Math' ]
   AssertBuffersAreEqualAsBytes( expected_buffer, vim_current.buffer )
 
 
 @patch( 'ycm.vimsupport.VariableExists', return_value = False )
-@patch( 'ycm.vimsupport.SearchInCurrentBuffer', return_value = 1 )
+@patch( 'ycm.vimsupport.SearchInCurrentBuffer', return_value = 2 )
 @patch( 'vim.current' )
 def InsertNamespace_append_test( vim_current, *args ):
-  contents = [ 'using System;', '', 'var taco;', 'var salad = new List']
+  contents = [ 'namespace Taqueria {',
+               '  using System;',
+               '',
+               '  class Tasty {',
+               '    int taco;',
+               '    List salad = new List']
   vim_current.buffer = VimBuffer( '', contents = contents )
 
   vimsupport.InsertNamespace( 'System.Collections' )
 
-  expected_buffer = [ 'using System;',
-                      'using System.Collections;',
+  expected_buffer = [ 'namespace Taqueria {',
+                      '  using System;',
+                      '  using System.Collections;',
                       '',
-                      'var taco;',
-                      'var salad = new List' ]
+                      '  class Tasty {',
+                      '    int taco;',
+                      '    List salad = new List']
   AssertBuffersAreEqualAsBytes( expected_buffer, vim_current.buffer )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1562,7 +1562,7 @@ def InsertNamespace_append_test( vim_current, *args ):
                '',
                '  class Tasty {',
                '    int taco;',
-               '    List salad = new List']
+               '    List salad = new List' ]
   vim_current.buffer = VimBuffer( '', contents = contents )
 
   vimsupport.InsertNamespace( 'System.Collections' )
@@ -1573,5 +1573,5 @@ def InsertNamespace_append_test( vim_current, *args ):
                       '',
                       '  class Tasty {',
                       '    int taco;',
-                      '    List salad = new List']
+                      '    List salad = new List' ]
   AssertBuffersAreEqualAsBytes( expected_buffer, vim_current.buffer )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -846,9 +846,11 @@ def InsertNamespace( namespace ):
       return
 
   pattern = '^\s*using\(\s\+[a-zA-Z0-9]\+\s\+=\)\?\s\+[a-zA-Z0-9.]\+\s*;\s*'
+  existing_indent = ''
   line = SearchInCurrentBuffer( pattern )
-  existing_line = LineTextInCurrentBuffer( line )
-  existing_indent = re.sub( r"\S.*", "", existing_line )
+  if line > 0:
+    existing_line = LineTextInCurrentBuffer( line )
+    existing_indent = re.sub( r"\S.*", "", existing_line )
   new_line = "{0}using {1};\n\n".format( existing_indent, namespace )
   replace_pos = { 'line_num': line + 1, 'column_num': 1 }
   ReplaceChunk( replace_pos, replace_pos, new_line, 0, 0, vim.current.buffer )
@@ -856,11 +858,14 @@ def InsertNamespace( namespace ):
 
 
 def SearchInCurrentBuffer( pattern ):
+  """ Returns the 1-indexed line on which the pattern matches
+  (going UP from the current position) or 0 if not found """
   return GetIntValue( "search('{0}', 'Wcnb')".format( EscapeForVim( pattern )))
 
 
 def LineTextInCurrentBuffer( line ):
-  return vim.current.buffer[ line ]
+  """ Returns the text on the 1-indexed line (NOT 0-indexed) """
+  return vim.current.buffer[ line - 1 ]
 
 
 def ClosePreviewWindow():

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -848,7 +848,7 @@ def InsertNamespace( namespace ):
   pattern = '^\s*using\(\s\+[a-zA-Z0-9]\+\s\+=\)\?\s\+[a-zA-Z0-9.]\+\s*;\s*'
   existing_indent = ''
   line = SearchInCurrentBuffer( pattern )
-  if line > 0:
+  if line:
     existing_line = LineTextInCurrentBuffer( line )
     existing_indent = re.sub( r"\S.*", "", existing_line )
   new_line = "{0}using {1};\n\n".format( existing_indent, namespace )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -863,9 +863,9 @@ def SearchInCurrentBuffer( pattern ):
   return GetIntValue( "search('{0}', 'Wcnb')".format( EscapeForVim( pattern )))
 
 
-def LineTextInCurrentBuffer( line ):
+def LineTextInCurrentBuffer( line_number ):
   """ Returns the text on the 1-indexed line (NOT 0-indexed) """
-  return vim.current.buffer[ line - 1 ]
+  return vim.current.buffer[ line_number - 1 ]
 
 
 def ClosePreviewWindow():

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -851,7 +851,7 @@ def InsertNamespace( namespace ):
   existing_indent = re.sub( r"\S.*", "", existing_line )
   new_line = "{0}using {1};\n\n".format( existing_indent, namespace )
   replace_pos = { 'line_num': line + 1, 'column_num': 1 }
-  ReplaceChunk( replace_pos, replace_pos, new_line, 0, 0 )
+  ReplaceChunk( replace_pos, replace_pos, new_line, 0, 0, vim.current.buffer )
   PostVimMessage( 'Add namespace: {0}'.format( namespace ), warning = False )
 
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Auto-inserting namespace imports in C# is broken because the `ReplaceChunk()` call is missing an argument

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

ReplaceChunk must have changed to require the buffer at some point

No test is included because it's a one-line change; the method is theoretically covered, so I'm not sure why the missing argument error was not caught (not familiar with these tests). Happy to add one if needed (and I can get pointed in the right direction).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2425)
<!-- Reviewable:end -->
