### PR TITLE
[READY] Improve issue template - guide the user in completing it

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,9 @@ the brackets) _before_ filing your issue:**
 - [ ] If filing a bug report, I have included which OS (including specific OS
   version) I am using.
 - [ ] If filing a bug report, I have included a minimal test case that reproduces
-  my issue.
+  my issue, including what I expected to happen and what actually happened.
+- [ ] If filing a installation failure report, I have included the entire output
+  of `install.py` (or `cmake`/`make`/`ninja`) including its invocation
 - [ ] **I understand this is an open-source project staffed by volunteers and
   that any help I receive is a selfless, heartfelt _gift_ of their free time. I
   know I am not entitled to anything and will be polite and courteous.**
@@ -29,11 +31,52 @@ quickly and that neither your nor our time is needlessly wasted.
 
 # Issue Details
 
-[If filing a bug report, please include **a list of steps** that describe how to
-reproduce the bug you are experiencing. Also include test code if relevant.]
+> Provide a clear description of the problem, including the following key
+> questions:
+
+* What did you do?
+
+> Include steps to reproduce here.
+
+> Include description of a minimal test case, including any actual code required
+> to reproduce the issue.
+
+* What did you expect to happen?
+
+> Include description of the expected behaviour.
+
+* What actually happened?
+
+> Include description of the observed behaviour, including actual output,
+> screenshots, etc.
+
+# Diagnostic data
+
+## Output of `vim --version`
+
+> Place the output here, or a link to a [gist][].
+
+## Output of `YcmDebugInfo`
+
+> Place the output here, or a link to a [gist][].
+
+## Contents of YCM, ycmd and completion engine logfiles
+
+> Include link here to a [gist][] containing the entire logfiles for ycm, ycmd
+> and any completer logfiles listed by `:YcmToggleLogs`.
+
+## OS version, distribution, etc.
+
+> Include system information here.
+
+## Output of build/install commands
+
+> Include link to a [gist][] containing the invocation and entire output of
+> `install.py` if reporting an installation issue.
 
 [cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
 [code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
 [readme]: https://github.com/Valloric/YouCompleteMe/blob/master/README.md
 [faq]: https://github.com/Valloric/YouCompleteMe/blob/master/README.md#faq
 [search]: https://www.google.com/search?q=site%3Ahttps%3A%2F%2Fgithub.com%2FValloric%2FYouCompleteMe%2Fissues%20python%20mac
+[gist]: https://gist.github.com/


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.

> project administration-only change

- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The issue template has worked very well and a larger number of reported issues include useful diagnostics. However, this is still far from ubiquitous.

I've noticed two recurring problems, that I've tried to solve with an update to the template:

- when reporting a build failure, not including the _entire_ `install.py` log or the command used to run it
- when reporting issues, stating that something doesn't work, but not stating what the expected behaviour was (this is a common human mistake).

Meanwhile, I've encouraged the reporter to fill in the sections by actually providing such sections in the template for them to fill in. 

This is unlikely to get us to 100%, but hopefully another incremental increase in the quality of reports will come out of it.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2496)
<!-- Reviewable:end -->
