### PR TITLE
[READY] Remove outdated Syntastic option

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -96,8 +96,7 @@ let g:ycm_server_python_interpreter =
       \ get( g:, 'ycm_path_to_python_interpreter', '' ) )
 
 let g:ycm_show_diagnostics_ui =
-      \ get( g:, 'ycm_show_diagnostics_ui',
-      \ get( g:, 'ycm_register_as_syntastic_checker', 1 ) )
+      \ get( g:, 'ycm_show_diagnostics_ui', 1 )
 
 let g:ycm_enable_diagnostic_signs =
       \ get( g:, 'ycm_enable_diagnostic_signs',


### PR DESCRIPTION
The `ycm_register_as_syntastic_checker` option was introduced a long time ago in commit https://github.com/Valloric/YouCompleteMe/commit/16b6f877c62510840e4547e11f4b31a89e68f491 and became obsolete when [Syntastic support was replaced](https://github.com/Valloric/YouCompleteMe/commit/6c01881e1a615b1b87fc5ef20855d11f9fde32a7). Since then, it doesn't serve any purpose except being an alias to the `ycm_show_diagnostics_ui` option which can be an issue (see #2455) so we remove it.

Fixes #2455.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2456)
<!-- Reviewable:end -->
