### PR TITLE
[RFC] Add a more obvious explanation for users of the default system Vim on macOS

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -31,6 +31,20 @@ elseif v:version < 704 || (v:version == 704 && !has( 'patch1578' ))
   echohl WarningMsg |
         \ echomsg "YouCompleteMe unavailable: requires Vim 7.4.1578+." |
         \ echohl None
+  if v:version == 704 && has( 'patch8056' )
+    " Very very special case for users of the default Vim on macOS. For some
+    " reason, that version of Vim contains a completely arbitrary (presumably
+    " custom) patch '8056', which fools users (but not our has( 'patch1578' )
+    " check) into thinking they have a sufficiently new Vim. In fact they do
+    " not and YCM fails to initialise. So we give them a more specific warning.
+    echohl WarningMsg
+          \ | echomsg
+          \ "Info: You appear to be running the default system Vim on macOS. "
+          \ . "It reports as patch 8056, but it is really older than 1578. "
+          \ . "Please consider MacVim, homebrew Vim or a self-built Vim that "
+          \ . "satisfies the minimum requirement."
+          \ | echohl None
+  endif
   call s:restore_cpo()
   finish
 elseif !has( 'timers' )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

No tests because we don't have Vimscript tests. But I tested:

* System Vim on macOS:

```
BeniMac:YouCompleteMe-Clean ben$ /usr/bin/vi
YouCompleteMe unavailable: requires Vim 7.4.1578+.
Info: You appear to be running the default system Vim on macOS. It reports as patch 8056, but it is really older than 1578. Please consider MacVim, homebrew Vim or a self-built Vim that satisfies the minimum requirement.
Press ENTER or type command to continue
```

* Manually built too-old Vim on macOS (regression test)

```
BeniMac:vim ben$ ./src/vim
YouCompleteMe unavailable: requires Vim 7.4.1578+.
Press ENTER or type command to continue
BeniMac:vim ben$
```

* MacVim (latest) works
* Homebrew Vim (latest) works
* Whatever random Vim I was using before works

# Why this change is necessary and useful

As the comment says, and referred in [this issue]( https://github.com/Valloric/YouCompleteMe/issues/2721#issuecomment-317272969) and [this comment](https://github.com/Valloric/YouCompleteMe/issues/549#issuecomment-317272203) users of macOS are being flummoxed by the reporting of its version on the launch screen as some bogus patch number. I guess Apple patched it for some reason (such as their OS protection or something), and just chose a random high number (or perhaps some v8 back patch, who knows). 

Anyway, a specific error message for such users means they can get a working system without reporting to us, but it's our overhead to maintain the extra code. So RFC for that reason.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2728)
<!-- Reviewable:end -->
