### PR TITLE
[READY] Update ycmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ addons:
     packages:
      - cmake-data
      - cmake
-     - g++-4.8
+     # 4.9 is the first version of GCC with good enough C++11 support to build
+     # ycmd.
+     - g++-4.9
      - ninja-build
      # Everything below is a Python build dep (though it depends on Python
      # version). We need them because pyenv builds Python.

--- a/README.md
+++ b/README.md
@@ -656,9 +656,13 @@ process.
 
     - C# support: install [Mono on non-Windows platforms][mono-install].
       Navigate to `YouCompleteMe/third_party/ycmd/third_party/OmniSharpServer`
-      and run `msbuild /property:Configuration=Release` on Windows. Replace
-      `msbuild` by `xbuild` on other platforms. On Windows, be sure that [the
-      build utility `msbuild` is in your PATH][add-msbuild-to-path].
+      and run
+
+          msbuild /property:Configuration=Release /property:TargetFrameworkVersion=v4.5
+
+      Replace `msbuild` by `xbuild` if `msbuild` is not available. On Windows,
+      be sure that [the build utility `msbuild` is in your
+      PATH][add-msbuild-to-path].
 
     - Go support: install [Go][go-install] and add it to your path. Navigate to
       `YouCompleteMe/third_party/ycmd/third_party/gocode` and run `go build`.

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -5,8 +5,8 @@
 
 mkdir ${HOME}/bin
 
-ln -s /usr/bin/g++-4.8 ${HOME}/bin/c++
-ln -s /usr/bin/gcc-4.8 ${HOME}/bin/cc
+ln -s /usr/bin/g++-4.9 ${HOME}/bin/c++
+ln -s /usr/bin/gcc-4.9 ${HOME}/bin/cc
 
 export PATH=${HOME}/bin:${PATH}
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -870,9 +870,12 @@ will notify you to recompile it. You should then rerun the install process.
 
    - C# support: install Mono on non-Windows platforms [41]. Navigate to
      'YouCompleteMe/third_party/ycmd/third_party/OmniSharpServer' and run
-     'msbuild /property:Configuration=Release' on Windows. Replace
-     'msbuild' by 'xbuild' on other platforms. On Windows, be sure that
-     the build utility 'msbuild' is in your PATH [37].
+
+     msbuild /property:Configuration=Release
+     /property:TargetFrameworkVersion=v4.5
+
+   Replace 'msbuild' by 'xbuild' if 'msbuild' is not available. On Windows,
+   be sure that the build utility 'msbuild' is in your PATH [37].
 
    - Go support: install Go [27] and add it to your path. Navigate to
      'YouCompleteMe/third_party/ycmd/third_party/gocode' and run 'go


### PR DESCRIPTION
This include the following changes:
 - PR Valloric/ycmd#710: allow compilation for iOS projects;
 - PR Valloric/ycmd#728: handle unicode pathname when loading source on Python 2;
 - PR Valloric/ycmd#735: update JediHTTP;
 - PR Valloric/ycmd#741: update Boost to 1.64.0;
 - PR Valloric/ycmd#744: create a symlink instead of renaming libclang;
 - PR Valloric/ycmd#745: ignore identifiers from comments and strings on certain events;
 - PR Valloric/ycmd#746: ignore identifiers from comments and strings by filetype;
 - PR Valloric/ycmd#749: improve CSS identifier regex;
 - PR Valloric/ycmd#753: fix Godef build error;
 - PR Valloric/ycmd#754: search Python library in lib64 folder in addition to lib;
 - PR Valloric/ycmd#767: specify .NET Framework 4.5.

This also updates the C# instructions in the full installation guide according to PR Valloric/ycmd#767 and [`xbuild` being deprecated in favor of `msbuild` in Mono](http://www.mono-project.com/docs/about-mono/releases/5.0.0/#xbuild).

Fixes #2674.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2676)
<!-- Reviewable:end -->
