### PR TITLE
[READY] Stop polling for readiness if the server crashed

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -486,6 +486,11 @@ endfunction
 
 
 function! s:PollServerReady( timer_id )
+  if !s:Pyeval( 'ycm_state.IsServerAlive()' )
+    " Server crashed. Don't poll it again.
+    return
+  endif
+
   if !s:Pyeval( 'ycm_state.CheckIfServerIsReady()' )
     let s:pollers.server_ready.id = timer_start(
           \ s:pollers.server_ready.wait_milliseconds,

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -221,7 +221,7 @@ class YouCompleteMe( object ):
 
 
   def CheckIfServerIsReady( self ):
-    if not self._server_is_ready_with_cache and self.IsServerAlive():
+    if not self._server_is_ready_with_cache:
       with HandleServerException( display = False ):
         self._server_is_ready_with_cache = BaseRequest.GetDataFromHandler(
             'ready' )


### PR DESCRIPTION
There is no need to continue polling the server if its process has terminated (i.e. the server crashed). This fixes issue https://github.com/Valloric/YouCompleteMe/issues/2683 when the server is not working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2704)
<!-- Reviewable:end -->
