### PR TITLE
[READY] Update autocommands examples in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,9 +1652,11 @@ For instance:
 ```viml
 function! s:CustomizeYcmLocationWindow()
   " Move the window to the top of the screen.
-  execute "wincmd K"
+  wincmd K
   " Set the window height to 5.
-  execute "5wincmd _"
+  5wincmd _
+  " Switch back to working window.
+  wincmd p
 endfunction
 
 autocmd User YcmLocationOpened call s:CustomizeYcmLocationWindow()
@@ -1671,9 +1673,9 @@ instance:
 ```viml
 function! s:CustomizeYcmQuickFixWindow()
   " Move the window to the top of the screen.
-  execute "wincmd K"
+  wincmd K
   " Set the window height to 5.
-  execute "5wincmd _"
+  5wincmd _
 endfunction
 
 autocmd User YcmQuickFixOpened call s:CustomizeYcmQuickFixWindow()

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1946,9 +1946,11 @@ For instance:
 >
   function! s:CustomizeYcmLocationWindow()
     " Move the window to the top of the screen.
-    execute "wincmd K"
+    wincmd K
     " Set the window height to 5.
-    execute "5wincmd _"
+    5wincmd _
+    " Switch back to working window.
+    wincmd p
   endfunction
   
   autocmd User YcmLocationOpened call s:CustomizeYcmLocationWindow()
@@ -1965,9 +1967,9 @@ quickfix window. For instance:
 >
   function! s:CustomizeYcmQuickFixWindow()
     " Move the window to the top of the screen.
-    execute "wincmd K"
+    wincmd K
     " Set the window height to 5.
-    execute "5wincmd _"
+    5wincmd _
   endfunction
   
   autocmd User YcmQuickFixOpened call s:CustomizeYcmQuickFixWindow()


### PR DESCRIPTION
I am not aware of a Vim option to not switch to the location list (or quickfix) window when calling `lopen` (respectively `copen`) so I think it's a good idea to give an example in the docs on how to achieve this using the `YcmLocationOpened` and `YcmQuickFixOpened` autocommands.

Also, the `execute` calls are not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2635)
<!-- Reviewable:end -->
