### PR TITLE
Add g:ycm_start_autocmd option

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -53,6 +53,11 @@ endfunction
 
 
 function! youcompleteme#Enable()
+  augroup youcompletemeStart
+    " Make sure startup autocmd only calls youcompleteme#Enable() once.
+    autocmd!
+  augroup END
+
   call s:SetUpBackwardsCompatibility()
 
   " This can be 0 if YCM libs are old or -1 if an exception occured while

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -124,6 +124,7 @@ Contents ~
   45. The |g:ycm_goto_buffer_command| option
   46. The |g:ycm_disable_for_files_larger_than_kb| option
   47. The |g:ycm_python_binary_path| option
+  48. The |g:ycm_start_autocmd| option
  11. FAQ                                                    |youcompleteme-faq|
   1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |import-vim|
   2. On very rare occasions Vim crashes when I tab through the completion menu |youcompleteme-on-very-rare-occasions-vim-crashes-when-i-tab-through-completion-menu|
@@ -2655,6 +2656,20 @@ Default: "''"
 NOTE: the settings above will make YCM use the first 'python' executable found
 through the PATH.
 
+-------------------------------------------------------------------------------
+The *g:ycm_start_autocmd* option
+
+YCM attempts to minimize its impact on Vim startup time by deferring most of
+its initialization until the |VimEnter| |autocommand| fires. You can use this
+option to make initialization even lazier by switching to another autocommand,
+or list of autocommands. For example, to wait for the |CursorHold| or
+|CursorHoldI| autocommands (which fire after Vim has been idle for
+|'updatetime'|), you would use a configuration like the following.
+
+Default: VimEnter
+>
+  let g:ycm_start_autocmd = 'CursorHold,CursorHoldI'
+<
 ===============================================================================
                                                             *youcompleteme-faq*
 FAQ ~

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -129,12 +129,15 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
+let g:ycm_start_autocmd =
+      \ get( g:, 'ycm_start_autocmd', 'VimEnter' )
+
 " On-demand loading. Let's use the autoload folder and not slow down vim's
 " startup procedure.
 if has( 'vim_starting' ) " loading at startup
   augroup youcompletemeStart
     autocmd!
-    autocmd VimEnter * call youcompleteme#Enable()
+    execute 'autocmd ' . g:ycm_start_autocmd . ' * call youcompleteme#Enable()'
   augroup END
 else " manual loading with :packadd
   call youcompleteme#Enable()


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

Profiling with `vim --startuptime` shows that YCM is responsible for about 250ms of the overall 500ms that Vim spends starting up on my machine. By switching from "VimEnter" to "CursorHold,CursorHoldI" as a trigger for calling `youcompleteme#Enable`, we get almost all of that back, leading to an approximately 50% speed-up and a very perceptible improvement in responsiveness.

The trade-off here is that YCM won't get fully initialized until Vim has been idle for `'updatetime'` seconds (2s in my set-up, which apparently YCM itself sets; before YCM runs though, the default of 4s is probably active). As not everybody may like this trade-off, I've made all this configurable via an option.

Test plan: Manually tested with `--startuptime` and the settings shown in the documentation (no automated tests yet because testing VimScript changes automatically is hard, like it says in the `CONTRIBUTING` doc; wanting some feedback on whether this would be the sort of thing that you'd want to include before I go further with it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2454)
<!-- Reviewable:end -->
