### PR TITLE
[READY] Improve server crash notification at startup

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -487,6 +487,7 @@ endfunction
 
 function! s:PollServerReady( timer_id )
   if !s:Pyeval( 'ycm_state.IsServerAlive()' )
+    exec s:python_command "ycm_state.NotifyUserIfServerCrashed()"
     " Server crashed. Don't poll it again.
     return
   endif

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -108,7 +108,7 @@ def RunNotifyUserIfServerCrashed( ycm, test, post_vim_message ):
   ycm._server_popen = MagicMock( autospec = True )
   ycm._server_popen.poll.return_value = test[ 'return_code' ]
 
-  ycm._NotifyUserIfServerCrashed()
+  ycm.OnFileReadyToParse()
 
   assert_that( ycm._logger.error.call_args[ 0 ][ 0 ],
                test[ 'expected_message' ] )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -186,8 +186,6 @@ class YouCompleteMe( object ):
     self._server_popen = utils.SafePopen( args, stdin_windows = PIPE,
                                           stdout = PIPE, stderr = PIPE )
 
-    self._NotifyUserIfServerCrashed()
-
 
   def _SetupLogging( self ):
     def FreeFileFromOtherProcesses( file_object ):
@@ -244,7 +242,7 @@ class YouCompleteMe( object ):
     return self._server_is_ready_with_cache
 
 
-  def _NotifyUserIfServerCrashed( self ):
+  def NotifyUserIfServerCrashed( self ):
     if ( not self._server_popen or self._user_notified_about_crash or
          self.IsServerAlive() ):
       return
@@ -371,7 +369,7 @@ class YouCompleteMe( object ):
 
   def OnFileReadyToParse( self ):
     if not self.IsServerAlive():
-      self._NotifyUserIfServerCrashed()
+      self.NotifyUserIfServerCrashed()
       return
 
     if not self.IsServerReady():


### PR DESCRIPTION
Instead of notifying the user if the server crashed immediately after starting it (which is unlikely to work because the server process is necessarily up at this point), do it during polling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2798)
<!-- Reviewable:end -->
