### PR TITLE
[READY] Fix flake8 error

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -59,6 +59,7 @@ def PatchNoProxy():
   os.environ['no_proxy'] = ( additions if not current_value
                              else current_value + ',' + additions )
 
+
 # We need this so that Requests doesn't end up using the local HTTP proxy when
 # talking to ycmd. Users should actually be setting this themselves when
 # configuring a proxy server on their machine, but most don't know they need to


### PR DESCRIPTION
This fixes a new error detected by the last version of `pycodestyle` (2.2.0), which is a dependency of `flake8`:
```
C:\projects\youcompleteme\python\ycm\youcompleteme.py:69:1: E305 expected 2 blank lines after class or function definition, found 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2441)
<!-- Reviewable:end -->
