### PR TITLE
[READY] Fix diagnostic highlighting with invalid location extent

### DIFF
--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -138,11 +138,12 @@ def _UpdateSquiggles( buffer_number_to_line_to_diags ):
       location_extent = diag[ 'location_extent' ]
       is_error = _DiagnosticIsError( diag )
 
-      if location_extent[ 'start' ][ 'line_num' ] < 0:
+      if location_extent[ 'start' ][ 'line_num' ] <= 0:
         location = diag[ 'location' ]
         vimsupport.AddDiagnosticSyntaxMatch(
-            location[ 'line_num' ],
-            location[ 'column_num' ] )
+          location[ 'line_num' ],
+          location[ 'column_num' ],
+          is_error = is_error )
       else:
         vimsupport.AddDiagnosticSyntaxMatch(
           location_extent[ 'start' ][ 'line_num' ],

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -520,8 +520,7 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
       contains(
         VimMatch( 'YcmWarningSection', '\%3l\%5c\_.\{-}\%3l\%7c' ),
         VimMatch( 'YcmWarningSection', '\%3l\%3c\_.\{-}\%3l\%9c' ),
-        # FIXME: match should be inserted at the end of line 3 (missing ";").
-        VimMatch( 'YcmErrorSection', '\%0l\%0c' )
+        VimMatch( 'YcmErrorSection', '\%3l\%8c' )
       )
     )
 


### PR DESCRIPTION
ycmd may return a location extent with a starting column of zero (see the test for an example) which is not a valid column (columns are 1-indexed). We should use the location in this case. Also, when the location extent is not valid, we should call `AddDiagnosticSyntaxMatch` with the `is_error` parameter to highlight warnings as such and not as errors (`is_error` is `True` by default).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2602)
<!-- Reviewable:end -->
