### PR TITLE
[READY] Restore cursor position after omnifunc call

### DIFF
--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -90,12 +90,21 @@ class OmniCompleter( Completer ):
       # because it affects the value returned by 'query'
       request_data[ 'start_column' ] = return_value + 1
 
+      # Calling directly the omnifunc may move the cursor position. This is the
+      # case with the default Vim omnifunc for C-family languages
+      # (ccomplete#Complete) which calls searchdecl to find a declaration. This
+      # function is supposed to move the cursor to the found declaration but it
+      # doesn't when called through the omni completion mapping (CTRL-X CTRL-O).
+      # So, we restore the cursor position after calling the omnifunc.
+      line, column = vimsupport.CurrentLineAndColumn()
+
       omnifunc_call = [ self._omnifunc,
                         "(0,'",
                         vimsupport.EscapeForVim( request_data[ 'query' ] ),
                         "')" ]
-
       items = vim.eval( ''.join( omnifunc_call ) )
+
+      vimsupport.SetCurrentLineAndColumn( line, column )
 
       if isinstance( items, dict ) and 'words' in items:
         items = items[ 'words' ]

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -56,6 +56,12 @@ def CurrentLineAndColumn():
   return line, column
 
 
+def SetCurrentLineAndColumn( line, column ):
+  """Sets the cursor position to the 0-based line and 0-based column."""
+  # Line from vim.current.window.cursor is 1-based.
+  vim.current.window.cursor = ( line + 1, column )
+
+
 def CurrentColumn():
   """Returns the 0-based current column. Do NOT access the CurrentColumn in
   vim.current.line. It doesn't exist yet when the cursor is at the end of the


### PR DESCRIPTION
When compiled without C-family support, YCM will use the default omnifunc from Vim (`ccomplete#Complete`) to provide semantic completion. This omnifunc calls [`searchdecl`](http://vimdoc.sourceforge.net/htmldoc/eval.html#searchdecl()) to find a declaration, which is supposed to move the cursor to that declaration. However, the cursor is not moved when called through the omni completion mapping (`CTRL-X CTRL-O`). Since PR https://github.com/Valloric/YouCompleteMe/pull/2657, YCM calls the omnifunc outside completion mode and thus the cursor is moved to the found declaration after typing `.` or `->`.

Considering this `searchdecl` trick may be used by other omnifuncs, we fix the issue by always restoring the cursor position after calling the omnifunc.

Fixes #2698.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2707)
<!-- Reviewable:end -->
