### PR TITLE
[READY] Improve error message when server crashes

### DIFF
--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -28,7 +28,7 @@ MockVimModule()
 
 import os
 import sys
-from hamcrest import ( assert_that, contains, empty, is_in, is_not, has_length,
+from hamcrest import ( assert_that, contains, empty, equal_to, is_in, is_not,
                        matches_regexp )
 from mock import call, MagicMock, patch
 
@@ -53,23 +53,19 @@ def RunNotifyUserIfServerCrashed( ycm, test, post_vim_message ):
 
   ycm._NotifyUserIfServerCrashed()
 
-  assert_that( ycm._logger.method_calls,
-               has_length( len( test[ 'expected_logs' ] ) ) )
-  ycm._logger.error.assert_has_calls(
-    [ call( log ) for log in test[ 'expected_logs' ] ] )
-  post_vim_message.assert_has_exact_calls( [
-    call( test[ 'expected_vim_message' ] )
-  ] )
+  assert_that( ycm._logger.error.call_args[ 0 ][ 0 ],
+               test[ 'expected_message' ] )
+  assert_that( post_vim_message.call_args[ 0 ][ 0 ],
+               test[ 'expected_message' ] )
 
 
 def YouCompleteMe_NotifyUserIfServerCrashed_UnexpectedCore_test():
-  message = ( "The ycmd server SHUT DOWN (restart with ':YcmRestartServer'). "
-              "Unexpected error while loading the YCM core library. "
-              "Use the ':YcmToggleLogs' command to check the logs." )
+  message = ( "The ycmd server SHUT DOWN \(restart with ':YcmRestartServer'\). "
+              "Unexpected error while loading the YCM core library. Type "
+              "':YcmToggleLogs ycmd_\d+_stderr_.+.log' to check the logs." )
   RunNotifyUserIfServerCrashed( {
     'return_code': 3,
-    'expected_logs': [ message ],
-    'expected_vim_message': message
+    'expected_message': matches_regexp( message )
   } )
 
 
@@ -79,8 +75,7 @@ def YouCompleteMe_NotifyUserIfServerCrashed_MissingCore_test():
               "using it. Follow the instructions in the documentation." )
   RunNotifyUserIfServerCrashed( {
     'return_code': 4,
-    'expected_logs': [ message ],
-    'expected_vim_message': message
+    'expected_message': equal_to( message )
   } )
 
 
@@ -91,8 +86,7 @@ def YouCompleteMe_NotifyUserIfServerCrashed_Python2Core_test():
               "interpreter path." )
   RunNotifyUserIfServerCrashed( {
     'return_code': 5,
-    'expected_logs': [ message ],
-    'expected_vim_message': message
+    'expected_message': equal_to( message )
   } )
 
 
@@ -103,8 +97,7 @@ def YouCompleteMe_NotifyUserIfServerCrashed_Python3Core_test():
               "interpreter path." )
   RunNotifyUserIfServerCrashed( {
     'return_code': 6,
-    'expected_logs': [ message ],
-    'expected_vim_message': message
+    'expected_message': equal_to( message )
   } )
 
 
@@ -114,19 +107,17 @@ def YouCompleteMe_NotifyUserIfServerCrashed_OutdatedCore_test():
               "install.py script. See the documentation for more details." )
   RunNotifyUserIfServerCrashed( {
     'return_code': 7,
-    'expected_logs': [ message ],
-    'expected_vim_message': message
+    'expected_message': equal_to( message )
   } )
 
 
 def YouCompleteMe_NotifyUserIfServerCrashed_UnexpectedExitCode_test():
-  message = ( "The ycmd server SHUT DOWN (restart with ':YcmRestartServer'). "
-              "Unexpected exit code 1. Use the ':YcmToggleLogs' command to "
-              "check the logs." )
+  message = ( "The ycmd server SHUT DOWN \(restart with ':YcmRestartServer'\). "
+              "Unexpected exit code 1. Type "
+              "':YcmToggleLogs ycmd_\d+_stderr_.+.log' to check the logs." )
   RunNotifyUserIfServerCrashed( {
     'return_code': 1,
-    'expected_logs': [ message ],
-    'expected_vim_message': message
+    'expected_message': matches_regexp( message )
   } )
 
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -79,10 +79,10 @@ SERVER_SHUTDOWN_MESSAGE = (
   "The ycmd server SHUT DOWN (restart with ':YcmRestartServer')." )
 EXIT_CODE_UNEXPECTED_MESSAGE = (
   "Unexpected exit code {code}. "
-  "Use the ':YcmToggleLogs' command to check the logs." )
+  "Type ':YcmToggleLogs {logfile}' to check the logs." )
 CORE_UNEXPECTED_MESSAGE = (
   "Unexpected error while loading the YCM core library. "
-  "Use the ':YcmToggleLogs' command to check the logs." )
+  "Type ':YcmToggleLogs {logfile}' to check the logs." )
 CORE_MISSING_MESSAGE = (
   'YCM core library not detected; you need to compile YCM before using it. '
   'Follow the instructions in the documentation.' )
@@ -238,8 +238,10 @@ class YouCompleteMe( object ):
     self._user_notified_about_crash = True
 
     return_code = self._server_popen.poll()
+    logfile = os.path.basename( self._server_stderr )
     if return_code == server_utils.CORE_UNEXPECTED_STATUS:
-      error_message = CORE_UNEXPECTED_MESSAGE
+      error_message = CORE_UNEXPECTED_MESSAGE.format(
+          logfile = logfile )
     elif return_code == server_utils.CORE_MISSING_STATUS:
       error_message = CORE_MISSING_MESSAGE
     elif return_code == server_utils.CORE_PYTHON2_STATUS:
@@ -249,7 +251,9 @@ class YouCompleteMe( object ):
     elif return_code == server_utils.CORE_OUTDATED_STATUS:
       error_message = CORE_OUTDATED_MESSAGE
     else:
-      error_message = EXIT_CODE_UNEXPECTED_MESSAGE.format( code = return_code )
+      error_message = EXIT_CODE_UNEXPECTED_MESSAGE.format(
+          code = return_code,
+          logfile = logfile )
 
     error_message = SERVER_SHUTDOWN_MESSAGE + ' ' + error_message
     self._logger.error( error_message )


### PR DESCRIPTION
This PR improves the error message displayed to the user when the server unexpectedly crashes by giving the exact command to type to open the server logfile.

We could go further by automatically opening the server logfile but this is too disruptive in my opinion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2752)
<!-- Reviewable:end -->
