### PR TITLE
[READY] Do not open location list at the bottom of screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1658,8 +1658,8 @@ Autocommands
 
 This `User` autocommand is fired when YCM opens the location list window in
 response to the `YcmDiags` command. By default, the location list window is
-opened to full width at the bottom of the screen and its height is set to fit
-all entries. This behavior can be overridden by using the `YcmLocationOpened`
+opened to the bottom of the current window and its height is set to fit all
+entries. This behavior can be overridden by using the `YcmLocationOpened`
 autocommand which is triggered while the cursor is in the location list window.
 For instance:
 ```viml

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1955,8 +1955,8 @@ The *YcmLocationOpened* autocommand
 
 This 'User' autocommand is fired when YCM opens the location list window in
 response to the 'YcmDiags' command. By default, the location list window is
-opened to full width at the bottom of the screen and its height is set to fit
-all entries. This behavior can be overridden by using the |YcmLocationOpened|
+opened to the bottom of the current window and its height is set to fit all
+entries. This behavior can be overridden by using the |YcmLocationOpened|
 autocommand which is triggered while the cursor is in the location list window.
 For instance:
 >

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -60,7 +60,7 @@ def SetLocationList_test( vim_eval ):
 def OpenLocationList_test( vim_command, fitting_height, variable_exists ):
   vimsupport.OpenLocationList( focus = False, autoclose = True )
   vim_command.assert_has_exact_calls( [
-    call( 'botright lopen' ),
+    call( 'lopen' ),
     call( 'au WinLeave <buffer> q' ),
     call( 'doautocmd User YcmLocationOpened' ),
     call( 'silent! wincmd p' )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -250,13 +250,13 @@ def SetLocationList( diagnostics ):
 
 
 def OpenLocationList( focus = False, autoclose = False ):
-  """Open the location list to full width at the bottom of the screen with its
+  """Open the location list to the bottom of the current window with its
   height automatically set to fit all entries. This behavior can be overridden
   by using the YcmLocationOpened autocommand. When focus is set to True, the
   location list window becomes the active window. When autoclose is set to True,
   the location list window is automatically closed after an entry is
   selected."""
-  vim.command( 'botright lopen' )
+  vim.command( 'lopen' )
 
   SetFittingHeightForCurrentWindow()
 


### PR DESCRIPTION
The location list is specific to the current window so it should be opened inside the current window (default behavior), not to full width at the bottom of the screen (with `:botright`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2781)
<!-- Reviewable:end -->
