### PR TITLE
Address #1366 by reusing a single preview buffer

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1262,6 +1262,8 @@ def WriteToPreviewWindow_test( vim_current, vim_command ):
     call( 'modifiable', True ),
     call( 'readonly', False ),
     call( 'buftype', 'nofile' ),
+    call( 'bufhidden', 'wipe' ),
+    call( 'buflisted', False ),
     call( 'swapfile', False ),
     call( 'modifiable', False ),
     call( 'modified', False ),

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -895,6 +895,15 @@ def OpenFileInPreviewWindow( filename ):
   vim.command( 'silent! pedit! ' + filename )
 
 
+def GetPreviewBuffer():
+  """ Get the preview buffer. Create it if it does not exist. """
+  variable_name = 'g:ycm_preview_buffer_name'
+  if not VariableExists( variable_name ):
+    SetVariableValue( variable_name, vim.eval( 'tempname()' ) )
+
+  return GetVariableValue( variable_name )
+
+
 def WriteToPreviewWindow( message ):
   """ Display the supplied message in the preview window """
 
@@ -907,7 +916,7 @@ def WriteToPreviewWindow( message ):
 
   ClosePreviewWindow()
 
-  OpenFileInPreviewWindow( vim.eval( 'tempname()' ) )
+  OpenFileInPreviewWindow( GetPreviewBuffer() )
 
   if JumpToPreviewWindow():
     # We actually got to the preview window. By default the preview window can't
@@ -922,6 +931,7 @@ def WriteToPreviewWindow( message ):
     vim.current.buffer.options[ 'swapfile' ]   = False
     vim.current.buffer.options[ 'modifiable' ] = False
     vim.current.buffer.options[ 'readonly' ]   = True
+    vim.current.buffer.options[ 'buflisted' ]  = False
 
     # We need to prevent closing the window causing a warning about unsaved
     # file, so we pretend to Vim that the buffer has not been changed.

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -928,6 +928,8 @@ def WriteToPreviewWindow( message ):
     vim.current.buffer[:] = message.splitlines()
 
     vim.current.buffer.options[ 'buftype' ]    = 'nofile'
+    vim.current.buffer.options[ 'bufhidden' ]  = 'wipe'
+    vim.current.buffer.options[ 'buflisted' ]  = False
     vim.current.buffer.options[ 'swapfile' ]   = False
     vim.current.buffer.options[ 'modifiable' ] = False
     vim.current.buffer.options[ 'readonly' ]   = True

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -895,15 +895,6 @@ def OpenFileInPreviewWindow( filename ):
   vim.command( 'silent! pedit! ' + filename )
 
 
-def GetPreviewBuffer():
-  """ Get the preview buffer. Create it if it does not exist. """
-  variable_name = 'g:ycm_preview_buffer_name'
-  if not VariableExists( variable_name ):
-    SetVariableValue( variable_name, vim.eval( 'tempname()' ) )
-
-  return GetVariableValue( variable_name )
-
-
 def WriteToPreviewWindow( message ):
   """ Display the supplied message in the preview window """
 
@@ -916,7 +907,7 @@ def WriteToPreviewWindow( message ):
 
   ClosePreviewWindow()
 
-  OpenFileInPreviewWindow( GetPreviewBuffer() )
+  OpenFileInPreviewWindow( vim.eval( 'tempname()' ) )
 
   if JumpToPreviewWindow():
     # We actually got to the preview window. By default the preview window can't

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -924,7 +924,6 @@ def WriteToPreviewWindow( message ):
     vim.current.buffer.options[ 'swapfile' ]   = False
     vim.current.buffer.options[ 'modifiable' ] = False
     vim.current.buffer.options[ 'readonly' ]   = True
-    vim.current.buffer.options[ 'buflisted' ]  = False
 
     # We need to prevent closing the window causing a warning about unsaved
     # file, so we pretend to Vim that the buffer has not been changed.


### PR DESCRIPTION
* Additionally set the preview buffer to be unlisted so it does not interfere with commands like :bnext
* See [my comment](https://github.com/Valloric/YouCompleteMe/issues/1366#issuecomment-259878581) for more details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2436)
<!-- Reviewable:end -->
