### PR TITLE
[READY] Pin YCM extra conf version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3063,7 +3063,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [vim]: http://www.vim.org/
 [syntastic]: https://github.com/scrooloose/syntastic
 [lightline]: https://github.com/itchyny/lightline.vim
-[flags_example]: https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py
+[flags_example]: https://raw.githubusercontent.com/Valloric/ycmd/6463774035e61a660ad9150a592b8829eb37fd10/cpp/ycm/.ycm_extra_conf.py
 [compdb]: http://clang.llvm.org/docs/JSONCompilationDatabase.html
 [subsequence]: https://en.wikipedia.org/wiki/Subsequence
 [listtoggle]: https://github.com/Valloric/ListToggle

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3386,7 +3386,7 @@ References ~
 [44] http://clang.llvm.org/docs/JSONCompilationDatabase.html
 [45] https://ninja-build.org/manual.html
 [46] https://github.com/rizsotto/Bear
-[47] https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py
+[47] https://raw.githubusercontent.com/Valloric/ycmd/6463774035e61a660ad9150a592b8829eb37fd10/cpp/ycm/.ycm_extra_conf.py
 [48] https://github.com/rdnetto/YCM-Generator
 [49] http://ternjs.net/doc/manual.html#configuration
 [50] http://ternjs.net/doc/manual.html#server


### PR DESCRIPTION
By linking to a specific version of [ycmd `.ycm_extra_conf.py` file](https://github.com/Valloric/ycmd/blob/master/cpp/ycm/.ycm_extra_conf.py) in the docs, users following the link won't copy a version of this file that's incompatible with the current version of YCM when that file is modified because of a change in our `.ycm_extra_conf.py` specs (like in PR https://github.com/Valloric/ycmd/pull/795), and ycmd submodule is not yet updated.

Also, link to the raw file instead of the github page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2737)
<!-- Reviewable:end -->
