### PR TITLE
[READY] Fix links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1690,7 +1690,7 @@ you don't need to change any options. These options can be configured in your
 let g:ycm_min_num_of_chars_for_completion = 1
 ```
 
-Note that after changing an option in your [vimrc script] [vimrc] you have to
+Note that after changing an option in your [vimrc script][vimrc] you have to
 restart Vim for the changes to take effect.
 
 ### The `g:ycm_min_num_of_chars_for_completion` option
@@ -2988,10 +2988,10 @@ version of Python.
 
 ### On Windows I get `E887: Sorry, this command is disabled, the Python's site module could not be loaded`
 
-If you are running vim on Windows with Python 2.7.11, this is likely caused by
-a [bug][vim_win-python2.7.11-bug]. Follow this [workaround]
-[vim_win-python2.7.11-bug_workaround] or use a different version (Python 2.7.12
-does not suffer from the bug).
+If you are running vim on Windows with Python 2.7.11, this is likely caused by a
+[bug][vim_win-python2.7.11-bug]. Follow this
+[workaround][vim_win-python2.7.11-bug_workaround] or use a different version
+(Python 2.7.12 does not suffer from the bug).
 
 ### I can't complete python packages in a virtual environment.
 
@@ -3107,6 +3107,6 @@ This software is licensed under the [GPL v3 license][gpl].
 [ccoc]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
 [JediHTTP]: https://github.com/vheon/JediHTTP
 [vim_win-python2.7.11-bug]: https://github.com/vim/vim/issues/717
-[vim_win-python2.7.11-bug_workaround]: https://github.com/vim/vim-win32-installer/blob/master/appveyor.bat#L90
+[vim_win-python2.7.11-bug_workaround]: https://github.com/vim/vim-win32-installer/blob/a27bbdba9bb87fa0e44c8a00d33d46be936822dd/appveyor.bat#L86-L88
 [gitter]: https://gitter.im/Valloric/YouCompleteMe
 [ninja-compdb]: https://ninja-build.org/manual.html

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3397,7 +3397,7 @@ References ~
 [64] https://github.com/Valloric/YouCompleteMe/issues/303
 [65] http://stackoverflow.com/questions/14552348/runtime-error-r6034-in-embedded-python-application/34696022
 [66] https://github.com/vim/vim/issues/717
-[67] https://github.com/vim/vim-win32-installer/blob/master/appveyor.bat#L90
+[67] https://github.com/vim/vim-win32-installer/blob/a27bbdba9bb87fa0e44c8a00d33d46be936822dd/appveyor.bat#L86-L88
 [68] https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
 [69] https://github.com/Valloric/YouCompleteMe/issues?state=open
 [70] http://www.gnu.org/copyleft/gpl.html


### PR DESCRIPTION
Two links are not properly displayed because of wrong markdown syntax. Also, the link for the Python 2.7.11 workaround doesn't point to the right section of [`appveyor.bat`](https://github.com/vim/vim-win32-installer/blob/master/appveyor.bat) because the file changed since then. Use a specific commit instead of master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2597)
<!-- Reviewable:end -->
