### PR TITLE
[READY] Import urljoin and urlparse from ycmd.utils

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -25,11 +25,10 @@ from builtins import *  # noqa
 import contextlib
 import logging
 import json
-from future.moves.urllib.parse import urljoin, urlparse
 from future.utils import native
 from base64 import b64decode, b64encode
 from ycm import vimsupport
-from ycmd.utils import ToBytes
+from ycmd.utils import ToBytes, urljoin, urlparse
 from ycmd.hmac_utils import CreateRequestHmac, CreateHmac, SecureBytesEqual
 from ycmd.responses import ServerError, UnknownExtraConf
 


### PR DESCRIPTION
See https://github.com/Valloric/ycmd/pull/724. This also fixes a regression in startup time on Python 3 because importing `futures.moves` was calling [the `import_top_level_modules` function](https://github.com/PythonCharmers/python-future/blob/master/src/future/moves/__init__.py#L7-L8) which is slow.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2577.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2578)
<!-- Reviewable:end -->
