### PR TITLE
[READY] Prefer Python 3 over Python 2

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -28,26 +28,29 @@ let s:cursor_moved = 0
 let s:previous_allowed_buffer_number = 0
 
 
-function! s:UsingPython2()
-  " I'm willing to bet quite a bit that sooner or later, somebody will ask us to
-  " make it configurable which version of Python we use.
-  if has('python')
+" When both versions are available, we prefer Python 3 over Python 2:
+"  - faster startup (no monkey-patching from python-future);
+"  - better Windows support (e.g. temporary paths are not returned in all
+"    lowercase);
+"  - Python 2 support will eventually be dropped.
+function! s:UsingPython3()
+  if has('python3')
     return 1
   endif
   return 0
 endfunction
 
 
-let s:using_python2 = s:UsingPython2()
-let s:python_until_eof = s:using_python2 ? "python << EOF" : "python3 << EOF"
-let s:python_command = s:using_python2 ? "py " : "py3 "
+let s:using_python3 = s:UsingPython3()
+let s:python_until_eof = s:using_python3 ? "python3 << EOF" : "python << EOF"
+let s:python_command = s:using_python3 ? "py3 " : "py "
 
 
 function! s:Pyeval( eval_string )
-  if s:using_python2
-    return pyeval( a:eval_string )
+  if s:using_python3
+    return py3eval( a:eval_string )
   endif
-  return py3eval( a:eval_string )
+  return pyeval( a:eval_string )
 endfunction
 
 


### PR DESCRIPTION
When both versions are available, we should use Python 3 over Python 2 for the following reasons:
 - faster startup:

<table>
  <tr>
    <th rowspan="2">Platform</th>
    <th colspan="2">First run (ms)</th>
    <th colspan="2">Subsequent runs (ms)</th>
  </tr>
  <tr>
    <td>Python 2</td>
    <td>Python 3</td>
    <td>Python 2</td>
    <td>Python 3</td>
  </tr>
  <tr>    
    <td>Ubuntu 16.04 64-bit</td>
    <td>197</td>
    <td>110</td>
    <td>117</td>
    <td>84</td>
  </tr>
  <tr>
    <td>macOS 10.12</td>
    <td>322</td>
    <td>186</td>
    <td>210</td>
    <td>124</td>
  </tr>
  <tr> 
    <td>Windows 10 64-bit</td>
    <td>601</td>
    <td>295</td>
    <td>251</td>
    <td>144</td>
  </tr>  
</table>

*Results obtained by running the `prof.py` script from [this branch](https://github.com/micbou/YouCompleteMe/tree/profiling-startup). The difference between first run and subsequent runs is Python bytecode generation (`*.pyc` files).*

These differences are due to `python-future` monkey-patching a lot of stuff on Python 2 but not on Python 3;

 - better Windows support. For instance, [the `tempfile` module returns temporary paths in all lowercase on Python 2](https://bugs.python.org/issue14255) (we use it to create our logfiles). This is fixed on Python 3.
 - [Python 2 support will be dropped in 2020](https://docs.python.org/devguide/index.html#branchstatus).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2566)
<!-- Reviewable:end -->
