### PR TITLE
[READY] Update ClearCompilationFlagCache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,12 +1605,13 @@ Supported in filetypes: `cs, go, javascript, python, rust, typescript`
 #### The `ClearCompilationFlagCache` subcommand
 
 YCM caches the flags it gets from the `FlagsForFile` function in your
-`ycm_extra_conf.py` file if you return them with the `do_cache` parameter set to
-`True`. The cache is in memory and is never invalidated (unless you restart Vim
-of course).
+`ycm_extra_conf.py` file unless you return them with the `do_cache` parameter
+set to `False`. It also caches the flags extracted from the compilation
+database. The cache is in memory and is never invalidated (unless you restart
+the server with the `:YcmRestartServer` command).
 
 This command clears that cache entirely. YCM will then re-query your
-`FlagsForFile` function as needed in the future.
+`FlagsForFile` function or your compilation database as needed in the future.
 
 Supported in filetypes: `c, cpp, objc, objcpp`
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1896,12 +1896,13 @@ Supported in filetypes: 'cs, go, javascript, python, rust, typescript'
 The *ClearCompilationFlagCache* subcommand
 
 YCM caches the flags it gets from the 'FlagsForFile' function in your
-'ycm_extra_conf.py' file if you return them with the 'do_cache' parameter set
-to 'True'. The cache is in memory and is never invalidated (unless you restart
-Vim of course).
+'ycm_extra_conf.py' file unless you return them with the 'do_cache' parameter
+set to 'False'. It also caches the flags extracted from the compilation
+database. The cache is in memory and is never invalidated (unless you restart
+the server with the |:YcmRestartServer| command).
 
 This command clears that cache entirely. YCM will then re-query your
-'FlagsForFile' function as needed in the future.
+'FlagsForFile' function or your compilation database as needed in the future.
 
 Supported in filetypes: 'c, cpp, objc, objcpp'
 


### PR DESCRIPTION
Update the documentation for the `ClearCompilationFlagCache` subcommand by taking into account that:
 - the `do_cache` parameter is set to `True` by default;
 - the flags from the compilation database are also cached;
 - restarting the server clears the cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2763)
<!-- Reviewable:end -->
