### PR TITLE
Don't set omnifunc when not allowed

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -119,14 +119,16 @@ function! youcompleteme#Enable()
   call s:OnBufferRead()
 endfunction
 
+
 function s:DeferredUntilInsertEnter()
   let s:defer_omnifunc = 0
   autocmd! ycm_defer_omnifunc
 
-  if s:AllowedToCompleteInCurrentFile()
+  if s:AllowedToCompleteInCurrentBuffer()
     call s:SetOmnicompleteFunc()
   endif
 endfunction
+
 
 function! youcompleteme#EnableCursorMovedAutocommands()
   augroup ycmcompletemecursormove

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -108,9 +108,7 @@ function! youcompleteme#Enable()
   if s:defer_omnifunc
     augroup ycm_defer_omnifunc
       autocmd!
-      autocmd InsertEnter * call s:SetOmnicompleteFunc()
-                        \ | let s:defer_omnifunc = 0
-                        \ | autocmd! ycm_defer_omnifunc
+      autocmd InsertEnter * call s:DeferredUntilInsertEnter()
     augroup END
   endif
 
@@ -121,6 +119,14 @@ function! youcompleteme#Enable()
   call s:OnBufferRead()
 endfunction
 
+function s:DeferredUntilInsertEnter()
+  let s:defer_omnifunc = 0
+  autocmd! ycm_defer_omnifunc
+
+  if s:AllowedToCompleteInCurrentFile()
+    call s:SetOmnicompleteFunc()
+  endif
+endfunction
 
 function! youcompleteme#EnableCursorMovedAutocommands()
   augroup ycmcompletemecursormove


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

See pull request: [#2072](https://github.com/Valloric/YouCompleteMe/pull/2072)
Unfortunately I was not able to reproduce the original author's results. I tried using a clean .vim and .vimrc. The only plugins I used were YCM and ctrlfs.vim, just as the original author mentioned. The .vimrc looks like this:
```VimL
syntax on
set history=500
set nocp
filetype plugin indent on
set encoding=GBK
```
Whatever I tried to do with configuration, I couldn't get a start without an error, but it is already known that YCM doesn't work properly with any file not using UTF encoding.
The error I was getting on vim start up:
```
Error detected while processing function youcompleteme#Enable[67]..<SNR>36_OnBufferRead[6]..<SNR>36_AllowedToCompleteInCurrentBuffer[1]..<SNR>36_AllowedToCompleteInBuffer:
line   15:
E715: Dictionary required
Press ENTER or type command to continue
Error detected while processing function <SNR>36_OnCursorMovedNormalMode[1]..<SNR>36_AllowedToCompleteInCurrentBuffer[1]..<SNR>36_AllowedToCompleteInBuffer:
line   15:
E715: Dictionary required
Press ENTER or type command to continue
```
Error I was having after almost every key press:
```
Error detected while processing function <SNR>36_OnCursorMovedNormalMode[1]..<SNR>36_AllowedToCompleteInCurrentBuffer[1]..<SNR>36_AllowedToCompleteInBuffer:
line   15:
E715: Dictionary required
Press ENTER or type command to continue
```

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2434)
<!-- Reviewable:end -->
