### PR TITLE
[READY] Echo diagnostic asynchronously

### DIFF
--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -44,6 +44,7 @@ DEFAULT_CLIENT_OPTIONS = {
   'keep_logfiles': 0,
   'extra_conf_vim_data': [],
   'show_diagnostics_ui': 1,
+  'echo_current_diagnostic': 1,
   'enable_diagnostic_signs': 1,
   'enable_diagnostic_highlighting': 0,
   'always_populate_location_list': 0,


### PR DESCRIPTION
If there is a diagnostic on the current line while updating diagnostics, echo it on the command line. Here's a demo:

![echo-diagnostic-async](https://user-images.githubusercontent.com/10026824/31182114-4e784200-a923-11e7-831b-e613d126fd8b.gif)

Without this change, users have to move the cursor up and down to see the message on the command line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2797)
<!-- Reviewable:end -->
