### PR TITLE
Send extra_conf_vim_data in requests from :YcmCompleter and :YcmDebugInfo commands

### DIFF
--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -36,16 +36,19 @@ def _EnsureBackwardsCompatibility( arguments ):
 
 
 class CommandRequest( BaseRequest ):
-  def __init__( self, arguments, completer_target = None ):
+  def __init__( self, arguments, completer_target = None, extra_data = None ):
     super( CommandRequest, self ).__init__()
     self._arguments = _EnsureBackwardsCompatibility( arguments )
     self._completer_target = ( completer_target if completer_target
                                else 'filetype_default' )
+    self._extra_data = extra_data
     self._response = None
 
 
   def Start( self ):
     request_data = BuildRequestData()
+    if self._extra_data:
+      request_data.update( self._extra_data )
     request_data.update( {
       'completer_target': self._completer_target,
       'command_arguments': self._arguments
@@ -129,8 +132,8 @@ class CommandRequest( BaseRequest ):
     vimsupport.WriteToPreviewWindow( self._response[ 'detailed_info' ] )
 
 
-def SendCommandRequest( arguments, completer ):
-  request = CommandRequest( arguments, completer )
+def SendCommandRequest( arguments, completer, extra_data = None ):
+  request = CommandRequest( arguments, completer, extra_data )
   # This is a blocking call.
   request.Start()
   request.RunPostCommandActionsIfNeeded()

--- a/python/ycm/client/debug_info_request.py
+++ b/python/ycm/client/debug_info_request.py
@@ -28,13 +28,16 @@ from ycm.client.base_request import ( BaseRequest, BuildRequestData,
 
 
 class DebugInfoRequest( BaseRequest ):
-  def __init__( self ):
+  def __init__( self, extra_data = None ):
     super( DebugInfoRequest, self ).__init__()
+    self._extra_data = extra_data
     self._response = None
 
 
   def Start( self ):
     request_data = BuildRequestData()
+    if self._extra_data:
+      request_data.update( self._extra_data )
     with HandleServerException( display = False ):
       self._response = self.PostDataToHandler( request_data, 'debug_info' )
 
@@ -111,8 +114,8 @@ def _FormatCompleterDebugInfo( completer ):
   return message
 
 
-def SendDebugInfoRequest():
-  request = DebugInfoRequest()
+def SendDebugInfoRequest( extra_data = None ):
+  request = DebugInfoRequest( extra_data )
   # This is a blocking call.
   request.Start()
   return request.Response()

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -32,13 +32,19 @@ from mock import patch
 from ycm.tests import YouCompleteMeInstance
 
 
-@YouCompleteMeInstance()
+@YouCompleteMeInstance( { 'extra_conf_vim_data': [ 'tempname()' ] } )
 def SendCommandRequest_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
   with MockVimBuffers( [ current_buffer ], current_buffer ):
+    with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
+      ycm.SendCommandRequest( [ 'GoTo' ], 'python' )
+      send_request.assert_called_once_with(
+        [ 'GoTo' ], 'python', { 'extra_conf_data': {
+          'tempname()': '_TEMP_FILE_' } }
+      )
     with patch( 'ycm.client.base_request.JsonFromFuture',
                 return_value = 'Some response' ):
       assert_that(
-        ycm.SendCommandRequest( 'GoTo', 'python' ),
+        ycm.SendCommandRequest( [ 'GoTo' ], 'python' ),
         equal_to( 'Some response' )
       )

--- a/python/ycm/tests/testdata/.ycm_extra_conf.py
+++ b/python/ycm/tests/testdata/.ycm_extra_conf.py
@@ -1,0 +1,7 @@
+def FlagsForFile( filename, **kwargs ):
+  temp_dir = kwargs[ 'client_data' ][ 'tempname()' ]
+
+  return {
+    'flags': [ temp_dir ],
+    'do_cache': False
+  }

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -160,7 +160,7 @@ def YouCompleteMe_DebugInfo_ServerRunning_test( ycm ):
         '(?P<CLANG>True)?(?(CLANG)|False)\n'
         'Clang version: .+\n'
         'Extra configuration file found and loaded\n'
-        'Extra configuration path: .*/testdata/\\.ycm_extra_conf\\.py\n'
+        'Extra configuration path: .*testdata[/\\\\]\\.ycm_extra_conf\\.py\n'
         '(?(CLANG)C-family completer debug information:\n'
         '  Compilation database path: None\n'
         '  Flags: \\[\'_TEMP_FILE_\'.*\\]\n)'

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -140,9 +140,16 @@ def YouCompleteMe_NotifyUserIfServerCrashed_UnexpectedExitCode_test():
   } )
 
 
-@YouCompleteMeInstance()
+@YouCompleteMeInstance( { 'extra_conf_vim_data': [ 'tempname()' ] } )
 def YouCompleteMe_DebugInfo_ServerRunning_test( ycm ):
-  current_buffer = VimBuffer( 'current_buffer' )
+  dir_of_script = os.path.dirname( os.path.abspath( __file__ ) )
+  buf_name = os.path.join( dir_of_script, 'testdata', 'test.cpp' )
+  extra_conf = os.path.join( dir_of_script, 'testdata', '.ycm_extra_conf.py' )
+
+  from ycm.client.base_request import _LoadExtraConfFile
+  _LoadExtraConfFile( extra_conf )
+
+  current_buffer = VimBuffer( buf_name, filetype='cpp' )
   with MockVimBuffers( [ current_buffer ], current_buffer ):
     assert_that(
       ycm.DebugInfo(),
@@ -150,9 +157,14 @@ def YouCompleteMe_DebugInfo_ServerRunning_test( ycm ):
         'Client logfile: .+\n'
         'Server Python interpreter: .+\n'
         'Server Python version: .+\n'
-        'Server has Clang support compiled in: (True|False)\n'
+        'Server has Clang support compiled in: '
+        '(?P<CLANG>True)?(?(CLANG)|False)\n'
         'Clang version: .+\n'
-        'No extra configuration file found\n'
+        'Extra configuration file found and loaded\n'
+        'Extra configuration path: .*/testdata/\\.ycm_extra_conf\\.py\n'
+        '(?(CLANG)C-family completer debug information:\n'
+        '  Compilation database path: None\n'
+        '  Flags: \\[\'_TEMP_FILE_\'.*\\]\n)'
         'Server running at: .+\n'
         'Server process ID: \d+\n'
         'Server logfiles:\n'

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -34,6 +34,7 @@ from hamcrest import ( assert_that, contains, empty, is_in, is_not, has_length,
 from mock import call, MagicMock, patch
 
 from ycm.tests import StopServer, YouCompleteMeInstance
+from ycm.client.base_request import _LoadExtraConfFile
 from ycmd.responses import ServerError
 
 
@@ -145,8 +146,6 @@ def YouCompleteMe_DebugInfo_ServerRunning_test( ycm ):
   dir_of_script = os.path.dirname( os.path.abspath( __file__ ) )
   buf_name = os.path.join( dir_of_script, 'testdata', 'test.cpp' )
   extra_conf = os.path.join( dir_of_script, 'testdata', '.ycm_extra_conf.py' )
-
-  from ycm.client.base_request import _LoadExtraConfFile
   _LoadExtraConfFile( extra_conf )
 
   current_buffer = VimBuffer( buf_name, filetype='cpp' )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -302,7 +302,9 @@ class YouCompleteMe( object ):
 
 
   def SendCommandRequest( self, arguments, completer ):
-    return SendCommandRequest( arguments, completer )
+    extra_data = {}
+    self._AddExtraConfDataIfNeeded( extra_data )
+    return SendCommandRequest( arguments, completer, extra_data )
 
 
   def GetDefinedSubcommands( self ):
@@ -636,7 +638,9 @@ class YouCompleteMe( object ):
     debug_info = ''
     if self._client_logfile:
       debug_info += 'Client logfile: {0}\n'.format( self._client_logfile )
-    debug_info += FormatDebugInfoResponse( SendDebugInfoRequest() )
+    extra_data = {}
+    self._AddExtraConfDataIfNeeded( extra_data )
+    debug_info += FormatDebugInfoResponse( SendDebugInfoRequest( extra_data ) )
     debug_info += (
       'Server running at: {0}\n'
       'Server process ID: {1}\n'.format( BaseRequest.server_location,


### PR DESCRIPTION
Send extra_conf_vim_data in requests from :YcmCompleter and :YcmDebugInfo commands. It's needed for passing compile_commands.json directory to every call of FlagsForFile in client_data argument.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
Directory of compile_commands.json may be different for different configurations. And there is needed a way for passing it to every call of FlagsForFile in client_data argument.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2570)
<!-- Reviewable:end -->
