### PR TITLE
[READY] Fix unicode warning when jumping on Python 2

### DIFF
--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -29,11 +29,12 @@ import functools
 import os
 import requests
 import time
+import warnings
 
 from ycm.client.base_request import BaseRequest
 from ycm.youcompleteme import YouCompleteMe
 from ycmd import user_options_store
-from ycmd.utils import WaitUntilProcessIsTerminated
+from ycmd.utils import CloseStandardStreams, WaitUntilProcessIsTerminated
 
 # The default options which are only relevant to the client, not the server and
 # thus are not part of default_options.json, but are required for a working
@@ -84,8 +85,21 @@ def StopServer( ycm ):
   try:
     ycm.OnVimLeave()
     WaitUntilProcessIsTerminated( ycm._server_popen )
+    CloseStandardStreams( ycm._server_popen )
   except Exception:
     pass
+
+
+def setUpPackage():
+  # We treat warnings as errors in our tests because warnings raised inside Vim
+  # will interrupt user workflow with a traceback and we don't want that.
+  warnings.filterwarnings( 'error' )
+  # We ignore warnings from nose as we are not interested in them.
+  warnings.filterwarnings( 'ignore', module = 'nose' )
+
+
+def tearDownPackage():
+  warnings.resetwarnings()
 
 
 def YouCompleteMeInstance( custom_options = {} ):

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -91,8 +91,8 @@ def _MockGetBufferVariable( buffer_number, option ):
         return vim_buffer.filetype
       if option == 'changedtick':
         return vim_buffer.changedtick
-      if option == '&hid':
-        return vim_buffer.hidden
+      if option == '&bh':
+        return vim_buffer.bufhidden
       return ''
   return ''
 
@@ -135,6 +135,9 @@ def _MockVimOptionsEval( value ):
 
   if value == '&showcmd':
     return 1
+
+  if value == '&hidden':
+    return 0
 
   return None
 
@@ -211,21 +214,21 @@ def MockVimCommand( command ):
 
 class VimBuffer( object ):
   """An object that looks like a vim.buffer object:
-   - |name|    : full path of the buffer with symbolic links resolved;
-   - |number|  : buffer number;
-   - |contents|: list of lines representing the buffer contents;
-   - |filetype|: buffer filetype. Empty string if no filetype is set;
-   - |modified|: True if the buffer has unsaved changes, False otherwise;
-   - |hidden|  : True if the buffer is hidden, False otherwise;
-   - |window|  : number of the buffer window. None if the buffer is hidden;
-   - |omnifunc|: omni completion function used by the buffer."""
+   - |name|     : full path of the buffer with symbolic links resolved;
+   - |number|   : buffer number;
+   - |contents| : list of lines representing the buffer contents;
+   - |filetype| : buffer filetype. Empty string if no filetype is set;
+   - |modified| : True if the buffer has unsaved changes, False otherwise;
+   - |bufhidden|: value of the 'bufhidden' option (see :h bufhidden);
+   - |window|   : number of the buffer window. None if the buffer is hidden;
+   - |omnifunc| : omni completion function used by the buffer."""
 
   def __init__( self, name,
                       number = 1,
                       contents = [],
                       filetype = '',
-                      modified = True,
-                      hidden = False,
+                      modified = False,
+                      bufhidden = '',
                       window = None,
                       omnifunc = '' ):
     self.name = os.path.realpath( name ) if name else ''
@@ -233,8 +236,8 @@ class VimBuffer( object ):
     self.contents = contents
     self.filetype = filetype
     self.modified = modified
-    self.hidden = hidden
-    self.window = window if not hidden else None
+    self.bufhidden = bufhidden
+    self.window = window
     self.omnifunc = omnifunc
     self.changedtick = 1
 

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1624,7 +1624,7 @@ def JumpToLocation_SameFile_SameBuffer_NoSwapFile_test( vim_command ):
 @patch( 'ycmd.user_options_store._USER_OPTIONS',
         { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
-def JumpToLocation_DifferentFile_SameBuffer_NoSwapFile_test( vim_command ):
+def JumpToLocation_DifferentFile_SameBuffer_Unmodified_test( vim_command ):
   current_buffer = VimBuffer( 'uni¢𐍈d€' )
   with MockVimBuffers( [ current_buffer ], current_buffer ) as vim:
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
@@ -1634,7 +1634,47 @@ def JumpToLocation_DifferentFile_SameBuffer_NoSwapFile_test( vim_command ):
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
+      call( u'keepjumps edit {0}'.format( target_name ) ),
+      call( 'normal! zz' )
+    ] )
+
+
+@patch( 'ycmd.user_options_store._USER_OPTIONS',
+        { 'goto_buffer_command': 'same-buffer' } )
+@patch( 'vim.command', new_callable = ExtendedMock )
+def JumpToLocation_DifferentFile_SameBuffer_Modified_CannotHide_test(
+    vim_command ):
+
+  current_buffer = VimBuffer( 'uni¢𐍈d€', modified = True )
+  with MockVimBuffers( [ current_buffer ], current_buffer ) as vim:
+    target_name = os.path.realpath( u'different_uni¢𐍈d€' )
+
+    vimsupport.JumpToLocation( target_name, 2, 5 )
+
+    assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
+    vim_command.assert_has_exact_calls( [
+      call( 'normal! m\'' ),
       call( u'keepjumps split {0}'.format( target_name ) ),
+      call( 'normal! zz' )
+    ] )
+
+
+@patch( 'ycmd.user_options_store._USER_OPTIONS',
+        { 'goto_buffer_command': 'same-buffer' } )
+@patch( 'vim.command', new_callable = ExtendedMock )
+def JumpToLocation_DifferentFile_SameBuffer_Modified_CanHide_test(
+    vim_command ):
+
+  current_buffer = VimBuffer( 'uni¢𐍈d€', modified = True, bufhidden = "hide" )
+  with MockVimBuffers( [ current_buffer ], current_buffer ) as vim:
+    target_name = os.path.realpath( u'different_uni¢𐍈d€' )
+
+    vimsupport.JumpToLocation( target_name, 2, 5 )
+
+    assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
+    vim_command.assert_has_exact_calls( [
+      call( 'normal! m\'' ),
+      call( u'keepjumps edit {0}'.format( target_name ) ),
       call( 'normal! zz' )
     ] )
 
@@ -1671,7 +1711,7 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Quit_test( vim_command ):
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
-      call( u'keepjumps split {0}'.format( target_name ) )
+      call( u'keepjumps edit {0}'.format( target_name ) )
     ] )
 
 
@@ -1690,7 +1730,7 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Abort_test( vim_command ):
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
-      call( u'keepjumps split {0}'.format( target_name ) )
+      call( u'keepjumps edit {0}'.format( target_name ) )
     ] )
 
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -152,7 +152,7 @@ def BufferIsVisible( buffer_number ):
 
 def GetBufferFilepath( buffer_object ):
   if buffer_object.name:
-    return buffer_object.name
+    return ToUnicode( buffer_object.name )
   # Buffers that have just been created by a command like :enew don't have any
   # buffer name so we use the buffer number for that.
   return os.path.join( GetCurrentDirectory(), str( buffer_object.number ) )
@@ -372,7 +372,7 @@ def TryJumpLocationInOpenedTab( filename, line, column ):
 
   for tab in vim.tabpages:
     for win in tab.windows:
-      if win.buffer.name == filepath:
+      if GetBufferFilepath( win.buffer ) == filepath:
         vim.current.tabpage = tab
         vim.current.window = win
         vim.current.window.cursor = ( line, column - 1 )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -355,7 +355,9 @@ def VimExpressionToPythonType( vim_expression ):
 
 
 def HiddenEnabled( buffer_object ):
-  return bool( int( GetBufferOption( buffer_object, 'hid' ) ) )
+  if GetBufferOption( buffer_object, 'bh' ) == "hide":
+    return True
+  return GetBoolValue( '&hidden' )
 
 
 def BufferIsUsable( buffer_object ):


### PR DESCRIPTION
On Python 2, jumping in a file whose path contains non-ASCII characters raises the following warnings:
```
Error detected while processing function <SNR>26_CompleterCommand:
line   18:
python\ycm\vimsupport.py:400: UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if filename != GetCurrentBufferFilepath():
python\ycm\vimsupport.py:375: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if win.buffer.name == filepath:
```
This happens because, in the `JumpToLocation` function, we are comparing a unicode object (`filename` and `filepath`) with a Vim buffer name (`vim.current.buffer.name` returned by `GetCurrentBufferFilepath` and `win.buffer.name` where `win` is a Vim window) which is a byte object on Python 2.

For now, this PR adds tests covering the `JumpToLocation` function with unicode paths. They will raise the warnings on Python 2 and will fail because warnings are now treated as errors in tests. I'll update the PR with the fix once the builds are done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2702)
<!-- Reviewable:end -->
