### PR TITLE
[READY] Accept capitalized name for Python executable

### DIFF
--- a/python/ycm/paths.py
+++ b/python/ycm/paths.py
@@ -34,7 +34,7 @@ DIR_OF_YCMD = os.path.join( DIR_OF_CURRENT_SCRIPT, '..', '..', 'third_party',
                             'ycmd' )
 WIN_PYTHON_PATH = os.path.join( sys.exec_prefix, 'python.exe' )
 PYTHON_BINARY_REGEX = re.compile(
-  r'python((2(\.[67])?)|(3(\.[3-9])?))?(.exe)?$' )
+  r'python((2(\.[67])?)|(3(\.[3-9])?))?(.exe)?$', re.IGNORECASE )
 
 
 def Memoize( obj ):

--- a/python/ycm/tests/paths_test.py
+++ b/python/ycm/tests/paths_test.py
@@ -30,11 +30,13 @@ from ycm.paths import _EndsWithPython
 
 
 def EndsWithPython_Good( path ):
-  ok_( _EndsWithPython( path ) )
+  ok_( _EndsWithPython( path ),
+       'Path {0} does not end with a Python name.'.format( path ) )
 
 
 def EndsWithPython_Bad( path ):
-  ok_( not _EndsWithPython( path ) )
+  ok_( not _EndsWithPython( path ),
+       'Path {0} does end with a Python name.'.format( path ) )
 
 
 def EndsWithPython_Python2Paths_test():
@@ -43,7 +45,8 @@ def EndsWithPython_Python2Paths_test():
     'python2',
     '/usr/bin/python2.6',
     '/home/user/.pyenv/shims/python2.7',
-    r'C:\Python26\python.exe'
+    r'C:\Python26\python.exe',
+    '/Contents/MacOS/Python'
   ]
 
   for path in python_paths:


### PR DESCRIPTION
I was looking at `PathToPythonInterpreter` coverage and was surprised to see [that line](
https://github.com/Valloric/YouCompleteMe/blob/01570aac03f609d30d7c94871161c1e2128ce9e7/python/ycm/paths.py#L84) covered. This shouldn't be the case since we are supposed to use the Python from `PYTHON_USED_DURING_BUILDING`. This happens because the Python executable used in our Travis builds on macOS is named `Python` (with a capital letter) and so we don't accept it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2590)
<!-- Reviewable:end -->
