### PR TITLE
[READY] Require coverage.py package older than version 4.4 

### DIFF
--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -7,4 +7,8 @@ PyHamcrest >= 1.8.0
 # This needs to be kept in sync with submodule checkout in
 # third_party/ycmd/third_party
 future     == 0.15.2
+# coverage.py 4.4 removed the path from the filename attribute in its reports.
+# This leads to incorrect coverage from codecov as it relies on this attribute
+# to find the source file.
+coverage   <  4.4
 codecov    >= 2.0.5


### PR DESCRIPTION
See PR https://github.com/Valloric/ycmd/pull/770.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2672)
<!-- Reviewable:end -->
