### PR TITLE
[READY] Mention auto-insert wrapping bug in the FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -2663,9 +2663,12 @@ cache.
 
 ### YCM auto-inserts completion strings I don't want!
 
-This means you probably have some mappings that interfere with YCM's internal
-ones. Make sure you don't have something mapped to `<C-p>`, `<C-x>` or `<C-u>`
-(in insert mode).
+If this happens when Vim automatically wraps text then it's a Vim bug that has
+been fixed in version 8.0.0127. Update your Vim to this version or later.
+
+This could also be some mappings that interfere with YCM's internal ones. Make
+sure you don't have something mapped to `<C-p>`, `<C-x>` or `<C-u>` (in insert
+mode).
 
 YCM _never_ selects something for you; it just shows you a menu and the user has
 to explicitly select something. If something is being selected automatically,

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -429,6 +429,11 @@ Install development tools and CMake:
 >
   sudo apt-get install build-essential cmake
 <
+**Note:** On older systems (e.g. Ubuntu 14.04) you may run into compilation
+issues with 'cmake'. Therefore, install the following instead:
+>
+  sudo apt-get install build-essential cmake3
+<
 Make sure you have Python headers installed:
 >
   sudo apt-get install python-dev python3-dev
@@ -2911,9 +2916,12 @@ cache.
                 *youcompleteme-ycm-auto-inserts-completion-strings-i-dont-want*
 YCM auto-inserts completion strings I don't want! ~
 
-This means you probably have some mappings that interfere with YCM's internal
-ones. Make sure you don't have something mapped to '<C-p>', '<C-x>' or '<C-u>'
-(in insert mode).
+If this happens when Vim automatically wraps text then it's a Vim bug that has
+been fixed in version 8.0.0127. Update your Vim to this version or later.
+
+This could also be some mappings that interfere with YCM's internal ones. Make
+sure you don't have something mapped to '<C-p>', '<C-x>' or '<C-u>' (in insert
+mode).
 
 YCM _never_ selects something for you; it just shows you a menu and the user
 has to explicitly select something. If something is being selected


### PR DESCRIPTION
Prior to version 8.0.0127, Vim would insert the first suggestion when leaving completion while auto-wrapping text. See issue https://github.com/vim/vim/issues/1312 and [the corresponding patch](https://github.com/vim/vim/commit/73fd4988866c3adc15b5d093efdf5e8cf70d093d). This would cause issues #771 and #2789 when using YCM.

We mention this bug in the FAQ and suggest to update to Vim 8.0.0127 or later.

Closes https://github.com/Valloric/YouCompleteMe/issues/771.
Closes https://github.com/Valloric/YouCompleteMe/issues/2789.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2802)
<!-- Reviewable:end -->
