### PR TITLE
Escape '#' symbol in filepath

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -377,7 +377,8 @@ def BufferIsUsable( buffer_object ):
 
 
 def EscapedFilepath( filepath ):
-  return filepath.replace( ' ' , r'\ ' )
+  return ( filepath.replace( ' ', r'\ ' )
+                   .replace( '#', r'\#' ) )
 
 
 # Both |line| and |column| need to be 1-based


### PR DESCRIPTION
'JumpToLocation' fails when a filepath contains the '#' symbol.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2623)
<!-- Reviewable:end -->
