### PR TITLE
[READY] Reset the start column in omnifunc completer

### DIFF
--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -83,6 +83,13 @@ class OmniCompleter( Completer ):
         # FIXME: Technically, if the return is -1 we should raise an error
         return []
 
+      # Use the start column calculated by the omnifunc, rather than our own
+      # interpretation. This is important for certain languages where our
+      # identifier detection is either incorrect or not compatible with the
+      # behaviour of the omnifunc. Note: do this before calling the omnifunc
+      # because it affects the value returned by 'query'
+      request_data[ 'start_column' ] = return_value + 1
+
       omnifunc_call = [ self._omnifunc,
                         "(0,'",
                         vimsupport.EscapeForVim( request_data[ 'query' ] ),


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

A number of issues have been raised over the years where YCM doesn't interact great with the user's omnifunc. This is commonly because we ignore the omnifunc's `findstart` response, and use our own implementation (`base.CompletionStartColumn`).

In combination with valloric/ycmd#681 this change uses the omnifunc's start column for completions and fixes valloric/ycmd#671 and others, such as:

- https://github.com/Valloric/YouCompleteMe/issues/1322 probably (not yet tested)
- https://github.com/Valloric/YouCompleteMe/issues/1957
- https://github.com/Valloric/YouCompleteMe/issues/1816

Note: This is just an initial test for sharing the code to gauge reaction. Not fully tested yet.




[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2489)
<!-- Reviewable:end -->
