### PR TITLE
[READY] Add Python 3 support to update_from_readme script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-Markdown==2.6.5
-beautifulsoup4==4.4.1
-html5lib==0.9999999
-six==1.10.0
-wsgiref==0.1.2
+Markdown       == 2.6.5
+beautifulsoup4 == 4.4.1
+html5lib       == 0.9999999

--- a/update_from_readme.py
+++ b/update_from_readme.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from bs4 import BeautifulSoup
 from markdown import markdown
 import fileinput
 import re
+
 
 def ContentToIdValue( content ):
   content = content.replace( ' ', '-' )
@@ -15,32 +16,31 @@ def AddIdsForHeadings( soup ):
     for heading in headings:
       heading[ 'id' ] = ContentToIdValue( heading.get_text() )
 
-  for i in xrange( 1, 7 ):
+  for i in range( 1, 7 ):
     AddIds( soup.find_all( 'h' + str( i ) ) )
   return soup
 
-markdown_lines = list( fileinput.input() )
+markdown_lines = list( fileinput.input( mode = 'rb' ) )
 
 # We delete the first two lines because that's the big YCM heading which we
 # already have on the page
-del markdown_lines[:2]
+del markdown_lines[ : 2 ]
 
-markdown_source = ''.join( markdown_lines )
+markdown_source = b''.join( markdown_lines )
 
-with open('index.html', 'r+') as content_file:
+with open( 'index.html', 'r+b' ) as content_file:
   content = content_file.read()
 
-  new_contents = markdown( unicode( markdown_source, 'utf-8' ),
-                           extensions=['fenced_code'] )
+  new_contents = markdown( markdown_source.decode( 'utf8' ),
+                           extensions = [ 'fenced_code' ] )
   new_tags = AddIdsForHeadings( BeautifulSoup( new_contents, 'html5lib' ) )
 
-  soup = BeautifulSoup( content, 'html5lib' )
-  elem = soup.find( id='markdown-output' )
+  soup = BeautifulSoup( content.decode( 'utf8' ), 'html5lib' )
+  elem = soup.find( id = 'markdown-output' )
   elem.clear()
   for new_elem in new_tags.body.contents:
     elem.append( new_elem )
 
   content_file.seek( 0 )
   content_file.truncate()
-  content_file.write( str( soup ) )
-
+  content_file.write( str( soup ).encode( 'utf8' ) )


### PR DESCRIPTION
This makes the `update_from_readme.py` script compatible with Python 3.

`six` is a dependency of `html5lib` and `wsgiref` is available since Python 2.5 so we can remove them from `requirements.txt`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2608)
<!-- Reviewable:end -->
