### PR TITLE
[READY] Use gui_running instead of gui to defer YCM loading at VimEnter

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -128,7 +128,7 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
-if has( 'vim_starting' ) && has( 'gui' ) " loading at startup, in gui
+if has( 'vim_starting' ) && has( 'gui_running' ) " Loading at startup, in gui.
   " We defer loading until after VimEnter to allow the gui to fork (see
   " `:h gui-fork`) and avoid a deadlock situation, as explained here:
   " https://github.com/Valloric/YouCompleteMe/pull/2473#issuecomment-267716136
@@ -136,7 +136,7 @@ if has( 'vim_starting' ) && has( 'gui' ) " loading at startup, in gui
     autocmd!
     autocmd VimEnter * call youcompleteme#Enable()
   augroup END
-else " manual loading with :packadd, or not starting the gui
+else " Manual loading with :packadd, or not starting the gui.
   call youcompleteme#Enable()
 endif
 


### PR DESCRIPTION
`has('gui')` returns `1` even in console Vim if it is compiled with `+gui`. We should use `gui_running` instead. See https://github.com/Valloric/YouCompleteMe/commit/1d1a4f4cff04ed32ab924dda20666e67eabdefb4#commitcomment-20876179.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2554)
<!-- Reviewable:end -->
