### PR TITLE
Enable Swift diagnostic UI

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -101,7 +101,7 @@ CORE_OUTDATED_MESSAGE = (
   'script. See the documentation for more details.' )
 SERVER_IDLE_SUICIDE_SECONDS = 10800  # 3 hours
 DIAGNOSTIC_UI_FILETYPES = set( [ 'cpp', 'cs', 'c', 'objc', 'objcpp',
-                                 'typescript' ] )
+                                 'typescript', 'swift' ] )
 CLIENT_LOGFILE_FORMAT = 'ycm_'
 SERVER_LOGFILE_FORMAT = 'ycmd_{port}_{std}_'
 


### PR DESCRIPTION
This patch enables Swift semantic diagnostics. Currently warnings and errors are supported in the backend, and fixits will come soon! 🚀 

It depends on the [backing `YCMD` PR](https://github.com/Valloric/ycmd/pull/763)

![012c3244-43c1-11e7-9bb1-c106dd77ab22](https://cloud.githubusercontent.com/assets/1245820/26533044/0133fa46-43c7-11e7-84a7-6778b660ccae.gif)

There's no tests, because I'm not sure if diagnostics are tested in `YCM` at the language level - but I can add them if it makes sense.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

So we can see diagnostics as we type in Swift!

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2667)
<!-- Reviewable:end -->
