### PR TITLE
[READY] Include subservers logfiles in YcmToggleLogs command

### DIFF
--- a/python/ycm/client/debug_info_request.py
+++ b/python/ycm/client/debug_info_request.py
@@ -40,10 +40,10 @@ class DebugInfoRequest( BaseRequest ):
 
 
   def Response( self ):
-    return _FormatDebugInfoResponse( self._response )
+    return self._response
 
 
-def _FormatDebugInfoResponse( response ):
+def FormatDebugInfoResponse( response ):
   if not response:
     return 'Server errored, no debug info from server\n'
   message = _FormatYcmdDebugInfo( response )

--- a/python/ycm/tests/client/debug_info_request_test.py
+++ b/python/ycm/tests/client/debug_info_request_test.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 from copy import deepcopy
 from hamcrest import assert_that, contains_string, equal_to
 
-from ycm.client.debug_info_request import _FormatDebugInfoResponse
+from ycm.client.debug_info_request import FormatDebugInfoResponse
 
 
 GENERIC_RESPONSE = {
@@ -76,7 +76,7 @@ GENERIC_RESPONSE = {
 
 def FormatDebugInfoResponse_NoResponse_test():
   assert_that(
-    _FormatDebugInfoResponse( None ),
+    FormatDebugInfoResponse( None ),
     equal_to( 'Server errored, no debug info from server\n' )
   )
 
@@ -88,7 +88,7 @@ def FormatDebugInfoResponse_NoExtraConf_test():
     'path': None
   } )
   assert_that(
-    _FormatDebugInfoResponse( response ),
+    FormatDebugInfoResponse( response ),
     contains_string(
       'No extra configuration file found\n'
     )
@@ -102,7 +102,7 @@ def FormatDebugInfoResponse_ExtraConfFoundButNotLoaded_test():
     'path': '/path/to/extra/conf'
   } )
   assert_that(
-    _FormatDebugInfoResponse( response ),
+    FormatDebugInfoResponse( response ),
     contains_string(
       'Extra configuration file found but not loaded\n'
       'Extra configuration path: /path/to/extra/conf\n'
@@ -117,7 +117,7 @@ def FormatDebugInfoResponse_ExtraConfFoundAndLoaded_test():
     'path': '/path/to/extra/conf'
   } )
   assert_that(
-    _FormatDebugInfoResponse( response ),
+    FormatDebugInfoResponse( response ),
     contains_string(
       'Extra configuration file found and loaded\n'
       'Extra configuration path: /path/to/extra/conf\n'
@@ -128,7 +128,7 @@ def FormatDebugInfoResponse_ExtraConfFoundAndLoaded_test():
 def FormatDebugInfoResponse_Completer_ServerRunningWithHost_test():
   response = deepcopy( GENERIC_RESPONSE )
   assert_that(
-    _FormatDebugInfoResponse( response ),
+    FormatDebugInfoResponse( response ),
     contains_string(
       'Completer name completer debug information:\n'
       '  Server name running at: http://127.0.0.1:1234\n'
@@ -150,7 +150,7 @@ def FormatDebugInfoResponse_Completer_ServerRunningWithoutHost_test():
     'port': None
   } )
   assert_that(
-    _FormatDebugInfoResponse( response ),
+    FormatDebugInfoResponse( response ),
     contains_string(
       'Completer name completer debug information:\n'
       '  Server name running\n'
@@ -172,7 +172,7 @@ def FormatDebugInfoResponse_Completer_ServerNotRunningWithNoLogfiles_test():
     'logfiles': []
   } )
   assert_that(
-    _FormatDebugInfoResponse( response ),
+    FormatDebugInfoResponse( response ),
     contains_string(
       'Completer name completer debug information:\n'
       '  Server name not running\n'

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -227,13 +227,19 @@ def YouCompleteMe_ToggleLogs_WithParameters_test( ycm,
 @YouCompleteMeInstance()
 @patch( 'ycm.vimsupport.PostVimMessage' )
 def YouCompleteMe_ToggleLogs_WithoutParameters_test( ycm, post_vim_message ):
-  ycm.ToggleLogs()
+  # We test on a Python buffer because the Python completer has subserver
+  # logfiles.
+  python_buffer = VimBuffer( 'buffer.py', filetype = 'python' )
+  with MockVimBuffers( [ python_buffer ], python_buffer ):
+    ycm.ToggleLogs()
 
   assert_that(
     # Argument passed to PostVimMessage.
     post_vim_message.call_args[ 0 ][ 0 ],
     matches_regexp(
       'Available logfiles are:\n'
+      'jedihttp_\d+_stderr_.+.log\n'
+      'jedihttp_\d+_stdout_.+.log\n'
       'ycm_.+.log\n'
       'ycmd_\d+_stderr_.+.log\n'
       'ycmd_\d+_stdout_.+.log' )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -48,7 +48,8 @@ from ycm.client.completer_available_request import SendCompleterAvailableRequest
 from ycm.client.command_request import SendCommandRequest
 from ycm.client.completion_request import ( CompletionRequest,
                                             ConvertCompletionDataToVimData )
-from ycm.client.debug_info_request import SendDebugInfoRequest
+from ycm.client.debug_info_request import ( SendDebugInfoRequest,
+                                            FormatDebugInfoResponse )
 from ycm.client.omni_completion_request import OmniCompletionRequest
 from ycm.client.event_notification import ( SendEventNotificationAsync,
                                             EventNotification )
@@ -648,7 +649,7 @@ class YouCompleteMe( object ):
     if self._client_logfile:
       debug_info += 'Client logfile: {0}\n'.format( self._client_logfile )
     if self.IsServerAlive():
-      debug_info += SendDebugInfoRequest()
+      debug_info += FormatDebugInfoResponse( SendDebugInfoRequest() )
     else:
       debug_info += 'Server crashed, no debug info from server\n'
     debug_info += (
@@ -667,6 +668,14 @@ class YouCompleteMe( object ):
     logfiles_list = [ self._client_logfile,
                       self._server_stdout,
                       self._server_stderr ]
+
+    if self.IsServerAlive():
+      debug_info = SendDebugInfoRequest()
+      completer = debug_info[ 'completer' ]
+      if completer:
+        for server in completer[ 'servers' ]:
+          logfiles_list.extend( server[ 'logfiles' ] )
+
     logfiles = {}
     for logfile in logfiles_list:
       logfiles[ os.path.basename( logfile ) ] = logfile


### PR DESCRIPTION
Thanks to PR #2342, we can easily update the `:YcmToggleLogs` command to also list the subservers logfiles and open them directly in Vim. For instance, when editing a Python file:
```
:YcmToggleLogs
Available logfiles are:
jedihttp_55438_stderr_g9rk18nc.log
jedihttp_55438_stdout_duc8kfqm.log
ycm_ttssiu.log
ycmd_55432_stderr_b9lnwf.log
ycmd_55432_stdout_jyakxs.log
```
Then
```
:YcmToggleLogs jedihttp_55438_stderr_g9rk18nc.log
```
to open the JediHTTP stderr logfile in Vim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2506)
<!-- Reviewable:end -->
