### PR TITLE
[READY] Always defer loading at VimEnter

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -128,7 +128,7 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
-if has( 'vim_starting' ) && has( 'gui_running' ) " Loading at startup, in gui.
+if has( 'vim_starting' ) " Loading at startup.
   " We defer loading until after VimEnter to allow the gui to fork (see
   " `:h gui-fork`) and avoid a deadlock situation, as explained here:
   " https://github.com/Valloric/YouCompleteMe/pull/2473#issuecomment-267716136
@@ -136,7 +136,7 @@ if has( 'vim_starting' ) && has( 'gui_running' ) " Loading at startup, in gui.
     autocmd!
     autocmd VimEnter * call youcompleteme#Enable()
   augroup END
-else " Manual loading with :packadd, or not starting the gui.
+else " Manual loading with :packadd.
   call youcompleteme#Enable()
 endif
 


### PR DESCRIPTION
YCM should start the same whether Vim is running in GUI or not. Otherwise, this makes it difficult for other plugins to interact with YCM at startup because they can't predict how YCM will start unless they also check if Vim is running in GUI which is unreasonable. Since we can't load it at Vim startup because of [a deadlock issue](https://github.com/Valloric/YouCompleteMe/pull/2473#issuecomment-267716136), we should always defer it at the VimEnter event.

See discussion in https://github.com/Valloric/YouCompleteMe/commit/39659caf34c664c7419cadb41cb813158e0749fa for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2561)
<!-- Reviewable:end -->
