### PR TITLE
[READY] Do not cache Python interpreter path

### DIFF
--- a/python/ycm/paths.py
+++ b/python/ycm/paths.py
@@ -25,7 +25,6 @@ from builtins import *  # noqa
 import os
 import sys
 import vim
-import functools
 import re
 
 # Can't import these from setup.py because it makes nosetests go crazy.
@@ -37,19 +36,9 @@ PYTHON_BINARY_REGEX = re.compile(
   r'python((2(\.[67])?)|(3(\.[3-9])?))?(.exe)?$', re.IGNORECASE )
 
 
-def Memoize( obj ):
-  cache = obj.cache = {}
-
-  @functools.wraps( obj )
-  def memoizer( *args, **kwargs ):
-    key = str( args ) + str( kwargs )
-    if key not in cache:
-      cache[ key ] = obj( *args, **kwargs )
-    return cache[ key ]
-  return memoizer
-
-
-@Memoize
+# Not caching the result of this function; users shouldn't have to restart Vim
+# after running the install script or setting the
+# `g:ycm_server_python_interpreter` option.
 def PathToPythonInterpreter():
   # Not calling the Python interpreter to check its version as it significantly
   # impacts startup time.


### PR DESCRIPTION
Once YCM is installed through a plugin manager in Vim (e.g. using the `:PluginInstall` command with Vundle), it picks a Python interpreter (most likely the one used to run YCM inside Vim), caches it, and starts the server with it. This fails since the `ycm_core` library is not yet compiled and the following message is displayed on the status line:
```
The ycmd server SHUT DOWN (restart with ':YcmRestartServer'). YCM core library not detected; you need to compile YCM before using it. Follow the instructions in the documentation.
```
After reading the documentation, the user may then build the library directly from Vim:
```
:!/path/to/YCM/install.py
```
or by opening a new terminal and calling the `install.py` script without leaving Vim. Once the compilation is done, he will restart the server with the `:YcmRestartServer` command. However, since the Python interpreter used to start the server is already cached, YCM will not pick the one from the `PYTHON_USED_DURING_BUILDING` file generated by the `install.py` script. If these Pythons are different (e.g. Python 2 versus Python 3), YCM will fail to start the server again. This doesn't happen if we don't cache the Python interpreter path.

I suspect this is the issue experienced in #2431 and often reported by users on Ubuntu 16.04 where Vim is compiled with Python 3 support but default Python is Python 2. See https://github.com/Valloric/YouCompleteMe/pull/2140#issuecomment-273495342 and https://github.com/Valloric/YouCompleteMe/issues/35#issuecomment-290877053.

Fixes #2431.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2598)
<!-- Reviewable:end -->
