### PR TITLE
[READY] Improve reparse requirement on BufEnter event

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -345,7 +345,11 @@ function! s:AllowedToCompleteInBuffer( buffer )
         \ has_key( g:ycm_filetype_whitelist, buffer_filetype )
   let blacklist_allows = !has_key( g:ycm_filetype_blacklist, buffer_filetype )
 
-  return whitelist_allows && blacklist_allows
+  let allowed = whitelist_allows && blacklist_allows
+  if allowed
+    let s:previous_allowed_buffer_number = bufnr( a:buffer )
+  endif
+  return allowed
 endfunction
 
 
@@ -355,15 +359,11 @@ endfunction
 
 
 function! s:VisitedBufferRequiresReparse()
-  if !s:AllowedToCompleteInCurrentBuffer()
+  if bufnr( '%' ) ==# s:previous_allowed_buffer_number
     return 0
   endif
 
-  if bufnr( '' ) ==# s:previous_allowed_buffer_number
-    return 0
-  endif
-  let s:previous_allowed_buffer_number = bufnr( '' )
-  return 1
+  return s:AllowedToCompleteInCurrentBuffer()
 endfunction
 
 


### PR DESCRIPTION
When opening a file, Vim triggers the `BufRead` event then the `BufEnter` one. By setting the `s:previous_allowed_buffer_number` variable in `s:AllowedToCompleteInBuffer`, we avoid a reparse on `BufEnter` after parsing the buffer on `BufRead`. This reduces the number of `BufferVisit` and `FileReadyToParse` requests sent to the server by one when opening a file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2644)
<!-- Reviewable:end -->
