### PR TITLE
[READY] Check completefunc when forcing semantic completion

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -706,10 +706,13 @@ endfunction
 
 
 function! s:InvokeSemanticCompletion()
-  let s:force_semantic = 1
-  exec s:python_command "ycm_state.SendCompletionRequest( True )"
+  if &completefunc == "youcompleteme#CompleteFunc"
+    let s:force_semantic = 1
+    exec s:python_command "ycm_state.SendCompletionRequest( True )"
 
-  call s:PollCompletion()
+    call s:PollCompletion()
+  endif
+
   " Since this function is called in a mapping through the expression register
   " <C-R>=, its return value is inserted (see :h c_CTRL-R_=). We don't want to
   " insert anything so we return an empty string.


### PR DESCRIPTION
When `completefunc` is not set (because YCM is not allowed to complete in the current buffer or the server failed to start) and semantic completion is forced with `<C-Space>`, Vim returns the following error:
```
E764: Option 'completefunc' is not set
```
This happens because we don't check if `completefunc` is set to `youcompleteme#CompleteFunc` in that case.

To completely avoid this issue, we always set the `completefunc` before invoking it. This may look inefficient but, in practice, the performance cost is almost nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2722)
<!-- Reviewable:end -->
