### PR TITLE
[READY] Convert stderr from server to unicode

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -242,7 +242,8 @@ class YouCompleteMe( object ):
     else:
       error_message = EXIT_CODE_UNEXPECTED_MESSAGE.format( code = return_code )
 
-    server_stderr = '\n'.join( self._server_popen.stderr.read().splitlines() )
+    server_stderr = '\n'.join(
+        utils.ToUnicode( self._server_popen.stderr.read() ).splitlines() )
     if server_stderr:
       self._logger.error( server_stderr )
 


### PR DESCRIPTION
On Python 3, reading stderr from server returns bytes. We need to convert it to unicode for `splitlines()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2569)
<!-- Reviewable:end -->
