### PR TITLE
Disable sitecustomize when checking python version

### DIFF
--- a/python/ycm/paths.py
+++ b/python/ycm/paths.py
@@ -118,6 +118,9 @@ def IsPythonVersionCorrect( path ):
     return False
 
   command = [ path,
+              # Disable site customize. Faster, and less likely to encounter
+              # issues with disconnected mounts (nfs, fuse, etc.)
+              '-S',
               '-c',
               "import sys;"
               "major, minor = sys.version_info[ :2 ];"


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't:
    - This seems quite difficult to test in a cross-platform, cross-version fashion, but
    - I might have missed something, I am not a python expert. :)
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Sitecustomize files can be slow or broken and might hang editor
startup.  Since they aren't necessary for checking the python version,
disable them to get a small speed boost for everyone, and an editor
that doesn't hang indefinitely on startup if the sitecustomize gets
into an infinite loop (due to a bad NFS mount or similar).

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2502)
<!-- Reviewable:end -->
