### PR TITLE
[READY] Removing unnecessary travis webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,3 @@ cache:
   directories:
     - $HOME/.cache/pip  # Python packages from pip
     - $HOME/.pyenv  # pyenv
-notifications:
-    webhooks: http://35.185.255.222:54856/travis


### PR DESCRIPTION
Our homu instance gets travis events through GitHub status events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2643)
<!-- Reviewable:end -->
