### PR TITLE
[READY] Handle server exceptions from loading/ignoring extra conf

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -215,12 +215,13 @@ def HandleServerException( display = True, truncate = False ):
      response = BaseRequest.PostDataToHandler( ... )
   """
   try:
-    yield
-  except UnknownExtraConf as e:
-    if vimsupport.Confirm( str( e ) ):
-      _LoadExtraConfFile( e.extra_conf_file )
-    else:
-      _IgnoreExtraConfFile( e.extra_conf_file )
+    try:
+      yield
+    except UnknownExtraConf as e:
+      if vimsupport.Confirm( str( e ) ):
+        _LoadExtraConfFile( e.extra_conf_file )
+      else:
+        _IgnoreExtraConfFile( e.extra_conf_file )
   except Exception as e:
     _logger.exception( 'Error while handling server response' )
     if display:


### PR DESCRIPTION
Since PR #2453, we don't catch anymore exceptions raised from loading or ignoring a `.ycm_extra_conf.py` file. For instance, loading this extra conf:
```python
raise Exception
```
will result in a Python traceback inside Vim. This is fixed by catching the `UnknownExtraConf` exception in its own block (as [it was before](https://github.com/Valloric/YouCompleteMe/blob/48b7ccef76c9f15b8fc0227b5e661eb55e483459/python/ycm/client/event_notification.py#L64-L73)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2488)
<!-- Reviewable:end -->
