### PR TITLE
[READY] Update ycmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -3101,7 +3101,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [vim]: http://www.vim.org/
 [syntastic]: https://github.com/scrooloose/syntastic
 [lightline]: https://github.com/itchyny/lightline.vim
-[flags_example]: https://raw.githubusercontent.com/Valloric/ycmd/6463774035e61a660ad9150a592b8829eb37fd10/cpp/ycm/.ycm_extra_conf.py
+[flags_example]: https://raw.githubusercontent.com/Valloric/ycmd/3ad0300e94edc13799e8bf7b831de8b57153c5aa/cpp/ycm/.ycm_extra_conf.py
 [compdb]: http://clang.llvm.org/docs/JSONCompilationDatabase.html
 [subsequence]: https://en.wikipedia.org/wiki/Subsequence
 [listtoggle]: https://github.com/Valloric/ListToggle

--- a/README.md
+++ b/README.md
@@ -1742,6 +1742,43 @@ Default: `0`
 let g:ycm_min_num_identifier_candidate_chars = 0
 ```
 
+### The `g:ycm_max_num_candidates` option
+
+This option controls the maximum number of semantic completion suggestions shown
+in the completion menu. This only applies to suggestions from semantic
+completion engines; see [the `g:ycm_max_identifier_candidates`
+option](#the-gycm_max_num_identifier_candidates-option) to limit the number of
+suggestions from the identifier-based engine.
+
+A special value of `0` means there is no limit.
+
+**NOTE:** Setting this option to `0` or to a value greater than `100` is not
+recommended as it will slow down completion when there are a very large number
+of suggestions.
+
+Default: `50`
+
+```viml
+let g:ycm_max_num_candidates = 50
+```
+
+### The `g:ycm_max_num_identifier_candidates` option
+
+This option controls the maximum number of completion suggestions from the
+identifier-based engine shown in the completion menu.
+
+A special value of `0` means there is no limit.
+
+**NOTE:** Setting this option to `0` or to a value greater than `100` is not
+recommended as it will slow down completion when there are a very large number
+of suggestions.
+
+Default: `10`
+
+```viml
+let g:ycm_max_num_identifier_candidates = 10
+```
+
 ### The `g:ycm_auto_trigger` option
 
 When set to `0`, this option turns off YCM's identifier completer (the

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -83,51 +83,53 @@ Contents ~
  10. Options                                            |youcompleteme-options|
   1. The |g:ycm_min_num_of_chars_for_completion| option
   2. The |g:ycm_min_num_identifier_candidate_chars| option
-  3. The |g:ycm_auto_trigger| option
-  4. The |g:ycm_filetype_whitelist| option
-  5. The |g:ycm_filetype_blacklist| option
-  6. The |g:ycm_filetype_specific_completion_to_disable| option
-  7. The |g:ycm_show_diagnostics_ui| option
-  8. The |g:ycm_error_symbol| option
-  9. The |g:ycm_warning_symbol| option
-  10. The |g:ycm_enable_diagnostic_signs| option
-  11. The |g:ycm_enable_diagnostic_highlighting| option
-  12. The |g:ycm_echo_current_diagnostic| option
-  13. The |g:ycm_filter_diagnostics| option
-  14. The |g:ycm_always_populate_location_list| option
-  15. The |g:ycm_open_loclist_on_ycm_diags| option
-  16. The |g:ycm_complete_in_comments| option
-  17. The |g:ycm_complete_in_strings| option
-  18. The |g:ycm_collect_identifiers_from_comments_and_strings| option
-  19. The |g:ycm_collect_identifiers_from_tags_files| option
-  20. The |g:ycm_seed_identifiers_with_syntax| option
-  21. The |g:ycm_extra_conf_vim_data| option
-  22. The |g:ycm_server_python_interpreter| option
-  23. The |g:ycm_keep_logfiles| option
-  24. The |g:ycm_log_level| option
-  25. The |g:ycm_auto_start_csharp_server| option
-  26. The |g:ycm_auto_stop_csharp_server| option
-  27. The |g:ycm_csharp_server_port| option
-  28. The |g:ycm_csharp_insert_namespace_expr| option
-  29. The |g:ycm_add_preview_to_completeopt| option
-  30. The |g:ycm_autoclose_preview_window_after_completion| option
-  31. The |g:ycm_autoclose_preview_window_after_insertion| option
-  32. The |g:ycm_max_diagnostics_to_display| option
-  33. The |g:ycm_key_list_select_completion| option
-  34. The |g:ycm_key_list_previous_completion| option
-  35. The |g:ycm_key_list_stop_completion| option
-  36. The |g:ycm_key_invoke_completion| option
-  37. The |g:ycm_key_detailed_diagnostics| option
-  38. The |g:ycm_global_ycm_extra_conf| option
-  39. The |g:ycm_confirm_extra_conf| option
-  40. The |g:ycm_extra_conf_globlist| option
-  41. The |g:ycm_filepath_completion_use_working_dir| option
-  42. The |g:ycm_semantic_triggers| option
-  43. The |g:ycm_cache_omnifunc| option
-  44. The |g:ycm_use_ultisnips_completer| option
-  45. The |g:ycm_goto_buffer_command| option
-  46. The |g:ycm_disable_for_files_larger_than_kb| option
-  47. The |g:ycm_python_binary_path| option
+  3. The |g:ycm_max_num_candidates| option
+  4. The |g:ycm_max_num_identifier_candidates| option
+  5. The |g:ycm_auto_trigger| option
+  6. The |g:ycm_filetype_whitelist| option
+  7. The |g:ycm_filetype_blacklist| option
+  8. The |g:ycm_filetype_specific_completion_to_disable| option
+  9. The |g:ycm_show_diagnostics_ui| option
+  10. The |g:ycm_error_symbol| option
+  11. The |g:ycm_warning_symbol| option
+  12. The |g:ycm_enable_diagnostic_signs| option
+  13. The |g:ycm_enable_diagnostic_highlighting| option
+  14. The |g:ycm_echo_current_diagnostic| option
+  15. The |g:ycm_filter_diagnostics| option
+  16. The |g:ycm_always_populate_location_list| option
+  17. The |g:ycm_open_loclist_on_ycm_diags| option
+  18. The |g:ycm_complete_in_comments| option
+  19. The |g:ycm_complete_in_strings| option
+  20. The |g:ycm_collect_identifiers_from_comments_and_strings| option
+  21. The |g:ycm_collect_identifiers_from_tags_files| option
+  22. The |g:ycm_seed_identifiers_with_syntax| option
+  23. The |g:ycm_extra_conf_vim_data| option
+  24. The |g:ycm_server_python_interpreter| option
+  25. The |g:ycm_keep_logfiles| option
+  26. The |g:ycm_log_level| option
+  27. The |g:ycm_auto_start_csharp_server| option
+  28. The |g:ycm_auto_stop_csharp_server| option
+  29. The |g:ycm_csharp_server_port| option
+  30. The |g:ycm_csharp_insert_namespace_expr| option
+  31. The |g:ycm_add_preview_to_completeopt| option
+  32. The |g:ycm_autoclose_preview_window_after_completion| option
+  33. The |g:ycm_autoclose_preview_window_after_insertion| option
+  34. The |g:ycm_max_diagnostics_to_display| option
+  35. The |g:ycm_key_list_select_completion| option
+  36. The |g:ycm_key_list_previous_completion| option
+  37. The |g:ycm_key_list_stop_completion| option
+  38. The |g:ycm_key_invoke_completion| option
+  39. The |g:ycm_key_detailed_diagnostics| option
+  40. The |g:ycm_global_ycm_extra_conf| option
+  41. The |g:ycm_confirm_extra_conf| option
+  42. The |g:ycm_extra_conf_globlist| option
+  43. The |g:ycm_filepath_completion_use_working_dir| option
+  44. The |g:ycm_semantic_triggers| option
+  45. The |g:ycm_cache_omnifunc| option
+  46. The |g:ycm_use_ultisnips_completer| option
+  47. The |g:ycm_goto_buffer_command| option
+  48. The |g:ycm_disable_for_files_larger_than_kb| option
+  49. The |g:ycm_python_binary_path| option
  11. FAQ                                                    |youcompleteme-faq|
   1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |youcompleteme-i-used-to-be-able-to-import-vim-in-.ycm_extra_conf.py-but-now-cant|
   2. I get 'ImportError' exceptions that mention 'PyInit_ycm_core' or 'initycm_core' |youcompleteme-i-get-importerror-exceptions-that-mention-pyinit_ycm_core-or-initycm_core|
@@ -2032,6 +2034,40 @@ effect on the various semantic completers.
 Default: '0'
 >
   let g:ycm_min_num_identifier_candidate_chars = 0
+<
+-------------------------------------------------------------------------------
+The *g:ycm_max_num_candidates* option
+
+This option controls the maximum number of semantic completion suggestions
+shown in the completion menu. This only applies to suggestions from semantic
+completion engines; see the 'g:ycm_max_identifier_candidates' option to limit
+the number of suggestions from the identifier-based engine.
+
+A special value of '0' means there is no limit.
+
+**NOTE:** Setting this option to '0' or to a value greater than '100' is not
+recommended as it will slow down completion when there are a very large number
+of suggestions.
+
+Default: '50'
+>
+  let g:ycm_max_num_candidates = 50
+<
+-------------------------------------------------------------------------------
+The *g:ycm_max_num_identifier_candidates* option
+
+This option controls the maximum number of completion suggestions from the
+identifier-based engine shown in the completion menu.
+
+A special value of '0' means there is no limit.
+
+**NOTE:** Setting this option to '0' or to a value greater than '100' is not
+recommended as it will slow down completion when there are a very large number
+of suggestions.
+
+Default: '10'
+>
+  let g:ycm_max_num_identifier_candidates = 10
 <
 -------------------------------------------------------------------------------
 The *g:ycm_auto_trigger* option

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3423,7 +3423,7 @@ References ~
 [44] http://clang.llvm.org/docs/JSONCompilationDatabase.html
 [45] https://ninja-build.org/manual.html
 [46] https://github.com/rizsotto/Bear
-[47] https://raw.githubusercontent.com/Valloric/ycmd/6463774035e61a660ad9150a592b8829eb37fd10/cpp/ycm/.ycm_extra_conf.py
+[47] https://raw.githubusercontent.com/Valloric/ycmd/3ad0300e94edc13799e8bf7b831de8b57153c5aa/cpp/ycm/.ycm_extra_conf.py
 [48] https://github.com/rdnetto/YCM-Generator
 [49] http://ternjs.net/doc/manual.html#configuration
 [50] http://ternjs.net/doc/manual.html#server

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -393,6 +393,8 @@ def OmniCompleter_GetCompletions_NoCache_ObjectListObject_test( ycm ):
     )
 
 
+@ExpectedFailure( 'Filtering on unicode is not supported by the server',
+                  contains_string( "value for 'completions' was <[]>" ) )
 @YouCompleteMeInstance( { 'cache_omnifunc': 1 } )
 def OmniCompleter_GetCompletions_Cache_List_Unicode_test( ycm ):
   def Omnifunc( findstart, base ):


### PR DESCRIPTION
This new version of ycmd includes the following changes:

 - PR Valloric/ycmd#795: add option to make relative paths in flags from extra conf absolute;
 - PR Valloric/ycmd#802: fix compilation on Haiku;
 - PR Valloric/ycmd#804: add libclang detection on FreeBSD;
 - PR Valloric/ycmd#808: write python used during build before installing completers;
 - PR Valloric/ycmd#810: support unknown languages from tags;
 - PR Valloric/ycmd#811: update Universal Ctags languages list;
 - PR Valloric/ycmd#814: resolve symlinks in extra conf glob patterns;
 - PR Valloric/ycmd#815: update JediHTTP;
 - PR Valloric/ycmd#816: update Boost to 1.65.0;
 - PR Valloric/ycmd#819: filter and sort candidates when query is empty;
 - PR Valloric/ycmd#820: improve LLVM root path search for prebuilt binaries;
 - PR Valloric/ycmd#822: inline critical utility functions;
 - PR Valloric/ycmd#824: do not sort header paths in filename completer;
 - PR Valloric/ycmd#825: implement partial sorting;
 - PR Valloric/ycmd#830: add max_num_candidates option;
 - PR Valloric/ycmd#831: fix multiline comments and strings issues;
 - PR Valloric/ycmd#832: update Clang to 5.0.0.

The `g:ycm_max_num_candidates` and `g:ycm_max_num_identifier_candidates` options are added to the documentation.

The link to ycmd extra conf is updated.

Fixes #2562.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2768)
<!-- Reviewable:end -->
