### PR TITLE
Move changedtick tracking into python.

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -478,19 +478,7 @@ function! s:OnFileReadyToParse()
     call s:SetOmnicompleteFunc()
     return
   endif
-
-  " Order is important here; we need to extract any information before
-  " reparsing the file again. If we sent the new parse request first, then
-  " the response would always be pending when we called
-  " HandleFileParseRequest.
-  exec s:python_command "ycm_state.HandleFileParseRequest()"
-
-  " We only want to send a new FileReadyToParse event notification if the buffer
-  " has changed since the last time we sent one.
-  if b:changedtick != get( b:, 'ycm_changedtick', -1 )
-    exec s:python_command "ycm_state.OnFileReadyToParse()"
-    let b:ycm_changedtick = b:changedtick
-  endif
+  exec s:python_command "ycm_state.OnFileReadyToParse()"
 endfunction
 
 

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2016, Davit Samvelyan
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+
+from ycm import vimsupport
+from ycm.client.event_notification import EventNotification
+from ycm.diagnostic_interface import DiagnosticInterface
+
+
+class Buffer( object ):
+
+  def __init__( self, bufnr, user_options ):
+    self.number = bufnr
+    self._parse_tick = 0
+    self._handled_tick = 0
+    self._parse_request = None
+    self._diag_interface = DiagnosticInterface( user_options )
+
+
+  def FileParseRequestReady( self, block = False ):
+    return self._parse_tick == 0 or block or self._parse_request.Done()
+
+
+  def SendParseRequest( self, extra_data ):
+    self._parse_request = EventNotification( 'FileReadyToParse',
+                                             extra_data = extra_data )
+    self._parse_request.Start()
+    self._parse_tick = self._ChangedTick()
+
+
+  def NeedsReparse( self ):
+    return self._parse_tick != self._ChangedTick()
+
+
+  def UpdateDiagnostics( self ):
+    diagnostics = self._parse_request.Response()
+    self._diag_interface.UpdateWithNewDiagnostics( diagnostics )
+
+
+  def PopulateLocationList( self ):
+    return self._diag_interface.PopulateLocationList()
+
+
+  def GetResponse( self ):
+    return self._parse_request.Response()
+
+
+  def IsResponseHandled( self ):
+    return self._handled_tick == self._parse_tick
+
+
+  def MarkResponseHandled( self ):
+    self._handled_tick = self._parse_tick
+
+
+  def OnCursorMoved( self ):
+    self._diag_interface.OnCursorMoved()
+
+
+  def GetErrorCount( self ):
+    return self._diag_interface.GetErrorCount()
+
+
+  def GetWarningCount( self ):
+    return self._diag_interface.GetWarningCount()
+
+
+  def _ChangedTick( self ):
+    return vimsupport.GetBufferChangedTick( self.number )
+
+
+class BufferDict( dict ):
+
+  def __init__( self, user_options ):
+    self._user_options = user_options
+
+
+  def __missing__( self, key ):
+    value = self[ key ] = Buffer( key, self._user_options )
+    return value

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -40,7 +40,7 @@ BUFWINNR_REGEX = re.compile( '^bufwinnr\((?P<buffer_number>[0-9]+)\)$' )
 BWIPEOUT_REGEX = re.compile(
   '^(?:silent! )bwipeout!? (?P<buffer_number>[0-9]+)$' )
 GETBUFVAR_REGEX = re.compile(
-  '^getbufvar\((?P<buffer_number>[0-9]+), "&(?P<option>.+)"\)$' )
+  '^getbufvar\((?P<buffer_number>[0-9]+), "(?P<option>.+)"\)$' )
 MATCHADD_REGEX = re.compile(
   '^matchadd\(\'(?P<group>.+)\', \'(?P<pattern>.+)\'\)$' )
 MATCHDELETE_REGEX = re.compile( '^matchdelete\((?P<id>)\)$' )
@@ -85,10 +85,12 @@ def _MockGetBufferWindowNumber( buffer_number ):
 def _MockGetBufferVariable( buffer_number, option ):
   for vim_buffer in VIM_MOCK.buffers:
     if vim_buffer.number == buffer_number:
-      if option == 'mod':
+      if option == '&mod':
         return vim_buffer.modified
-      if option == 'ft':
+      if option == '&ft':
         return vim_buffer.filetype
+      if option == 'changedtick':
+        return vim_buffer.changedtick
       return ''
   return ''
 
@@ -230,6 +232,7 @@ class VimBuffer( object ):
     self.modified = modified
     self.window = window
     self.omnifunc = omnifunc
+    self.changedtick = 1
 
 
   def __getitem__( self, index ):
@@ -248,6 +251,10 @@ class VimBuffer( object ):
   def GetLines( self ):
     """Returns the contents of the buffer as a list of unicode strings."""
     return [ ToUnicode( x ) for x in self.contents ]
+
+
+def EmulateCurrentBufferChange():
+  VIM_MOCK.current.buffer.changedtick += 1
 
 
 class VimMatch( object ):

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -349,6 +349,7 @@ def YouCompleteMe_ShowDiagnostics_NoDiagnosticsDetected_test(
                           'open_loclist_on_ycm_diags': 0 } )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
+@patch( 'ycm.youcompleteme.YouCompleteMe.IsServerReady', return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
 @patch( 'ycm.vimsupport.SetLocationList', new_callable = ExtendedMock )
 def YouCompleteMe_ShowDiagnostics_DiagnosticsFound_DoNotOpenLocationList_test(
@@ -388,6 +389,7 @@ def YouCompleteMe_ShowDiagnostics_DiagnosticsFound_DoNotOpenLocationList_test(
 @YouCompleteMeInstance( { 'open_loclist_on_ycm_diags': 1 } )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
+@patch( 'ycm.youcompleteme.YouCompleteMe.IsServerReady', return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
 @patch( 'ycm.vimsupport.SetLocationList', new_callable = ExtendedMock )
 @patch( 'ycm.vimsupport.OpenLocationList', new_callable = ExtendedMock )
@@ -431,6 +433,7 @@ def YouCompleteMe_ShowDiagnostics_DiagnosticsFound_OpenLocationList_test(
                           'enable_diagnostic_highlighting': 1 } )
 @patch( 'ycm.youcompleteme.YouCompleteMe.FiletypeCompleterExistsForFiletype',
         return_value = True )
+@patch( 'ycm.youcompleteme.YouCompleteMe.IsServerReady', return_value = True )
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
@@ -511,8 +514,7 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 3, 1 ) ):
     with patch( 'ycm.client.event_notification.EventNotification.Response',
                 return_value = diagnostics ):
-      ycm.OnFileReadyToParse()
-      ycm.HandleFileParseRequest( block = True )
+      ycm.OnFileReadyToParse( block = True )
 
     # Error match is added after warning matches.
     assert_that(

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -160,6 +160,14 @@ def GetBufferFilepath( buffer_object ):
   return os.path.join( GetCurrentDirectory(), str( buffer_object.number ) )
 
 
+def GetCurrentBufferNumber():
+  return vim.current.buffer.number
+
+
+def GetBufferChangedTick( bufnr ):
+  return GetIntValue( 'getbufvar({0}, "changedtick")'.format( bufnr ) )
+
+
 def UnplaceSignInBuffer( buffer_number, sign_id ):
   if buffer_number < 0:
     return

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -34,10 +34,10 @@ import vim
 from subprocess import PIPE
 from tempfile import NamedTemporaryFile
 from ycm import base, paths, vimsupport
+from ycm.buffer import BufferDict
 from ycmd import utils
 from ycmd import server_utils
 from ycmd.request_wrap import RequestWrap
-from ycm.diagnostic_interface import DiagnosticInterface
 from ycm.omni_completer import OmniCompleter
 from ycm import syntax_parse
 from ycm.client.ycmd_keepalive import YcmdKeepalive
@@ -50,8 +50,7 @@ from ycm.client.completion_request import ( CompletionRequest,
 from ycm.client.debug_info_request import ( SendDebugInfoRequest,
                                             FormatDebugInfoResponse )
 from ycm.client.omni_completion_request import OmniCompletionRequest
-from ycm.client.event_notification import ( SendEventNotificationAsync,
-                                            EventNotification )
+from ycm.client.event_notification import SendEventNotificationAsync
 from ycm.client.shutdown_request import SendShutdownRequest
 
 
@@ -115,11 +114,9 @@ class YouCompleteMe( object ):
     self._available_completers = {}
     self._user_options = user_options
     self._user_notified_about_crash = False
-    self._diag_interface = DiagnosticInterface( user_options )
     self._omnicomp = OmniCompleter( user_options )
-    self._latest_file_parse_request = None
+    self._buffers = BufferDict( user_options )
     self._latest_completion_request = None
-    self._latest_diagnostics = []
     self._logger = logging.getLogger( 'ycm' )
     self._client_logfile = None
     self._server_stdout = None
@@ -134,6 +131,11 @@ class YouCompleteMe( object ):
     self._complete_done_hooks = {
       'cs': lambda self: self._OnCompleteDone_Csharp()
     }
+
+
+  def _GetCurrentBuffer( self ):
+    return self._buffers[ vimsupport.GetCurrentBufferNumber() ]
+
 
   def _SetupServer( self ):
     self._available_completers = {}
@@ -355,21 +357,32 @@ class YouCompleteMe( object ):
     return False
 
 
-  def OnFileReadyToParse( self ):
+  def IsServerReady( self ):
+    return self._server_is_ready_with_cache
+
+
+  def OnFileReadyToParse( self, block = False ):
     if not self.IsServerAlive():
       self._NotifyUserIfServerCrashed()
       return
 
+    if not self.IsServerReady():
+      return
+
     self._omnicomp.OnFileReadyToParse( None )
 
-    extra_data = {}
-    self._AddTagsFilesIfNeeded( extra_data )
-    self._AddSyntaxDataIfNeeded( extra_data )
-    self._AddExtraConfDataIfNeeded( extra_data )
+    self.HandleFileParseRequest()
 
-    self._latest_file_parse_request = EventNotification(
-      'FileReadyToParse', extra_data = extra_data )
-    self._latest_file_parse_request.Start()
+    current_buffer = self._GetCurrentBuffer()
+    if current_buffer.NeedsReparse():
+      extra_data = {}
+      self._AddTagsFilesIfNeeded( extra_data )
+      self._AddSyntaxDataIfNeeded( extra_data )
+      self._AddExtraConfDataIfNeeded( extra_data )
+
+      current_buffer.SendParseRequest( extra_data )
+      if block:
+        self.HandleFileParseRequest()
 
 
   def OnBufferUnload( self, deleted_buffer_file ):
@@ -387,7 +400,7 @@ class YouCompleteMe( object ):
 
 
   def OnCursorMoved( self ):
-    self._diag_interface.OnCursorMoved()
+    self._GetCurrentBuffer().OnCursorMoved()
 
 
   def _CleanLogfile( self ):
@@ -569,11 +582,11 @@ class YouCompleteMe( object ):
 
 
   def GetErrorCount( self ):
-    return self._diag_interface.GetErrorCount()
+    return self._GetCurrentBuffer().GetErrorCount()
 
 
   def GetWarningCount( self ):
-    return self._diag_interface.GetWarningCount()
+    return self._GetCurrentBuffer().GetWarningCount()
 
 
   def DiagnosticUiSupportedForCurrentFiletype( self ):
@@ -587,51 +600,26 @@ class YouCompleteMe( object ):
 
 
   def _PopulateLocationListWithLatestDiagnostics( self ):
-    # Do nothing if loc list is already populated by diag_interface
-    if not self._user_options[ 'always_populate_location_list' ]:
-      self._diag_interface.PopulateLocationList( self._latest_diagnostics )
-    return bool( self._latest_diagnostics )
+    return self._GetCurrentBuffer().PopulateLocationList()
 
 
-  def UpdateDiagnosticInterface( self ):
-    self._diag_interface.UpdateWithNewDiagnostics( self._latest_diagnostics )
+  # For testing purposes
+  def FileParseRequestReady( self ):
+    return self._GetCurrentBuffer().FileParseRequestReady()
 
 
-  def FileParseRequestReady( self, block = False ):
-    return bool( self._latest_file_parse_request and
-                 ( block or self._latest_file_parse_request.Done() ) )
+  def HandleFileParseRequest( self ):
+    current_buffer = self._GetCurrentBuffer()
+    if current_buffer.IsResponseHandled():
+      return
 
-
-  def HandleFileParseRequest( self, block = False ):
-    # Order is important here:
-    # FileParseRequestReady has a low cost, while
     # NativeFiletypeCompletionUsable is a blocking server request
-    if ( self.FileParseRequestReady( block ) and
-         self.NativeFiletypeCompletionUsable() ):
-
+    if self.NativeFiletypeCompletionUsable():
+      current_buffer.GetResponse()
       if self.ShouldDisplayDiagnostics():
-        self._latest_diagnostics = self._latest_file_parse_request.Response()
-        self.UpdateDiagnosticInterface()
-      else:
-        # YCM client has a hard-coded list of filetypes which are known
-        # to support diagnostics, self.DiagnosticUiSupportedForCurrentFiletype()
-        #
-        # For filetypes which don't support diagnostics, we just want to check
-        # the _latest_file_parse_request for any exception or UnknownExtraConf
-        # response, to allow the server to raise configuration warnings, etc.
-        # to the user. We ignore any other supplied data.
-        self._latest_file_parse_request.Response()
+        current_buffer.UpdateDiagnostics()
 
-      # We set the file parse request to None because we want to prevent
-      # repeated issuing of the same warnings/errors/prompts. Setting this to
-      # None makes FileParseRequestReady return False until the next
-      # request is created.
-      #
-      # Note: it is the server's responsibility to determine the frequency of
-      # error/warning/prompts when receiving a FileReadyToParse event, but
-      # it our responsibility to ensure that we only apply the
-      # warning/error/prompt received once (for each event).
-      self._latest_file_parse_request = None
+    current_buffer.MarkResponseHandled()
 
 
   def DebugInfo( self ):
@@ -740,8 +728,7 @@ class YouCompleteMe( object ):
     vimsupport.PostVimMessage(
         'Forcing compilation, this will block Vim until done.',
         warning = False )
-    self.OnFileReadyToParse()
-    self.HandleFileParseRequest( block = True )
+    self.OnFileReadyToParse( True )
     vimsupport.PostVimMessage( 'Diagnostics refreshed', warning = False )
     return True
 


### PR DESCRIPTION
- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

Blocks new FileReadyToParse requests if there is already ongoing one, because new one will return "already parsing" result anyway.
Improvements:

 - Prevent server spamming.
 - Does not overwrite ongoing parse request, which allows to get intermediate info from it after parse is done.
 - Change parsed tick only when parse request will get going, rather then end up as "already parsing", allowing to know more precisely when parse is needed. (Fixes bug when adding compile error just after opening big TU does not show up until new change)
 - Fixes bug when calling YcmDiags on just opened big TU does not block.
 - Decreases number of unwanted/unnecessary FileRequestReady notifications, which improves DyeVim stability.
 - Moves some of the logic from VimL to python and simplifies it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2501)
<!-- Reviewable:end -->
