### PR TITLE
[READY] Prioritize errors over warnings on the same line

### DIFF
--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -48,8 +48,8 @@ def PresentDialog_Confirm_Call( message ):
 
 def PlaceSign_Call( sign_id, line_num, buffer_num, is_error ):
   sign_name = 'YcmError' if is_error else 'YcmWarning'
-  return call( 'sign place {0} line={1} name={2} buffer={3}'
-                  .format( sign_id, line_num, sign_name, buffer_num ) )
+  return call( 'sign place {0} name={1} line={2} buffer={3}'
+                  .format( sign_id, sign_name, line_num, buffer_num ) )
 
 
 def UnplaceSign_Call( sign_id, buffer_num ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -175,8 +175,8 @@ def PlaceSign( sign_id, line_num, buffer_num, is_error = True ):
     line_num = 1
 
   sign_name = 'YcmError' if is_error else 'YcmWarning'
-  vim.command( 'sign place {0} line={1} name={2} buffer={3}'.format(
-    sign_id, line_num, sign_name, buffer_num ) )
+  vim.command( 'sign place {0} name={1} line={2} buffer={3}'.format(
+    sign_id, sign_name, line_num, buffer_num ) )
 
 
 def PlaceDummySign( sign_id, buffer_num, line_num ):


### PR DESCRIPTION
When multiple diagnostics are on the same line, warnings may have higher priority than errors. See #2141 for an example. This happens for several reasons:
 - we sort diagnostics by column and then by kind. We should do the opposite;
 - we place all signs; each sign overriding the previous one. Since only one sign is visible by line, we should just insert the first one (which has the highest priority);
 - we draw highlighting matches (squiggles) in the same order as diagnostics; each match being drawn over the previous ones. We should draw them in reverse order (from lowest to highest priority).

Fixes #2141.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2592)
<!-- Reviewable:end -->
