### PR TITLE
[READY] Fix exception when response future is not set

### DIFF
--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -38,6 +38,7 @@ class CompletionRequest( BaseRequest ):
   def __init__( self, request_data ):
     super( CompletionRequest, self ).__init__()
     self.request_data = request_data
+    self._response_future = None
 
 
   def Start( self ):
@@ -47,7 +48,7 @@ class CompletionRequest( BaseRequest ):
 
 
   def Done( self ):
-    return self._response_future.done()
+    return bool( self._response_future ) and self._response_future.done()
 
 
   def RawResponse( self ):

--- a/python/ycm/client/event_notification.py
+++ b/python/ycm/client/event_notification.py
@@ -37,6 +37,7 @@ class EventNotification( BaseRequest ):
     self._event_name = event_name
     self._filepath = filepath
     self._extra_data = extra_data
+    self._response_future = None
     self._cached_response = None
 
 
@@ -51,7 +52,7 @@ class EventNotification( BaseRequest ):
 
 
   def Done( self ):
-    return self._response_future.done()
+    return bool( self._response_future ) and self._response_future.done()
 
 
   def Response( self ):


### PR DESCRIPTION
An `AttributeError` exception is raised when `Done` is called before `Start` in the `CompletionRequest` and `EventNotification` classes because the `_response_future` attribute is not yet defined.

Fixes #2461.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2465)
<!-- Reviewable:end -->
