### PR TITLE
[READY] Fix unicode warning when unloading buffer on Python 2

### DIFF
--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -25,7 +25,8 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from ycm.tests.test_utils import ( CurrentWorkingDirectory, ExtendedMock,
-                                   MockVimBuffers, MockVimModule, VimBuffer )
+                                   MockVimBuffers, MockVimModule, VimBuffer,
+                                   ToBytesOnPY2 )
 MockVimModule()
 
 import contextlib
@@ -447,14 +448,14 @@ def EventNotification_BufferVisit_BuildRequestForCurrentAndUnsavedBuffers_test(
 @YouCompleteMeInstance()
 def EventNotification_BufferUnload_BuildRequestForDeletedAndUnsavedBuffers_test(
     ycm ):
-  current_buffer_file = os.path.realpath( 'current_buffer' )
+  current_buffer_file = os.path.realpath( 'current_βuffer' )
   current_buffer = VimBuffer( name = current_buffer_file,
                               number = 1,
                               contents = [ 'current_buffer_contents' ],
                               filetype = 'some_filetype',
                               modified = True )
 
-  deleted_buffer_file = os.path.realpath( 'deleted_buffer' )
+  deleted_buffer_file = os.path.realpath( 'deleted_βuffer' )
   deleted_buffer = VimBuffer( name = deleted_buffer_file,
                               number = 2,
                               contents = [ 'deleted_buffer_contents' ],
@@ -464,7 +465,7 @@ def EventNotification_BufferUnload_BuildRequestForDeletedAndUnsavedBuffers_test(
   with patch( 'ycm.client.event_notification.EventNotification.'
               'PostDataToHandlerAsync' ) as post_data_to_handler_async:
     with MockVimBuffers( [ current_buffer, deleted_buffer ], current_buffer ):
-      ycm.OnBufferUnload( deleted_buffer_file )
+      ycm.OnBufferUnload( ToBytesOnPY2( deleted_buffer_file ) )
 
   assert_that(
     # Positional arguments passed to PostDataToHandlerAsync.

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -374,7 +374,9 @@ class YouCompleteMe( object ):
 
 
   def OnBufferUnload( self, deleted_buffer_file ):
-    SendEventNotificationAsync( 'BufferUnload', filepath = deleted_buffer_file )
+    SendEventNotificationAsync(
+        'BufferUnload',
+        filepath = utils.ToUnicode( deleted_buffer_file ) )
 
 
   def OnBufferVisit( self ):


### PR DESCRIPTION
When a buffer is unloaded, [we compare its name to the current buffer one in the `BuildRequestData` function](https://github.com/Valloric/YouCompleteMe/blob/5b89d4183232758f0ea02acee93d08b74e188dc7/python/ycm/client/base_request.py#L160). This raises a unicode warning on Python 2 when the deleted buffer name contains non-ASCII characters because the deleted buffer name is a byte object while the current buffer name is a unicode one.

I updated the `BufferUnload` test to show the issue. I'll send the fix once the builds failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2710)
<!-- Reviewable:end -->
