### PR TITLE
[READY] Refactor diagnostic commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,16 +1634,36 @@ For example:
 Autocommands
 ------------
 
+### The `YcmLocationOpened` autocommand
+
+This `User` autocommand is fired when YCM opens the location list window in
+response to the `YcmDiags` command. By default, the location list window is
+opened to full width at the bottom of the screen and its height is set to fit
+all entries. This behavior can be overridden by using the `YcmLocationOpened`
+autocommand which is triggered while the cursor is in the location list window.
+For instance:
+```viml
+function! s:CustomizeYcmLocationWindow()
+  " Move the window to the top of the screen.
+  execute "wincmd K"
+  " Set the window height to 5.
+  execute "5wincmd _"
+endfunction
+
+autocmd User YcmLocationOpened call s:CustomizeYcmLocationWindow()
+```
+
 ### The `YcmQuickFixOpened` autocommand
 
 This `User` autocommand is fired when YCM opens the quickfix window in response
 to the `GoTo*` and `RefactorRename` subcommands. By default, the quickfix window
 is opened to full width at the bottom of the screen and its height is set to fit
 all entries. This behavior can be overridden by using the `YcmQuickFixOpened`
-autocommand. For instance:
+autocommand which is triggered while the cursor is in the quickfix window. For
+instance:
 ```viml
-function s:CustomizeYcmQuickFixWindow()
-  " Move the window at the top of the screen.
+function! s:CustomizeYcmQuickFixWindow()
+  " Move the window to the top of the screen.
   execute "wincmd K"
   " Set the window height to 5.
   execute "5wincmd _"

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -78,7 +78,8 @@ Contents ~
   1. The |youcompleteme#GetErrorCount| function
   2. The |youcompleteme#GetWarningCount| function
  9. Autocommands                                   |youcompleteme-autocommands|
-  1. The |YcmQuickFixOpened| autocommand
+  1. The |YcmLocationOpened| autocommand
+  2. The |YcmQuickFixOpened| autocommand
  10. Options                                            |youcompleteme-options|
   1. The |g:ycm_min_num_of_chars_for_completion| option
   2. The |g:ycm_min_num_identifier_candidate_chars| option
@@ -128,44 +129,45 @@ Contents ~
   46. The |g:ycm_disable_for_files_larger_than_kb| option
   47. The |g:ycm_python_binary_path| option
  11. FAQ                                                    |youcompleteme-faq|
-  1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |import-vim|
+  1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |youcompleteme-i-used-to-be-able-to-import-vim-in-.ycm_extra_conf.py-but-now-cant|
   2. On very rare occasions Vim crashes when I tab through the completion menu |youcompleteme-on-very-rare-occasions-vim-crashes-when-i-tab-through-completion-menu|
-  3. I get |ImportError| exceptions that mention 'PyInit_ycm_core' or 'initycm_core'
-  4. I get a linker warning regarding |libpython| on Mac when compiling YCM
+  3. I get 'ImportError' exceptions that mention 'PyInit_ycm_core' or 'initycm_core' |youcompleteme-i-get-importerror-exceptions-that-mention-pyinit_ycm_core-or-initycm_core|
+  4. I get a linker warning regarding 'libpython' on Mac when compiling YCM |youcompleteme-i-get-linker-warning-regarding-libpython-on-mac-when-compiling-ycm|
   5. I get a weird window at the top of my file when I use the semantic engine |youcompleteme-i-get-weird-window-at-top-of-my-file-when-i-use-semantic-engine|
   6. It appears that YCM is not working |youcompleteme-it-appears-that-ycm-is-not-working|
   7. Sometimes it takes much longer to get semantic completions than normal |youcompleteme-sometimes-it-takes-much-longer-to-get-semantic-completions-than-normal|
   8. YCM auto-inserts completion strings I don't want! |youcompleteme-ycm-auto-inserts-completion-strings-i-dont-want|
-  9. I get a 'E227: mapping already exists for <blah>' error when I start Vim |E227:-mapping-already-exists-for-blah|
-  10. I get "'GLIBC_2.XX' not found (required by libclang.so)" when starting Vim |GLIBC_2.XX-not-found()|
+  9. I get a 'E227: mapping already exists for <blah>' error when I start Vim |youcompleteme-i-get-e227-mapping-already-exists-for-blah-error-when-i-start-vim|
+  10. I get "'GLIBC_2.XX' not found (required by libclang.so)" when starting Vim |youcompleteme-i-get-glibc_2.xx-not-found-when-starting-vim|
   11. I'm trying to use a Homebrew Vim with YCM and I'm getting segfaults |youcompleteme-im-trying-to-use-homebrew-vim-with-ycm-im-getting-segfaults|
   12. I have a Homebrew Python and/or MacVim; can't compile/SIGABRT when starting |youcompleteme-i-have-homebrew-python-and-or-macvim-cant-compile-sigabrt-when-starting|
-  13. I get 'LONG_BIT definition appears wrong for platform' when compiling |LONG_BIT-definition-appears-wrong-for-platform|
-  14. I get 'libpython2.7.a [...] relocation R_X86_64_32' when compiling |libpython2.7.a-...-relocation-R_X86_64_32|
-  15. I get 'Vim: Caught deadly signal SEGV' on Vim startup |Vim:-Caught-deadly-signal-SEGV|
-  16. I get 'Fatal Python error: PyThreadState_Get: no current thread' on startup |Fatal-Python-error:-PyThreadState_Get:-no-current-thread|
-  17. |install.py| says python must be compiled with '--enable-framework'. Wat?
+  13. I get 'LONG_BIT definition appears wrong for platform' when compiling |youcompleteme-i-get-long_bit-definition-appears-wrong-for-platform-when-compiling|
+  14. I get 'libpython2.7.a [...] relocation R_X86_64_32' when compiling |youcompleteme-i-get-libpython2.7.a-...-relocation-r_x86_64_32-when-compiling|
+  15. I get 'Vim: Caught deadly signal SEGV' on Vim startup |youcompleteme-i-get-vim-caught-deadly-signal-segv-on-vim-startup|
+  16. I get 'Fatal Python error: PyThreadState_Get: no current thread' on startup |youcompleteme-i-get-fatal-python-error-pythreadstate_get-no-current-thread-on-startup|
+  17. 'install.py' says python must be compiled with '--enable-framework'. Wat? |youcompleteme-install.py-says-python-must-be-compiled-with-enable-framework-.-wat|
   18. YCM does not read identifiers from my tags files |youcompleteme-ycm-does-not-read-identifiers-from-my-tags-files|
-  19. 'CTRL-U' in insert mode does not work                        |CTRL-sub-U|
+  19. 'CTRL-U' in insert mode does not work |youcompleteme-ctrl-u-in-insert-mode-does-not-work|
   20. YCM conflicts with UltiSnips TAB key usage |youcompleteme-ycm-conflicts-with-ultisnips-tab-key-usage|
-  21. Snippets added with |:UltiSnipsAddFiletypes| do not appear in the popup menu
+  21. Snippets added with ':UltiSnipsAddFiletypes' do not appear in the popup menu |youcompleteme-snippets-added-with-ultisnipsaddfiletypes-do-not-appear-in-popup-menu|
   22. Why isn't YCM just written in plain VimScript, FFS? |youcompleteme-why-isnt-ycm-just-written-in-plain-vimscript-ffs|
   23. Why does YCM demand such a recent version of Vim? |youcompleteme-why-does-ycm-demand-such-recent-version-of-vim|
   24. I get annoying messages in Vim's status area when I type |youcompleteme-i-get-annoying-messages-in-vims-status-area-when-i-type|
-  25. Nasty bugs happen if I have the 'vim-autoclose' plugin installed |vim-sub-autoclose|
+  25. Nasty bugs happen if I have the 'vim-autoclose' plugin installed |youcompleteme-nasty-bugs-happen-if-i-have-vim-autoclose-plugin-installed|
   26. Is there some sort of YCM mailing list? I have questions |youcompleteme-is-there-sort-of-ycm-mailing-list-i-have-questions|
   27. I get an internal compiler error when installing |youcompleteme-i-get-an-internal-compiler-error-when-installing|
-  28. I get weird errors when I press 'Ctrl-C' in Vim              |Ctrl-sub-C|
+  28. I get weird errors when I press 'Ctrl-C' in Vim |youcompleteme-i-get-weird-errors-when-i-press-ctrl-c-in-vim|
   29. Why did YCM stop using Syntastic for diagnostics display? |youcompleteme-why-did-ycm-stop-using-syntastic-for-diagnostics-display|
   30. Completion doesn't work with the C++ standard library headers |youcompleteme-completion-doesnt-work-with-c-standard-library-headers|
   31. When I open a JavaScript file, I get an annoying warning about '.tern-project'
-file |.tern-sub-project|
+file |youcompleteme-when-i-open-javascript-file-i-get-an-annoying-warning-about-.tern-project-file|
   32. When I start vim I get a runtime error saying 'R6034 An application has made an
-attempt to load the C runtime library incorrectly.' |R6034-An-application-has-made-an-attempt-to-load-the-C-runtime-library-incorrectly.|
+attempt to load the C runtime library incorrectly.' |youcompleteme-when-i-start-vim-i-get-runtime-error-saying-r6034-an-application-has-made-an-attempt-to-load-c-runtime-library-incorrectly.|
   33. I hear that YCM only supports Python 2, is that true? |youcompleteme-i-hear-that-ycm-only-supports-python-2-is-that-true|
   34. On Windows I get "E887: Sorry, this command is disabled, the Python's site
-module could not be loaded" |E887:-Sorry-this-command-is-disabled-the-Python-s-site-module-could-not-be-loaded|
+module could not be loaded" |youcompleteme-on-windows-i-get-e887-sorry-this-command-is-disabled-pythons-site-module-could-not-be-loaded|
   35. I can't complete python packages in a virtual environment. |youcompleteme-i-cant-complete-python-packages-in-virtual-environment.|
+  36. I want to defer loading of YouCompleteMe until after Vim finishes booting |i-want-to-defer-loading-of-youcompleteme-until-after-vim-finishes-booting|
  12. Contributor Code of Conduct    |youcompleteme-contributor-code-of-conduct|
  13. Contact                                            |youcompleteme-contact|
  14. License                                            |youcompleteme-license|
@@ -329,7 +331,7 @@ Installation ~
                                                        *youcompleteme-mac-os-x*
 Mac OS X ~
 
-These instructions (using |install.py|) are the quickest way to install
+These instructions (using 'install.py') are the quickest way to install
 YouCompleteMe, however they may not work for everyone. If the following
 instructions don't work for you, check out the full installation guide.
 
@@ -407,7 +409,7 @@ that are conservatively turned off by default that you may want to turn on.
                                                *youcompleteme-ubuntu-linux-x64*
 Ubuntu Linux x64 ~
 
-These instructions (using |install.py|) are the quickest way to install
+These instructions (using 'install.py') are the quickest way to install
 YouCompleteMe, however they may not work for everyone. If the following
 instructions don't work for you, check out the full installation guide.
 
@@ -476,7 +478,7 @@ that are conservatively turned off by default that you may want to turn on.
                                                *youcompleteme-fedora-linux-x64*
 Fedora Linux x64 ~
 
-These instructions (using |install.py|) are the quickest way to install
+These instructions (using 'install.py') are the quickest way to install
 YouCompleteMe, however they may not work for everyone. If the following
 instructions don't work for you, check out the full installation guide.
 
@@ -545,7 +547,7 @@ that are conservatively turned off by default that you may want to turn on.
                                                         *youcompleteme-windows*
 Windows ~
 
-These instructions (using |install.py|) are the quickest way to install
+These instructions (using 'install.py') are the quickest way to install
 YouCompleteMe, however they may not work for everyone. If the following
 instructions don't work for you, check out the full installation guide.
 
@@ -592,20 +594,20 @@ Compiling YCM **without** semantic support for C-family languages:
 <
 The following additional language support options are available:
 
-- C# support: add '--omnisharp-completer' when calling |install.py|. Be sure
+- C# support: add '--omnisharp-completer' when calling 'install.py'. Be sure
   that the build utility 'msbuild' is in your PATH [37].
 
 - Go support: install Go [27] and add '--gocode-completer' when calling
-  |install.py|.
+  'install.py'.
 
 - TypeScript support: install Node.js and npm [28] then install the
   TypeScript SDK with 'npm install -g typescript'.
 
 - JavaScript support: install Node.js and npm [28] and add '--tern-completer'
-  when calling |install.py|.
+  when calling 'install.py'.
 
 - Rust support: install Rust [29] and add '--racer-completer' when calling
-  |install.py|.
+  'install.py'.
 
 To simply compile with everything enabled, there's a '--all' flag. So, to
 install with all language features, ensure 'msbuild', 'go', 'tsserver', 'node',
@@ -631,7 +633,7 @@ that are conservatively turned off by default that you may want to turn on.
                                                 *youcompleteme-freebsd-openbsd*
 FreeBSD/OpenBSD ~
 
-These instructions (using |install.py|) are the quickest way to install
+These instructions (using 'install.py') are the quickest way to install
 YouCompleteMe, however they may not work for everyone. If the following
 instructions don't work for you, check out the full installation guide.
 
@@ -1926,16 +1928,36 @@ For example:
 Autocommands ~
 
 -------------------------------------------------------------------------------
+The *YcmLocationOpened* autocommand
+
+This 'User' autocommand is fired when YCM opens the location list window in
+response to the 'YcmDiags' command. By default, the location list window is
+opened to full width at the bottom of the screen and its height is set to fit
+all entries. This behavior can be overridden by using the |YcmLocationOpened|
+autocommand which is triggered while the cursor is in the location list window.
+For instance:
+>
+  function! s:CustomizeYcmLocationWindow()
+    " Move the window to the top of the screen.
+    execute "wincmd K"
+    " Set the window height to 5.
+    execute "5wincmd _"
+  endfunction
+  
+  autocmd User YcmLocationOpened call s:CustomizeYcmLocationWindow()
+<
+-------------------------------------------------------------------------------
 The *YcmQuickFixOpened* autocommand
 
 This 'User' autocommand is fired when YCM opens the quickfix window in response
 to the 'GoTo*' and 'RefactorRename' subcommands. By default, the quickfix
 window is opened to full width at the bottom of the screen and its height is
 set to fit all entries. This behavior can be overridden by using the
-|YcmQuickFixOpened| autocommand. For instance:
+|YcmQuickFixOpened| autocommand which is triggered while the cursor is in the
+quickfix window. For instance:
 >
-  function s:CustomizeYcmQuickFixWindow()
-    " Move the window at the top of the screen.
+  function! s:CustomizeYcmQuickFixWindow()
+    " Move the window to the top of the screen.
     execute "wincmd K"
     " Set the window height to 5.
     execute "5wincmd _"
@@ -2760,7 +2782,7 @@ found through the PATH.
 FAQ ~
 
 -------------------------------------------------------------------------------
-                                                                   *import-vim*
+*youcompleteme-i-used-to-be-able-to-import-vim-in-.ycm_extra_conf.py-but-now-cant*
 I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't ~
 
 YCM was rewritten to use a client-server architecture where most of the logic
@@ -2783,7 +2805,9 @@ That's a very rare Vim bug most users never encounter. It's fixed in Vim
 7.4.72. Update to that version (or above) to resolve the issue.
 
 -------------------------------------------------------------------------------
-I get *ImportError* exceptions that mention 'PyInit_ycm_core' or 'initycm_core'
+*youcompleteme-i-get-importerror-exceptions-that-mention-pyinit_ycm_core-or-initycm_core*
+I get 'ImportError' exceptions that mention 'PyInit_ycm_core' or ~
+'initycm_core' ~
 
 These errors are caused by building the YCM native libraries for Python 2 and
 trying to load them into a Python 3 process (or the other way around).
@@ -2802,7 +2826,8 @@ problem. Common values for that option are '/usr/bin/python' and
 '/usr/bin/python3'.
 
 -------------------------------------------------------------------------------
-I get a linker warning regarding *libpython* on Mac when compiling YCM
+*youcompleteme-i-get-linker-warning-regarding-libpython-on-mac-when-compiling-ycm*
+I get a linker warning regarding 'libpython' on Mac when compiling YCM ~
 
 If the warning is "ld: warning: path '/usr/lib/libpython2.7.dylib' following -L
 not a directory", then feel free to ignore it; it's caused by a limitation of
@@ -2870,7 +2895,7 @@ has to explicitly select something. If something is being selected
 automatically, this means there's a bug or a misconfiguration somewhere.
 
 -------------------------------------------------------------------------------
-                                        *E227:-mapping-already-exists-for-blah*
+*youcompleteme-i-get-e227-mapping-already-exists-for-blah-error-when-i-start-vim*
 I get a 'E227: mapping already exists for <blah>' error when I start Vim ~
 
 This means that YCM tried to set up a key mapping but failed because you
@@ -2882,7 +2907,7 @@ with your own. Then change that option value to something else so that the
 conflict goes away.
 
 -------------------------------------------------------------------------------
-                                                       *GLIBC_2.XX-not-found()*
+                   *youcompleteme-i-get-glibc_2.xx-not-found-when-starting-vim*
 I get "'GLIBC_2.XX' not found (required by libclang.so)" when starting Vim ~
 
 Your system is too old for the precompiled binaries from llvm.org. Compile
@@ -2907,7 +2932,7 @@ fixes that should make YCM work with such a configuration. Also rebuild Macvim
 then. If you still get problems with this, see issue #18 [59] for suggestions.
 
 -------------------------------------------------------------------------------
-                               *LONG_BIT-definition-appears-wrong-for-platform*
+*youcompleteme-i-get-long_bit-definition-appears-wrong-for-platform-when-compiling*
 I get 'LONG_BIT definition appears wrong for platform' when compiling ~
 
 Look at the output of your CMake call. There should be a line in it like the
@@ -2940,7 +2965,7 @@ to make sure you use the same version of Python that your Vim binary is built
 against, which is highly likely to be the system's default Python.
 
 -------------------------------------------------------------------------------
-                                    *libpython2.7.a-...-relocation-R_X86_64_32*
+ *youcompleteme-i-get-libpython2.7.a-...-relocation-r_x86_64_32-when-compiling*
 I get 'libpython2.7.a [...] relocation R_X86_64_32' when compiling ~
 
 The error is usually encountered when compiling YCM on Centos or RHEL. The full
@@ -2958,7 +2983,7 @@ version of libpython on your machine (for instance,
 to go through the full installation guide by hand.
 
 -------------------------------------------------------------------------------
-                                               *Vim:-Caught-deadly-signal-SEGV*
+             *youcompleteme-i-get-vim-caught-deadly-signal-segv-on-vim-startup*
 I get 'Vim: Caught deadly signal SEGV' on Vim startup ~
 
 This can happen on some Linux distros. If you encounter this situation, run Vim
@@ -2973,10 +2998,10 @@ you are using a correct 'libclang.so'. We recommend downloading prebuilt
 binaries from llvm.org.
 
 -------------------------------------------------------------------------------
-                     *Fatal-Python-error:-PyThreadState_Get:-no-current-thread*
+*youcompleteme-i-get-fatal-python-error-pythreadstate_get-no-current-thread-on-startup*
 I get 'Fatal Python error: PyThreadState_Get: no current thread' on startup ~
 
-This is caused by linking a static version of |libpython| into ycmd's
+This is caused by linking a static version of 'libpython' into ycmd's
 'ycm_core.so'. This leads to multiple copies of the python interpreter loaded
 when 'python' loads 'ycmd_core.so' and this messes up python's global state.
 The details aren't important.
@@ -2991,7 +3016,8 @@ achieved as follows (**NOTE:** for Mac, replace '--enable-shared' with
   pyenv install {version}'
 
 -------------------------------------------------------------------------------
-*install.py* says python must be compiled with '--enable-framework'. Wat?
+*youcompleteme-install.py-says-python-must-be-compiled-with-enable-framework-.-wat*
+'install.py' says python must be compiled with '--enable-framework'. Wat? ~
 
 See the previous answer for how to ensure your python is built to support
 dynamic modules.
@@ -3023,7 +3049,7 @@ buffer, run ':echo tagfiles()' with the relevant buffer active. Note that that
 function will only list tag files that already exist.
 
 -------------------------------------------------------------------------------
-                                                                   *CTRL-sub-U*
+                            *youcompleteme-ctrl-u-in-insert-mode-does-not-work*
 'CTRL-U' in insert mode does not work ~
 
 YCM keeps you in a 'completefunc' completion mode when you're typing in insert
@@ -3044,7 +3070,8 @@ options:
   g:UltiSnipsJumpBackwardTrigger
 <
 -------------------------------------------------------------------------------
-Snippets added with *:UltiSnipsAddFiletypes* do not appear in the popup menu
+*youcompleteme-snippets-added-with-ultisnipsaddfiletypes-do-not-appear-in-popup-menu*
+Snippets added with ':UltiSnipsAddFiletypes' do not appear in the popup menu ~
 
 For efficiency, YCM only fetches UltiSnips snippets in specific scenarios like
 visiting a buffer or setting its filetype. You can force YCM to retrieve them
@@ -3089,7 +3116,7 @@ If you're referring to the 'User defined completion <bla bla> back at original'
 and similar, then just update to Vim 7.4.314 (or later) and they'll go away.
 
 -------------------------------------------------------------------------------
-                                                            *vim-sub-autoclose*
+     *youcompleteme-nasty-bugs-happen-if-i-have-vim-autoclose-plugin-installed*
 Nasty bugs happen if I have the 'vim-autoclose' plugin installed ~
 
 Use the delimitMate [61] plugin instead. It does the same thing without
@@ -3115,7 +3142,7 @@ by setting the 'YCM_CORES' environment variable to '1'. Example:
   YCM_CORES=1 ./install.py --clang-completer
 <
 -------------------------------------------------------------------------------
-                                                                   *Ctrl-sub-C*
+                  *youcompleteme-i-get-weird-errors-when-i-press-ctrl-c-in-vim*
 I get weird errors when I press 'Ctrl-C' in Vim ~
 
 _Never_ use 'Ctrl-C' in Vim.
@@ -3193,7 +3220,7 @@ list of flags you return from your 'FlagsForFile' function in your
 See issue #303 [64] for details.
 
 -------------------------------------------------------------------------------
-                                                            *.tern-sub-project*
+*youcompleteme-when-i-open-javascript-file-i-get-an-annoying-warning-about-.tern-project-file*
 When I open a JavaScript file, I get an annoying warning about '.tern- ~
 project' file ~
 
@@ -3204,7 +3231,7 @@ If this is still really annoying, and you have a good reason not to have a
 directory and YCM will stop complaining.
 
 -------------------------------------------------------------------------------
-*R6034-An-application-has-made-an-attempt-to-load-the-C-runtime-library-incorrectly.*
+*youcompleteme-when-i-start-vim-i-get-runtime-error-saying-r6034-an-application-has-made-an-attempt-to-load-c-runtime-library-incorrectly.*
 When I start vim I get a runtime error saying 'R6034 An application has made ~
 an attempt to load the C runtime library incorrectly.' ~
 
@@ -3240,7 +3267,7 @@ to the Python interpreter you use for your project to get completions for that
 version of Python.
 
 -------------------------------------------------------------------------------
-*E887:-Sorry-this-command-is-disabled-the-Python-s-site-module-could-not-be-loaded*
+*youcompleteme-on-windows-i-get-e887-sorry-this-command-is-disabled-pythons-site-module-could-not-be-loaded*
 On Windows I get "E887: Sorry, this command is disabled, the Python's site ~
 module could not be loaded" ~
 
@@ -3260,6 +3287,19 @@ executable first in your PATH when the virtual environment is active then if
 you set |g:ycm_python_binary_path| to just "'python'" it will be found as the
 first Python and used to run JediHTTP [11].
 
+-------------------------------------------------------------------------------
+    *i-want-to-defer-loading-of-youcompleteme-until-after-vim-finishes-booting*
+I want to defer loading of YouCompleteMe until after Vim finishes booting ~
+
+In recent versions of Vim, you can install YCM in a folder under
+'~/.vim/pack/*/opt' and then load it once the user is idle via an autocommand:
+>
+  augroup load_ycm
+    autocmd!
+    autocmd CursorHold, CursorHoldI * :packadd YouCompleteMe
+                                  \ | autocmd! load_ycm
+  augroup END
+<
 ===============================================================================
                                     *youcompleteme-contributor-code-of-conduct*
 Contributor Code of Conduct ~

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -87,9 +87,8 @@ class CommandRequest( BaseRequest ):
   def _HandleGotoResponse( self ):
     if isinstance( self._response, list ):
       vimsupport.SetQuickFixList(
-        [ _BuildQfListItem( x ) for x in self._response ],
-        focus = True,
-        autoclose = True )
+        [ _BuildQfListItem( x ) for x in self._response ] )
+      vimsupport.OpenQuickFixList( focus = True, autoclose = True )
     else:
       vimsupport.JumpToLocation( self._response[ 'filepath' ],
                                  self._response[ 'line_num' ],

--- a/python/ycm/tests/client/command_request_test.py
+++ b/python/ycm/tests/client/command_request_test.py
@@ -267,10 +267,12 @@ class Response_Detection_test( object ):
       # GoToResponse_QuickFix_test, so here we just check that the right call is
       # made
       with patch( 'ycm.vimsupport.SetQuickFixList' ) as set_qf_list:
-        request = CommandRequest( [ command ] )
-        request._response = response
-        request.RunPostCommandActionsIfNeeded()
-        ok_( set_qf_list.called )
+        with patch( 'ycm.vimsupport.OpenQuickFixList' ) as open_qf_list:
+          request = CommandRequest( [ command ] )
+          request._response = response
+          request.RunPostCommandActionsIfNeeded()
+          ok_( set_qf_list.called )
+          ok_( open_qf_list.called )
 
     basic_goto = {
       'filepath': 'test',

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -583,7 +583,7 @@ class YouCompleteMe( object ):
                  self.DiagnosticUiSupportedForCurrentFiletype() )
 
 
-  def PopulateLocationListWithLatestDiagnostics( self ):
+  def _PopulateLocationListWithLatestDiagnostics( self ):
     # Do nothing if loc list is already populated by diag_interface
     if not self._user_options[ 'always_populate_location_list' ]:
       self._diag_interface.PopulateLocationList( self._latest_diagnostics )
@@ -629,16 +629,6 @@ class YouCompleteMe( object ):
       # it our responsibility to ensure that we only apply the
       # warning/error/prompt received once (for each event).
       self._latest_file_parse_request = None
-
-
-  def ShowDetailedDiagnostic( self ):
-    with HandleServerException():
-      detailed_diagnostic = BaseRequest.PostDataToHandler(
-          BuildRequestData(), 'detailed_diagnostic' )
-
-      if 'message' in detailed_diagnostic:
-        vimsupport.PostVimMessage( detailed_diagnostic[ 'message' ],
-                                   warning = False )
 
 
   def DebugInfo( self ):
@@ -724,6 +714,44 @@ class YouCompleteMe( object ):
       return False
     else:
       return not any([ x in filetype_to_disable for x in filetypes ])
+
+
+  def ShowDetailedDiagnostic( self ):
+    with HandleServerException():
+      detailed_diagnostic = BaseRequest.PostDataToHandler(
+          BuildRequestData(), 'detailed_diagnostic' )
+
+      if 'message' in detailed_diagnostic:
+        vimsupport.PostVimMessage( detailed_diagnostic[ 'message' ],
+                                   warning = False )
+
+
+  def ForceCompileAndDiagnostics( self ):
+    if not self.NativeFiletypeCompletionUsable():
+      vimsupport.PostVimMessage(
+          'Native filetype completion not supported for current file, '
+          'cannot force recompilation.', warning = False )
+      return False
+    vimsupport.PostVimMessage(
+        'Forcing compilation, this will block Vim until done.',
+        warning = False )
+    self.OnFileReadyToParse()
+    self.HandleFileParseRequest( block = True )
+    vimsupport.PostVimMessage( 'Diagnostics refreshed', warning = False )
+    return True
+
+
+  def ShowDiagnostics( self ):
+    if not self.ForceCompileAndDiagnostics():
+      return
+
+    if not self._PopulateLocationListWithLatestDiagnostics():
+      vimsupport.PostVimMessage( 'No warnings or errors detected.',
+                                 warning = False )
+      return
+
+    if self._user_options[ 'open_loclist_on_ycm_diags' ]:
+      vimsupport.OpenLocationList( focus = True )
 
 
   def _AddSyntaxDataIfNeeded( self, extra_data ):


### PR DESCRIPTION
This PR moves the logic of the `YcmDiags` and `YcmForceCompileAndDiagnostics` commands to the Python layer. It replaces the `echo` calls by `PostVimMessage` ones to display message on the status line and it always prints `Diagnostics refreshed` once compilation is done. This has the benefit of clearing the message `Forcing compilation, this will block Vim until done.` and avoiding the `Press Enter or type command to continue` prompt.

This also adds the `YcmLocationOpened` autocommand which is the same as `YcmQuickFixOpened` but for the location list window.

Fixes #2543.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2548)
<!-- Reviewable:end -->
