### PR TITLE
Added instructions for cmake3

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ process.
 Install development tools and CMake: 
 
     sudo apt-get install build-essential cmake
+    
+**Note:** On older systems (eg. Ubuntu 14.04) you may run into compilation-issues with `cmake`. Therefore, install the following instead:
+
+    sudo apt-get install build-essential cmake3
 
 Make sure you have Python headers installed:
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ process.
 Install development tools and CMake: 
 
     sudo apt-get install build-essential cmake
-    
-**Note:** On older systems (eg. Ubuntu 14.04) you may run into compilation-issues with `cmake`. Therefore, install the following instead:
+
+**Note:** On older systems (e.g. Ubuntu 14.04) you may run into compilation 
+issues with `cmake`. Therefore, install the following instead:
 
     sudo apt-get install build-essential cmake3
 


### PR DESCRIPTION
- Updated Linux64 instructions for older systems where cmake(2.8) might be causing compilation issues.
- Using cmake3 may likely address issues (in certain scenarios)

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This is a non-code PR adding instructions to the README.md file for situations where `cmake` may be the issue. The instructions simply specify that under certain scenarios, using `cmake3` instead of `cmake` may address the compilation-issues of YCM (eg. on older systems like Ubuntu 14.04). A reference to this issue can be found under the discussion here: [link](https://github.com/Valloric/YouCompleteMe/issues/2729#issuecomment-332961003)

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2792)
<!-- Reviewable:end -->
