### PR TITLE
[READY] Update 7-Zip requirement to 16.04 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,8 @@ _Windows x86-64_ for a 64-bit Vim. We recommend installing Python 3.
 variable.
 - [Visual Studio][visual-studio-download]. Download the community edition.
 During setup, select _Desktop development with C++_ in _Workloads_.
-- [7-zip][7z-download]. Required to build YCM with semantic support for
-C-family languages.
+- [7-zip 16.04 or later][7z-download]. Required to build YCM with semantic
+support for C-family languages.
 
 Compiling YCM **with** semantic support for C-family languages:
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -598,8 +598,8 @@ Download and install the following software:
 - Visual Studio [36]. Download the community edition. During setup, select
   _Desktop development with C++_ in _Workloads_.
 
-- 7-zip [37]. Required to build YCM with semantic support for C-family
-  languages.
+- 7-zip 16.04 or later [37]. Required to build YCM with semantic support for
+  C-family languages.
 
 Compiling YCM **with** semantic support for C-family languages:
 >
@@ -1594,7 +1594,7 @@ GoTo Commands ~
 
 These commands are useful for jumping around and exploring code. When moving
 the cursor, the subcommands add entries to Vim's 'jumplist' so you can use
-'CTRL-O' to jump back to where you where before invoking the command (and
+'CTRL-O' to jump back to where you were before invoking the command (and
 'CTRL-I' to jump forward; see ':h jumplist' for details). If there is more than
 one destination, the quickfix list (see ':h quickfix') is populated with the
 available locations and opened to full width at the bottom of the screen. You


### PR DESCRIPTION
There are some issues with [7-Zip 9.20](http://www.7-zip.org/download.html) when extracting files from the Clang installer. See https://github.com/Valloric/YouCompleteMe/issues/2756 and https://github.com/Valloric/YouCompleteMe/issues/2811.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2816)
<!-- Reviewable:end -->
