### PR TITLE
Clarified rust_src_path info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,12 @@ locate it.
 " In this example, the rust source code zip has been extracted to
 " /usr/local/rust/rustc-1.5.0
 let g:ycm_rust_src_path = '/usr/local/rust/rustc-1.5.0/src'
+
+" Ensure that you use the absolute path, tilde expansion is not done.
+" E.g. if source code is downloaded through rustup it would be
+let g:ycm_rust_src_path = '/home/[user]/.multirust/toolchains/[your-toolchain]/lib/rustlib/src/rust/src'
+" NOT
+let g:ycm_rust_src_path = '~/.multirust/toolchains/[your-toolchain]/lib/rustlib/src/rust/src'
 ```
 
 ### Python Semantic Completion


### PR DESCRIPTION
Added information on caveats for rust_src_path. Python's os.path.isdir
does not do ~ expansion, so some frustration was had until this was
discovered. This just tells the user that in the README, and includes
the example for rust source code downloaded through rustup.

While not strictly necessary, I think this would help some users. Especially as finding the error was not entirely trivial, and the root cause was unexpected.

No tests for changes as this only effects the README

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2695)
<!-- Reviewable:end -->
