### PR TITLE
Move changedtick handling to python && Diagnostics per buffer.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -418,18 +418,6 @@ function! s:SetUpCompleteopt()
 endfunction
 
 
-" For various functions/use-cases, we want to keep track of whether the buffer
-" has changed since the last time they were invoked. We keep the state of
-" b:changedtick of the last time the specific function was called in
-" b:ycm_changedtick.
-function! s:SetUpYcmChangedTick()
-  let b:ycm_changedtick  =
-        \ get( b:, 'ycm_changedtick', {
-        \   'file_ready_to_parse' : -1,
-        \ } )
-endfunction
-
-
 function! s:DisableOnLargeFile( filename )
   if exists( 'b:ycm_largefile' )
     return
@@ -457,10 +445,6 @@ endfunction
 
 
 function! s:OnBufferRead()
-  " We need to do this even when we are not allowed to complete in the current
-  " buffer because we might be allowed to complete in the future! The canonical
-  " example is creating a new buffer with :enew and then setting a filetype.
-  call s:SetUpYcmChangedTick()
 
   call s:DisableOnLargeFile( expand( '<afile>:p' ) )
 
@@ -514,21 +498,7 @@ endfunction
 
 
 function! s:OnFileReadyToParse()
-  " We need to call this just in case there is no b:ycm_changetick; this can
-  " happen for special buffers.
-  call s:SetUpYcmChangedTick()
-
-  " Order is important here; we need to extract any information before
-  " reparsing the file again. If we sent the new parse request first, then
-  " the response would always be pending when we called
-  " HandleFileParseRequest.
-  exec s:python_command "ycm_state.HandleFileParseRequest()"
-
-  let buffer_changed = b:changedtick != b:ycm_changedtick.file_ready_to_parse
-  if buffer_changed
-    exec s:python_command "ycm_state.OnFileReadyToParse()"
-  endif
-  let b:ycm_changedtick.file_ready_to_parse = b:changedtick
+  exec s:python_command "ycm_state.OnFileReadyToParse()"
 endfunction
 
 
@@ -844,8 +814,7 @@ function! s:ForceCompile()
   endif
 
   echom "Forcing compilation, this will block Vim until done."
-  exec s:python_command "ycm_state.OnFileReadyToParse()"
-  exec s:python_command "ycm_state.HandleFileParseRequest( True )"
+  exec s:python_command "ycm_state.OnFileReadyToParse( True )"
 
   return 1
 endfunction

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2016, Davit Samvelyan
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from ycm import vimsupport
+from ycm.client.event_notification import EventNotification
+
+
+class Buffer( object ):
+
+  def __init__( self, bufnr ):
+    self.number = bufnr
+    self._parse_tick = 0
+    self._handled_tick = 0
+    self._parse_request = None
+    self._diagnostics = []
+
+
+  def FileParseRequestReady( self, block = False ):
+    return self._parse_tick == 0 or block or self._parse_request.Done()
+
+
+  def SendParseRequest( self, extra_data ):
+    self._parse_request = EventNotification( 'FileReadyToParse',
+                                             extra_data = extra_data )
+    self._parse_request.Start()
+    self._parse_tick = self._ChangedTick()
+
+
+  def NeedsReparse( self ):
+    return self._parse_tick < self._ChangedTick()
+
+
+  def Diagnostics( self ):
+    return self._diagnostics
+
+
+  def UpdateDiagnostics( self ):
+    self._diagnostics = self._parse_request.Response()
+
+
+  def GetResponse( self ):
+    return self._parse_request.Response()
+
+
+  def IsResponseHandled( self ):
+    return self._handled_tick == self._parse_tick
+
+
+  def MarkResponseHandled( self ):
+    self._handled_tick = self._parse_tick
+
+
+  def _ChangedTick( self ):
+    return vimsupport.GetBufferChangeTick(self.number)
+
+
+class BufferDict( dict ):
+
+  def __missing__( self, key ):
+    value = self[ key ] = Buffer( key )
+    return value

--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -31,16 +31,17 @@ import vim
 
 
 class DiagnosticInterface( object ):
-  def __init__( self, user_options ):
+  def __init__( self, bufnr, user_options ):
+    self._bufnr = bufnr
     self._user_options = user_options
+    self._diagnostics = []
     self._diag_filter = DiagnosticFilter.CreateFromOptions( user_options )
     # Line and column numbers are 1-based
-    self._buffer_number_to_line_to_diags = defaultdict(
-      lambda: defaultdict( list ) )
+    self._line_to_diags = defaultdict( list )
+    self._placed_signs = []
     self._next_sign_id = 1
     self._previous_line_number = -1
     self._diag_message_needs_clearing = False
-    self._placed_signs = []
 
 
   def OnCursorMoved( self ):
@@ -54,54 +55,43 @@ class DiagnosticInterface( object ):
 
 
   def GetErrorCount( self ):
-    return len( self._FilterDiagnostics( _DiagnosticIsError ) )
+    return self._DiagnosticsCount( _DiagnosticIsError )
 
 
   def GetWarningCount( self ):
-    return len( self._FilterDiagnostics( _DiagnosticIsWarning ) )
+    return self._DiagnosticsCount( _DiagnosticIsWarning )
 
 
-  def PopulateLocationList( self, diags ):
-    vimsupport.SetLocationList(
-      vimsupport.ConvertDiagnosticsToQfList(
-          self._ApplyDiagnosticFilter( diags ) ) )
+  def PopulateLocationList( self ):
+    # Do nothing if loc list is already populated by diag_interface
+    if not self._user_options[ 'always_populate_location_list' ]:
+      self._UpdateLocationList()
+    return bool( self._diagnostics )
 
 
   def UpdateWithNewDiagnostics( self, diags ):
-    normalized_diags = [ _NormalizeDiagnostic( x ) for x in
-            self._ApplyDiagnosticFilter( diags ) ]
-    self._buffer_number_to_line_to_diags = _ConvertDiagListToDict(
-        normalized_diags )
+    self._diagnostics = [ _NormalizeDiagnostic( x ) for x in
+                            self._ApplyDiagnosticFilter( diags ) ]
+    self._ConvertDiagListToDict()
 
     if self._user_options[ 'enable_diagnostic_signs' ]:
-      self._placed_signs, self._next_sign_id = _UpdateSigns(
-        self._placed_signs,
-        self._buffer_number_to_line_to_diags,
-        self._next_sign_id )
+      self._UpdateSigns()
 
     if self._user_options[ 'enable_diagnostic_highlighting' ]:
-      _UpdateSquiggles( self._buffer_number_to_line_to_diags )
+      self._UpdateSquiggles()
 
     if self._user_options[ 'always_populate_location_list' ]:
-      self.PopulateLocationList( normalized_diags )
+      self._UpdateLocationList()
 
 
-  def _ApplyDiagnosticFilter( self, diags, extra_predicate = None ):
-    filetypes = vimsupport.CurrentFiletypes()
+  def _ApplyDiagnosticFilter( self, diags ):
+    filetypes = vimsupport.GetBufferFiletypes( self._bufnr )
     diag_filter = self._diag_filter.SubsetForTypes( filetypes )
-    predicate = diag_filter.IsAllowed
-    if extra_predicate is not None:
-      def Filter( diag ):
-        return extra_predicate( diag ) and diag_filter.IsAllowed( diag )
-
-      predicate = Filter
-
-    return filter( predicate, diags )
+    return filter( diag_filter.IsAllowed, diags )
 
 
   def _EchoDiagnosticForLine( self, line_num ):
-    buffer_num = vim.current.buffer.number
-    diags = self._buffer_number_to_line_to_diags[ buffer_num ][ line_num ]
+    diags = self._line_to_diags[ line_num ]
     if not diags:
       if self._diag_message_needs_clearing:
         # Clear any previous diag echo
@@ -117,142 +107,103 @@ class DiagnosticInterface( object ):
     self._diag_message_needs_clearing = True
 
 
-  def _FilterDiagnostics( self, predicate ):
-    matched_diags = []
-    line_to_diags = self._buffer_number_to_line_to_diags[
-      vim.current.buffer.number ]
-
-    for diags in itervalues( line_to_diags ):
-      matched_diags.extend( list(
-        self._ApplyDiagnosticFilter( diags, predicate ) ) )
-    return matched_diags
+  def _DiagnosticsCount( self, predicate ):
+    count = 0
+    for diags in itervalues( self._line_to_diags ):
+      count += sum( 1 for d in diags if predicate( d ) )
+    return count
 
 
-def _UpdateSquiggles( buffer_number_to_line_to_diags ):
-  vimsupport.ClearYcmSyntaxMatches()
-  line_to_diags = buffer_number_to_line_to_diags[ vim.current.buffer.number ]
+  def _ConvertDiagListToDict( self ):
+    self._line_to_diags = defaultdict( list )
+    for diag in self._diagnostics:
+      location = diag[ 'location' ]
+      bufnr = vimsupport.GetBufferNumberForFilename( location[ 'filepath' ] )
+      if bufnr != self._bufnr:
+          continue
+      line_number = location[ 'line_num' ]
+      self._line_to_diags[ line_number ].append( diag )
 
-  for diags in itervalues( line_to_diags ):
-    for diag in diags:
-      location_extent = diag[ 'location_extent' ]
-      is_error = _DiagnosticIsError( diag )
-
-      if location_extent[ 'start' ][ 'line_num' ] < 0:
-        location = diag[ 'location' ]
-        vimsupport.AddDiagnosticSyntaxMatch(
-            location[ 'line_num' ],
-            location[ 'column_num' ] )
-      else:
-        vimsupport.AddDiagnosticSyntaxMatch(
-          location_extent[ 'start' ][ 'line_num' ],
-          location_extent[ 'start' ][ 'column_num' ],
-          location_extent[ 'end' ][ 'line_num' ],
-          location_extent[ 'end' ][ 'column_num' ],
-          is_error = is_error )
-
-      for diag_range in diag[ 'ranges' ]:
-        vimsupport.AddDiagnosticSyntaxMatch(
-          diag_range[ 'start' ][ 'line_num' ],
-          diag_range[ 'start' ][ 'column_num' ],
-          diag_range[ 'end' ][ 'line_num' ],
-          diag_range[ 'end' ][ 'column_num' ],
-          is_error = is_error )
-
-
-def _UpdateSigns( placed_signs, buffer_number_to_line_to_diags, next_sign_id ):
-  new_signs, kept_signs, next_sign_id = _GetKeptAndNewSigns(
-    placed_signs, buffer_number_to_line_to_diags, next_sign_id
-  )
-  # Dummy sign used to prevent "flickering" in Vim when last mark gets
-  # deleted from buffer. Dummy sign prevents Vim to collapsing the sign column
-  # in that case.
-  # There's also a vim bug which causes the whole window to redraw in some
-  # conditions (vim redraw logic is very complex). But, somehow, if we place a
-  # dummy sign before placing other "real" signs, it will not redraw the
-  # buffer (patch to vim pending).
-  dummy_sign_needed = not kept_signs and new_signs
-
-  if dummy_sign_needed:
-    vimsupport.PlaceDummySign( next_sign_id + 1,
-                               vim.current.buffer.number,
-                               new_signs[ 0 ].line )
-
-  # We place only those signs that haven't been placed yet.
-  new_placed_signs = _PlaceNewSigns( kept_signs, new_signs )
-
-  # We use incremental placement, so signs that already placed on the correct
-  # lines will not be deleted and placed again, which should improve performance
-  # in case of many diags. Signs which don't exist in the current diag should be
-  # deleted.
-  _UnplaceObsoleteSigns( kept_signs, placed_signs )
-
-  if dummy_sign_needed:
-    vimsupport.UnPlaceDummySign( next_sign_id + 1, vim.current.buffer.number )
-
-  return new_placed_signs, next_sign_id
-
-
-def _GetKeptAndNewSigns( placed_signs, buffer_number_to_line_to_diags,
-                         next_sign_id ):
-  new_signs = []
-  kept_signs = []
-  for buffer_number, line_to_diags in iteritems(
-                                            buffer_number_to_line_to_diags ):
-    if not vimsupport.BufferIsVisible( buffer_number ):
-      continue
-
-    for line, diags in iteritems( line_to_diags ):
-      for diag in diags:
-        sign = _DiagSignPlacement( next_sign_id,
-                                   line,
-                                   buffer_number,
-                                   _DiagnosticIsError( diag ) )
-        if sign not in placed_signs:
-          new_signs += [ sign ]
-          next_sign_id += 1
-        else:
-          # We use .index here because `sign` contains a new id, but
-          # we need the sign with the old id to unplace it later on.
-          # We won't be placing the new sign.
-          kept_signs += [ placed_signs[ placed_signs.index( sign ) ] ]
-  return new_signs, kept_signs, next_sign_id
-
-
-
-def _PlaceNewSigns( kept_signs, new_signs ):
-  placed_signs = kept_signs[:]
-  for sign in new_signs:
-    # Do not set two signs on the same line, it will screw up storing sign
-    # locations.
-    if sign in placed_signs:
-      continue
-    vimsupport.PlaceSign( sign.id, sign.line, sign.buffer, sign.is_error )
-    placed_signs.append(sign)
-  return placed_signs
-
-
-def _UnplaceObsoleteSigns( kept_signs, placed_signs ):
-  for sign in placed_signs:
-    if sign not in kept_signs:
-      vimsupport.UnplaceSignInBuffer( sign.buffer, sign.id )
-
-
-def _ConvertDiagListToDict( diag_list ):
-  buffer_to_line_to_diags = defaultdict( lambda: defaultdict( list ) )
-  for diag in diag_list:
-    location = diag[ 'location' ]
-    buffer_number = vimsupport.GetBufferNumberForFilename(
-      location[ 'filepath' ] )
-    line_number = location[ 'line_num' ]
-    buffer_to_line_to_diags[ buffer_number ][ line_number ].append( diag )
-
-  for line_to_diags in itervalues( buffer_to_line_to_diags ):
-    for diags in itervalues( line_to_diags ):
+    for diags in itervalues( self._line_to_diags ):
       # We also want errors to be listed before warnings so that errors aren't
       # hidden by the warnings; Vim won't place a sign oven an existing one.
-      diags.sort( key = lambda diag: ( diag[ 'location' ][ 'column_num' ],
-                                       diag[ 'kind' ] ) )
-  return buffer_to_line_to_diags
+      diags.sort( key = lambda diag: ( diag[ 'kind' ],
+                                       diag[ 'location' ][ 'column_num' ] ) )
+
+
+  def _UpdateSigns( self ):
+    new_signs, obsolete_signs = self._GetNewAndObsoleteSigns()
+
+    self._PlaceNewSigns( new_signs )
+
+    self._UnplaceObsoleteSigns( obsolete_signs )
+
+
+  def _GetNewAndObsoleteSigns( self ):
+    new_signs = []
+    obsolete_signs = self._placed_signs[:]
+    for line, diags in iteritems( self._line_to_diags ):
+      # We always go for the first diagnostic on line,
+      # because it is sorted giving priority to the Errors.
+      diag = diags[ 0 ]
+      sign = _DiagSignPlacement( self._next_sign_id,
+                                 line, _DiagnosticIsError( diag ) )
+      try:
+        obsolete_signs.remove( sign )
+      except ValueError:
+        new_signs.append( sign )
+        self._next_sign_id += 1
+    return new_signs, obsolete_signs
+
+
+  def _PlaceNewSigns( self, new_signs ):
+    for sign in new_signs:
+      vimsupport.PlaceSign( sign.id, sign.line, self._bufnr, sign.is_error )
+      self._placed_signs.append( sign )
+
+
+  def _UnplaceObsoleteSigns( self, obsolete_signs ):
+    for sign in obsolete_signs:
+      self._placed_signs.remove( sign )
+      vimsupport.UnplaceSignInBuffer( self._bufnr, sign.id )
+
+
+  def _UpdateSquiggles( self ):
+    if self._bufnr != vim.current.buffer.number:
+      return
+
+    vimsupport.ClearYcmSyntaxMatches()
+
+    for diags in itervalues( self._line_to_diags ):
+      for diag in diags:
+        location_extent = diag[ 'location_extent' ]
+        is_error = _DiagnosticIsError( diag )
+
+        if location_extent[ 'start' ][ 'line_num' ] < 0:
+          location = diag[ 'location' ]
+          vimsupport.AddDiagnosticSyntaxMatch(
+              location[ 'line_num' ],
+              location[ 'column_num' ] )
+        else:
+          vimsupport.AddDiagnosticSyntaxMatch(
+            location_extent[ 'start' ][ 'line_num' ],
+            location_extent[ 'start' ][ 'column_num' ],
+            location_extent[ 'end' ][ 'line_num' ],
+            location_extent[ 'end' ][ 'column_num' ],
+            is_error = is_error )
+
+        for diag_range in diag[ 'ranges' ]:
+          vimsupport.AddDiagnosticSyntaxMatch(
+            diag_range[ 'start' ][ 'line_num' ],
+            diag_range[ 'start' ][ 'column_num' ],
+            diag_range[ 'end' ][ 'line_num' ],
+            diag_range[ 'end' ][ 'column_num' ],
+            is_error = is_error )
+
+
+  def _UpdateLocationList( self ):
+    vimsupport.SetLocationList(
+      vimsupport.ConvertDiagnosticsToQfList( self._diagnostics ) )
 
 
 _DiagnosticIsError = CompileLevel( 'error' )
@@ -269,12 +220,10 @@ def _NormalizeDiagnostic( diag ):
   return diag
 
 
-class _DiagSignPlacement(
-                    namedtuple( "_DiagSignPlacement",
-                                [ 'id', 'line', 'buffer', 'is_error' ] ) ):
+class _DiagSignPlacement( namedtuple( "_DiagSignPlacement",
+                                      [ 'id', 'line', 'is_error' ] ) ):
   # We want two signs that have different ids but the same location to compare
   # equal. ID doesn't matter.
   def __eq__( self, other ):
     return ( self.line == other.line and
-             self.buffer == other.buffer and
              self.is_error == other.is_error )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -146,6 +146,14 @@ def GetCurrentBufferFilepath():
   return GetBufferFilepath( vim.current.buffer )
 
 
+def GetCurrentBufferNumber():
+  return vim.current.buffer.number
+
+
+def GetBufferChangeTick( bufnr ):
+  return GetIntValue( u'getbufvar({0}, "changedtick")'.format( bufnr ) )
+
+
 def BufferIsVisible( buffer_number ):
   if buffer_number < 0:
     return False

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -585,6 +585,11 @@ def CurrentFiletypes():
   return VimExpressionToPythonType( "&filetype" ).split( '.' )
 
 
+def GetBufferFiletypes( bufnr ):
+  command = 'getbufvar({0}, "&ft")'.format( bufnr )
+  return VimExpressionToPythonType( command ).split( '.' )
+
+
 def FiletypesForBuffer( buffer_object ):
   # NOTE: Getting &ft for other buffers only works when the buffer has been
   # visited by the user at least once, which is true for modified buffers

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -39,7 +39,6 @@ from ycm.buffer import BufferDict
 from ycmd import utils
 from ycmd import server_utils
 from ycmd.request_wrap import RequestWrap
-from ycm.diagnostic_interface import DiagnosticInterface
 from ycm.omni_completer import OmniCompleter
 from ycm import syntax_parse
 from ycm.client.ycmd_keepalive import YcmdKeepalive
@@ -114,9 +113,8 @@ class YouCompleteMe( object ):
     self._available_completers = {}
     self._user_options = user_options
     self._user_notified_about_crash = False
-    self._diag_interface = DiagnosticInterface( user_options )
     self._omnicomp = OmniCompleter( user_options )
-    self._buffers = BufferDict()
+    self._buffers = BufferDict( user_options )
     self._buffer = None
     self._latest_completion_request = None
     self._logger = logging.getLogger( 'ycm' )
@@ -396,7 +394,7 @@ class YouCompleteMe( object ):
 
 
   def OnCursorMoved( self ):
-    self._diag_interface.OnCursorMoved()
+    self._buffer.OnCursorMoved()
 
 
   def _CleanLogfile( self ):
@@ -580,11 +578,13 @@ class YouCompleteMe( object ):
 
 
   def GetErrorCount( self ):
-    return self._diag_interface.GetErrorCount()
+    current_buffer = self._buffers[ vim.current.buffer.number ]
+    return current_buffer.GetErrorCount()
 
 
   def GetWarningCount( self ):
-    return self._diag_interface.GetWarningCount()
+    current_buffer = self._buffers[ vim.current.buffer.number ]
+    return current_buffer.GetWarningCount()
 
 
   def DiagnosticUiSupportedForCurrentFiletype( self ):
@@ -598,14 +598,7 @@ class YouCompleteMe( object ):
 
 
   def PopulateLocationListWithLatestDiagnostics( self ):
-    # Do nothing if loc list is already populated by diag_interface
-    if not self._user_options[ 'always_populate_location_list' ]:
-      self._diag_interface.PopulateLocationList( self._buffer.Diagnostics() )
-    return bool( self._buffer.Diagnostics() )
-
-
-  def UpdateDiagnosticInterface( self ):
-    self._diag_interface.UpdateWithNewDiagnostics( self._buffer.Diagnostics() )
+    return self._buffer.PopulateLocationList()
 
 
   # For testing purposes
@@ -621,7 +614,6 @@ class YouCompleteMe( object ):
     if self.NativeFiletypeCompletionUsable():
       if self.ShouldDisplayDiagnostics():
         self._buffer.UpdateDiagnostics()
-        self.UpdateDiagnosticInterface()
       else:
         # YCM client has a hard-coded list of filetypes which are known
         # to support diagnostics, self.DiagnosticUiSupportedForCurrentFiletype()
@@ -631,8 +623,6 @@ class YouCompleteMe( object ):
         # response, to allow the server to raise configuration warnings, etc.
         # to the user. We ignore any other supplied data.
         self._buffer.GetResponse()
-
-      self.NotifyFileParseReady( self._buffer.number )
 
     self._buffer.MarkResponseHandled()
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

First part of this PR moves file change tracking into python and blocks new FileReadyToParse requests if there is already ongoing one, because new one will return "already parsing" result anyway.
Improvements:
 - Prevent server spamming.
 - Does not overwrite ongoing parse request, which allows to get intermediate info from it after parse is done.
 - Change parsed tick only when parse request will get going, rather then end up as "already parsing", allowing to know more precisely when parse is needed. (Fixes bug when adding compile error just after opening big TU does not show up until new change)
 - Fixes bug when calling YcmDiags on just opened big TU does not block.
 - Decreases number of unwanted/unnecessary FileRequestReady notifications, which improves DyeVim stability.
 - Moves some of the logic from VimL to python and simplifies it.

Second part changes diagnostic interface to store diagnostics per buffer.
 - Fixes bug when switching to another window/buffer clears diagnostics of previous window/buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2498)
<!-- Reviewable:end -->
