### PR TITLE
[READY] Catch ConnectionError instead of ConnectTimeout

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -223,7 +223,7 @@ def HandleServerException( display = True, truncate = False ):
         _LoadExtraConfFile( e.extra_conf_file )
       else:
         _IgnoreExtraConfFile( e.extra_conf_file )
-  except requests.exceptions.ConnectTimeout:
+  except requests.exceptions.ConnectionError:
     # We don't display this exception to the user since it is likely to happen
     # for each subsequent request (typically if the server crashed) and we
     # don't want to spam the user with it.


### PR DESCRIPTION
On non-Windows platforms (tested on Linux and OS X), a `ConnectionError` exception is raised instead of a `ConnectTimeout` one when the connection cannot be established (e.g. the server crashed). Since [the latter is a subclass of the former](http://docs.python-requests.org/en/master/_modules/requests/exceptions/#ConnectTimeout), we only need to catch `ConnectionError`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2516)
<!-- Reviewable:end -->
