### PR TITLE
[WIP][RFC] Native Java support

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -146,10 +146,6 @@ function! youcompleteme#Enable()
   call s:SetUpCompleteopt()
   call s:SetUpKeyMappings()
 
-  if g:ycm_show_diagnostics_ui
-    call s:TurnOffSyntasticForCFamily()
-  endif
-
   call s:SetUpSigns()
   call s:SetUpSyntaxHighlighting()
 
@@ -387,15 +383,6 @@ function! s:SetUpBackwardsCompatibility()
   if has_key( g:, 'ycm_filetypes_to_completely_ignore' )
     let g:filetype_blacklist =  g:ycm_filetypes_to_completely_ignore
   endif
-endfunction
-
-
-" Needed so that YCM is used instead of Syntastic
-function! s:TurnOffSyntasticForCFamily()
-  let g:syntastic_cpp_checkers = []
-  let g:syntastic_c_checkers = []
-  let g:syntastic_objc_checkers = []
-  let g:syntastic_objcpp_checkers = []
 endfunction
 
 

--- a/python/ycm/client/messages_request.py
+++ b/python/ycm/client/messages_request.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2017 YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from ycm.vimsupport import PostVimMessage
+
+from ycm.client.base_request import ( BaseRequest, BuildRequestData,
+                                      JsonFromFuture, HandleServerException )
+
+import logging
+
+_logger = logging.getLogger( __name__ )
+
+# Looooong poll
+TIMEOUT_SECONDS = 60
+
+
+class MessagesPoll( BaseRequest ):
+  def __init__( self ):
+    super( MessagesPoll, self ).__init__()
+    self._request_data = BuildRequestData()
+    self._response_future = None
+
+
+  def _SendRequest( self ):
+    self._response_future = self.PostDataToHandlerAsync(
+      self._request_data,
+      'receive_messages',
+      timeout = TIMEOUT_SECONDS )
+    return
+
+
+  def Poll( self, diagnostics_handler ):
+    """This should be called regularly to check for new messages in this buffer.
+    Returns True if Poll should be called again in a while. Returns False when
+    the completer or server indicated that further polling should not be done
+    for the requested file."""
+
+    if self._response_future is None:
+      # First poll
+      self._SendRequest()
+      return True
+
+    if not self._response_future.done():
+      # Nothing yet...
+      return True
+
+    with HandleServerException( display = False ):
+      response = JsonFromFuture( self._response_future )
+
+      if isinstance( response, list ):
+        for notification in response:
+          if 'message' in notification:
+            PostVimMessage( notification[ 'message' ],
+                            warning = False,
+                            truncate = True )
+          elif 'diagnostics' in notification:
+            diagnostics_handler.UpdateWithNewDiagnosticsForFile(
+              notification[ 'filepath' ],
+              notification[ 'diagnostics' ] )
+      elif response is False:
+        # Don't keep polling for this file
+        return False
+      # else any truthy response means "nothing to see here; poll again in a
+      # while"
+
+      # Start the next poll (only if the last poll didn't raise an exception)
+      self._SendRequest()
+      return True
+
+    # If there was an exception, error or anything like that (e.g. the server
+    # died), don't re-poll.
+    return False

--- a/python/ycm/diagnostic_filter.py
+++ b/python/ycm/diagnostic_filter.py
@@ -119,14 +119,29 @@ def CompileRegex( raw_regex ):
   return FilterRegex
 
 
+# ycmd can return 4 types of diagnostic kind, but YCM only knows about and
+# supports ERROR and WARNING. So we map them as follows:
+#  - ERROR       (as is)
+#  - WARNING     (as is)
+#  - INFORMATION (mapped to WARNING)
+#  - HINT        (mapped to WARNING)
+DIAGNOSTIC_KIND_TO_VIM_LEVEL = {
+  "INFORMATION": "WARNING",
+  "HINT":        "WARNING"
+}
+
+
+def DiagnosticKindToVimLevel( kind ):
+  return DIAGNOSTIC_KIND_TO_VIM_LEVEL.get( kind, kind )
+
+
 def CompileLevel( level ):
-  # valid kinds are WARNING and ERROR;
-  #  expected input levels are `warning` and `error`
+  # expected input levels are `warning` and `error`
   # NOTE: we don't validate the input...
   expected_kind = level.upper()
 
   def FilterLevel( diagnostic ):
-    return diagnostic[ 'kind' ] == expected_kind
+    return DiagnosticKindToVimLevel( diagnostic[ 'kind' ] ) == expected_kind
 
   return FilterLevel
 

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -43,7 +43,7 @@ def OmniCompleter_GetCompletions_Cache_List_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 5 ) ):
@@ -66,7 +66,7 @@ def OmniCompleter_GetCompletions_Cache_ListFilter_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.t' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
@@ -89,7 +89,7 @@ def OmniCompleter_GetCompletions_NoCache_List_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 5 ) ):
@@ -112,7 +112,7 @@ def OmniCompleter_GetCompletions_NoCache_ListFilter_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.t' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
@@ -137,7 +137,7 @@ def OmniCompleter_GetCompletions_NoCache_UseFindStart_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.t' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
@@ -162,7 +162,7 @@ def OmniCompleter_GetCompletions_Cache_UseFindStart_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.t' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
@@ -187,7 +187,7 @@ def OmniCompleter_GetCompletions_Cache_Object_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.t' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
@@ -225,7 +225,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectList_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.tt' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
@@ -269,7 +269,7 @@ def OmniCompleter_GetCompletions_NoCache_ObjectList_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.tt' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
@@ -321,7 +321,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectListObject_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.tt' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
@@ -365,7 +365,7 @@ def OmniCompleter_GetCompletions_NoCache_ObjectListObject_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'test.tt' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
@@ -404,7 +404,7 @@ def OmniCompleter_GetCompletions_Cache_List_Unicode_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ '†åsty_π.' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 12 ) ):
@@ -429,7 +429,7 @@ def OmniCompleter_GetCompletions_NoCache_List_Unicode_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ '†åsty_π.' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 12 ) ):
@@ -456,7 +456,7 @@ def OmniCompleter_GetCompletions_Cache_List_Filter_Unicode_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ '†åsty_π.ππ' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 17 ) ):
@@ -479,7 +479,7 @@ def OmniCompleter_GetCompletions_NoCache_List_Filter_Unicode_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ '†åsty_π.ππ' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 17 ) ):
@@ -519,7 +519,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectList_Unicode_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ '†åsty_π.ππ' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 17 ) ):
@@ -572,7 +572,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectListObject_Unicode_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ '†åsty_π.t' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 13 ) ):
@@ -608,7 +608,7 @@ def OmniCompleter_GetCompletions_RestoreCursorPositionAfterOmnifuncCall_test(
                               contents = [ 'String test',
                                            '',
                                            'test.' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 3, 5 ) ):
@@ -635,7 +635,7 @@ def OmniCompleter_GetCompletions_NoCache_NoSemanticTrigger_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'te' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 3 ) ):
@@ -658,7 +658,7 @@ def OmniCompleter_GetCompletions_NoCache_ForceSemantic_test( ycm ):
 
   current_buffer = VimBuffer( 'buffer',
                               contents = [ 'te' ],
-                              filetype = 'java',
+                              filetype = 'ruby',
                               omnifunc = Omnifunc )
 
   with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 3 ) ):

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -34,7 +34,7 @@ from ycm import vimsupport
 from nose.tools import eq_
 from hamcrest import assert_that, calling, contains, equal_to, has_entry, raises
 from mock import MagicMock, call, patch
-from ycmd.utils import ToBytes
+from ycmd.utils import ToBytes, ToUnicode
 import os
 import json
 
@@ -90,12 +90,13 @@ def ReplaceChunk_SingleLine_Repl_1_test():
   # Replace with longer range
   result_buffer = [ 'This is a string' ]
   start, end = _BuildLocations( 1, 1, 1, 5 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'How long',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'How long' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'How long is a string' ], result_buffer )
   eq_( line_offset, 0 )
@@ -104,12 +105,12 @@ def ReplaceChunk_SingleLine_Repl_1_test():
   # and replace again, using delta
   start, end = _BuildLocations( 1, 10, 1, 11 )
   ( new_line_offset, new_char_offset ) = vimsupport.ReplaceChunk(
-                                                          start,
-                                                          end,
-                                                          ' piece of ',
-                                                          line_offset,
-                                                          char_offset,
-                                                          result_buffer )
+    start,
+    end,
+    ToUnicode( ' piece of ' ),
+    line_offset,
+    char_offset,
+    result_buffer )
 
   line_offset += new_line_offset
   char_offset += new_char_offset
@@ -125,12 +126,12 @@ def ReplaceChunk_SingleLine_Repl_1_test():
   start, end = _BuildLocations( 1, 11, 1, 17 )
 
   ( new_line_offset, new_char_offset ) = vimsupport.ReplaceChunk(
-                                                          start,
-                                                          end,
-                                                          'pie',
-                                                          line_offset,
-                                                          char_offset,
-                                                          result_buffer )
+    start,
+    end,
+    ToUnicode( 'pie' ),
+    line_offset,
+    char_offset,
+    result_buffer )
 
   line_offset += new_line_offset
   char_offset += new_char_offset
@@ -147,12 +148,13 @@ def ReplaceChunk_SingleLine_Repl_2_test():
   # Replace with shorter range
   result_buffer = [ 'This is a string' ]
   start, end = _BuildLocations( 1, 11, 1, 17 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'test',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'test' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This is a test' ], result_buffer )
   eq_( line_offset, 0 )
@@ -163,12 +165,13 @@ def ReplaceChunk_SingleLine_Repl_3_test():
   # Replace with equal range
   result_buffer = [ 'This is a string' ]
   start, end = _BuildLocations( 1, 6, 1, 8 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'be',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'be' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This be a string' ], result_buffer )
   eq_( line_offset, 0 )
@@ -179,12 +182,13 @@ def ReplaceChunk_SingleLine_Add_1_test():
   # Insert at start
   result_buffer = [ 'is a string' ]
   start, end = _BuildLocations( 1, 1, 1, 1 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'This ',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'This ' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This is a string' ], result_buffer )
   eq_( line_offset, 0 )
@@ -195,12 +199,13 @@ def ReplaceChunk_SingleLine_Add_2_test():
   # Insert at end
   result_buffer = [ 'This is a ' ]
   start, end = _BuildLocations( 1, 11, 1, 11 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'string',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'string' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This is a string' ], result_buffer )
   eq_( line_offset, 0 )
@@ -211,12 +216,13 @@ def ReplaceChunk_SingleLine_Add_3_test():
   # Insert in the middle
   result_buffer = [ 'This is a string' ]
   start, end = _BuildLocations( 1, 8, 1, 8 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          ' not',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( ' not' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This is not a string' ], result_buffer )
   eq_( line_offset, 0 )
@@ -227,12 +233,13 @@ def ReplaceChunk_SingleLine_Del_1_test():
   # Delete from start
   result_buffer = [ 'This is a string' ]
   start, end = _BuildLocations( 1, 1, 1, 6 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          '',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'is a string' ], result_buffer )
   eq_( line_offset, 0 )
@@ -243,12 +250,13 @@ def ReplaceChunk_SingleLine_Del_2_test():
   # Delete from end
   result_buffer = [ 'This is a string' ]
   start, end = _BuildLocations( 1, 10, 1, 18 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          '',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This is a' ], result_buffer )
   eq_( line_offset, 0 )
@@ -259,12 +267,13 @@ def ReplaceChunk_SingleLine_Del_3_test():
   # Delete from middle
   result_buffer = [ 'This is not a string' ]
   start, end = _BuildLocations( 1, 9, 1, 13 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          '',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This is a string' ], result_buffer )
   eq_( line_offset, 0 )
@@ -275,12 +284,13 @@ def ReplaceChunk_SingleLine_Unicode_ReplaceUnicodeChars_test():
   # Replace Unicode characters.
   result_buffer = [ 'This Uniçø∂‰ string is in the middle' ]
   start, end = _BuildLocations( 1, 6, 1, 20 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'Unicode ',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Unicode ' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This Unicode string is in the middle' ],
                                  result_buffer )
@@ -292,12 +302,13 @@ def ReplaceChunk_SingleLine_Unicode_ReplaceAfterUnicode_test():
   # Replace ASCII characters after Unicode characters in the line.
   result_buffer = [ 'This Uniçø∂‰ string is in the middle' ]
   start, end = _BuildLocations( 1, 30, 1, 43 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'fåke',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'fåke' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'This Uniçø∂‰ string is fåke' ],
                                  result_buffer )
@@ -309,12 +320,13 @@ def ReplaceChunk_SingleLine_Unicode_Grown_test():
   # Replace ASCII characters after Unicode characters in the line.
   result_buffer = [ 'a' ]
   start, end = _BuildLocations( 1, 1, 1, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'å',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'å' ),
+    0,
+    0,
+    result_buffer )
 
   AssertBuffersAreEqualAsBytes( [ 'å' ], result_buffer )
   eq_( line_offset, 0 )
@@ -326,8 +338,13 @@ def ReplaceChunk_RemoveSingleLine_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 2, 1, 3, 1 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, '',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '' ),
+    0,
+    0,
+    result_buffer )
   # First line is not affected.
   expected_buffer = [ 'aAa',
                       'aCa' ]
@@ -341,8 +358,14 @@ def ReplaceChunk_SingleToMultipleLines_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 2, 2, 2, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'Eb\nbF',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Eb\nbF' ),
+    0,
+    0,
+    result_buffer )
+
   expected_buffer = [ 'aAa',
                       'aEb',
                       'bFBa',
@@ -354,12 +377,12 @@ def ReplaceChunk_SingleToMultipleLines_test():
   # now make another change to the "2nd" line
   start, end = _BuildLocations( 2, 3, 2, 4 )
   ( new_line_offset, new_char_offset ) = vimsupport.ReplaceChunk(
-                                                           start,
-                                                           end,
-                                                           'cccc',
-                                                           line_offset,
-                                                           char_offset,
-                                                           result_buffer )
+    start,
+    end,
+    ToUnicode( 'cccc' ),
+    line_offset,
+    char_offset,
+    result_buffer )
 
   line_offset += new_line_offset
   char_offset += new_char_offset
@@ -375,12 +398,13 @@ def ReplaceChunk_SingleToMultipleLines_test():
 def ReplaceChunk_SingleToMultipleLines2_test():
   result_buffer = [ 'aAa', 'aBa', 'aCa' ]
   start, end = _BuildLocations( 2, 2, 2, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'Eb\nbFb\nG',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Eb\nbFb\nG' ),
+    0,
+    0,
+    result_buffer )
   expected_buffer = [ 'aAa',
                       'aEb',
                       'bFb',
@@ -394,12 +418,13 @@ def ReplaceChunk_SingleToMultipleLines2_test():
 def ReplaceChunk_SingleToMultipleLines3_test():
   result_buffer = [ 'aAa', 'aBa', 'aCa' ]
   start, end = _BuildLocations( 2, 2, 2, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'Eb\nbFb\nbGb',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Eb\nbFb\nbGb' ),
+    0,
+    0,
+    result_buffer )
   expected_buffer = [ 'aAa',
                       'aEb',
                       'bFb',
@@ -413,12 +438,13 @@ def ReplaceChunk_SingleToMultipleLines3_test():
 def ReplaceChunk_SingleToMultipleLinesReplace_test():
   result_buffer = [ 'aAa', 'aBa', 'aCa' ]
   start, end = _BuildLocations( 1, 2, 1, 4 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'Eb\nbFb\nbGb',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Eb\nbFb\nbGb' ),
+    0,
+    0,
+    result_buffer )
   expected_buffer = [ 'aEb',
                       'bFb',
                       'bGb',
@@ -434,12 +460,13 @@ def ReplaceChunk_SingleToMultipleLinesReplace_2_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 1, 2, 1, 4 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'Eb\nbFb\nbGb',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Eb\nbFb\nbGb' ),
+    0,
+    0,
+    result_buffer )
   expected_buffer = [ 'aEb',
                       'bFb',
                       'bGb',
@@ -452,12 +479,12 @@ def ReplaceChunk_SingleToMultipleLinesReplace_2_test():
   # now do a subsequent change (insert at end of line "1")
   start, end = _BuildLocations( 1, 4, 1, 4 )
   ( new_line_offset, new_char_offset ) = vimsupport.ReplaceChunk(
-                                                          start,
-                                                          end,
-                                                          'cccc',
-                                                          line_offset,
-                                                          char_offset,
-                                                          result_buffer )
+    start,
+    end,
+    ToUnicode( 'cccc' ),
+    line_offset,
+    char_offset,
+    result_buffer )
 
   line_offset += new_line_offset
   char_offset += new_char_offset
@@ -475,8 +502,13 @@ def ReplaceChunk_SingleToMultipleLinesReplace_2_test():
 def ReplaceChunk_MultipleLinesToSingleLine_test():
   result_buffer = [ 'aAa', 'aBa', 'aCaaaa' ]
   start, end = _BuildLocations( 2, 2, 3, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'E',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'E' ),
+    0,
+    0,
+    result_buffer )
   expected_buffer = [ 'aAa', 'aECaaaa' ]
   AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
   eq_( line_offset, -1 )
@@ -485,12 +517,12 @@ def ReplaceChunk_MultipleLinesToSingleLine_test():
   # make another modification applying offsets
   start, end = _BuildLocations( 3, 3, 3, 4 )
   ( new_line_offset, new_char_offset ) = vimsupport.ReplaceChunk(
-                                                          start,
-                                                          end,
-                                                          'cccc',
-                                                          line_offset,
-                                                          char_offset,
-                                                          result_buffer )
+    start,
+    end,
+    ToUnicode( 'cccc' ),
+    line_offset,
+    char_offset,
+    result_buffer )
 
   line_offset += new_line_offset
   char_offset += new_char_offset
@@ -503,19 +535,19 @@ def ReplaceChunk_MultipleLinesToSingleLine_test():
   # and another, for luck
   start, end = _BuildLocations( 3, 4, 3, 5 )
   ( new_line_offset, new_char_offset ) = vimsupport.ReplaceChunk(
-                                                          start,
-                                                          end,
-                                                          'dd\ndd',
-                                                          line_offset,
-                                                          char_offset,
-                                                          result_buffer )
+    start,
+    end,
+    ToUnicode( 'dd\ndd' ),
+    line_offset,
+    char_offset,
+    result_buffer )
 
   line_offset += new_line_offset
   char_offset += new_char_offset
 
   AssertBuffersAreEqualAsBytes( [ 'aAa',
-                                   'aECccccdd',
-                                   'ddaa' ], result_buffer )
+                                  'aECccccdd',
+                                  'ddaa' ], result_buffer )
   eq_( line_offset, 0 )
   eq_( char_offset, -2 )
 
@@ -526,8 +558,13 @@ def ReplaceChunk_MultipleLinesToSameMultipleLines_test():
                     'aCa',
                     'aDe' ]
   start, end = _BuildLocations( 2, 2, 3, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'Eb\nbF',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Eb\nbF' ),
+    0,
+    0,
+    result_buffer )
   expected_buffer = [ 'aAa',
                       'aEb',
                       'bFCa',
@@ -543,12 +580,13 @@ def ReplaceChunk_MultipleLinesToMoreMultipleLines_test():
                     'aCa',
                     'aDe' ]
   start, end = _BuildLocations( 2, 2, 3, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'Eb\nbFb\nbG',
-                                                          0,
-                                                          0,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'Eb\nbFb\nbG' ),
+    0,
+    0,
+    result_buffer )
   expected_buffer = [ 'aAa',
                       'aEb',
                       'bFb',
@@ -565,8 +603,8 @@ def ReplaceChunk_MultipleLinesToLessMultipleLines_test():
                     'aCa',
                     'aDe' ]
   start, end = _BuildLocations( 1, 2, 3, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'Eb\nbF',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'Eb\nbF' ), 0, 0, result_buffer )
   expected_buffer = [ 'aEb', 'bFCa', 'aDe' ]
   AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
   eq_( line_offset, -1 )
@@ -579,8 +617,8 @@ def ReplaceChunk_MultipleLinesToEvenLessMultipleLines_test():
                     'aCa',
                     'aDe' ]
   start, end = _BuildLocations( 1, 2, 4, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'Eb\nbF',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'Eb\nbF' ), 0, 0, result_buffer )
   expected_buffer = [ 'aEb', 'bFDe' ]
   AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
   eq_( line_offset, -2 )
@@ -592,8 +630,8 @@ def ReplaceChunk_SpanBufferEdge_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 1, 1, 1, 3 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'bDb',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'bDb' ), 0, 0, result_buffer )
   expected_buffer = [ 'bDba',
                       'aBa',
                       'aCa' ]
@@ -607,8 +645,8 @@ def ReplaceChunk_DeleteTextInLine_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 2, 2, 2, 3 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, '',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( '' ), 0, 0, result_buffer )
   expected_buffer = [ 'aAa',
                       'aa',
                       'aCa' ]
@@ -622,8 +660,8 @@ def ReplaceChunk_AddTextInLine_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 2, 2, 2, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'bDb',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'bDb' ), 0, 0, result_buffer )
   expected_buffer = [ 'aAa',
                       'abDbBa',
                       'aCa' ]
@@ -637,8 +675,8 @@ def ReplaceChunk_ReplaceTextInLine_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 2, 2, 2, 3 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'bDb',
-                                                          0, 0, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'bDb' ), 0, 0, result_buffer )
   expected_buffer = [ 'aAa',
                       'abDba',
                       'aCa' ]
@@ -652,8 +690,8 @@ def ReplaceChunk_SingleLineOffsetWorks_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 1, 1, 1, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'bDb',
-                                                          1, 1, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'bDb' ), 1, 1, result_buffer )
   expected_buffer = [ 'aAa',
                       'abDba',
                       'aCa' ]
@@ -667,8 +705,8 @@ def ReplaceChunk_SingleLineToMultipleLinesOffsetWorks_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 1, 1, 1, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'Db\nE',
-                                                          1, 1, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'Db\nE' ), 1, 1, result_buffer )
   expected_buffer = [ 'aAa',
                       'aDb',
                       'Ea',
@@ -683,8 +721,8 @@ def ReplaceChunk_MultipleLinesToSingleLineOffsetWorks_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 1, 1, 2, 2 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start, end, 'bDb',
-                                                          1, 1, result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start, end, ToUnicode( 'bDb' ), 1, 1, result_buffer )
   expected_buffer = [ 'aAa',
                       'abDbCa' ]
   AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
@@ -697,12 +735,13 @@ def ReplaceChunk_MultipleLineOffsetWorks_test():
                     'aBa',
                     'aCa' ]
   start, end = _BuildLocations( 3, 1, 4, 3 )
-  ( line_offset, char_offset ) = vimsupport.ReplaceChunk( start,
-                                                          end,
-                                                          'bDb\nbEb\nbFb',
-                                                          -1,
-                                                          1,
-                                                          result_buffer )
+  ( line_offset, char_offset ) = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( 'bDb\nbEb\nbFb' ),
+    -1,
+    1,
+    result_buffer )
   expected_buffer = [ 'aAa',
                       'abDb',
                       'bEb',
@@ -710,6 +749,75 @@ def ReplaceChunk_MultipleLineOffsetWorks_test():
   AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
   eq_( line_offset, 1 )
   eq_( char_offset, 1 )
+
+
+def ReplaceChunk_SingleNewline_InsertBegin_test():
+  result_buffer = [ 'line1', 'line2', 'line3' ]
+  start, end = _BuildLocations( 1, 1, 1, 1 )
+  line_offset, char_offset = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '\n' ),
+    0,
+    0,
+    result_buffer )
+
+  expected_buffer = [ '', 'line1', 'line2', 'line3' ]
+  AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
+  eq_( line_offset, 1 )
+  eq_( char_offset, 0 )
+
+
+def ReplaceChunk_SingleNewline_InsertMiddle_test():
+  result_buffer = [ 'line1', 'line2', 'line3' ]
+  start, end = _BuildLocations( 2, 1, 2, 1 )
+  line_offset, char_offset = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '\n' ),
+    0,
+    0,
+    result_buffer )
+
+  expected_buffer = [ 'line1', '', 'line2', 'line3' ]
+  AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
+  eq_( line_offset, 1 )
+  eq_( char_offset, 0 )
+
+
+def ReplaceChunk_SingleNewline_InsertEnd_test():
+  result_buffer = [ 'line1', 'line2', 'line3' ]
+  start, end = _BuildLocations( 3, 6, 3, 6 )
+  line_offset, char_offset = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '\n' ),
+    0,
+    0,
+    result_buffer )
+
+  expected_buffer = [ 'line1', 'line2', 'line3', '' ]
+  AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
+  eq_( line_offset, 1 )
+  eq_( char_offset, -5 )
+
+
+def ReplaceChunk_SingleNewline_Replace_test():
+  result_buffer = [ 'line1', 'line2', 'line3' ]
+  start, end = _BuildLocations( 1, 1, 2, 1 )
+  line_offset, char_offset = vimsupport.ReplaceChunk(
+    start,
+    end,
+    ToUnicode( '\n' ),
+    0,
+    0,
+    result_buffer )
+
+  expected_buffer = [ '', 'line2', 'line3' ]
+  AssertBuffersAreEqualAsBytes( expected_buffer, result_buffer )
+  eq_( line_offset, 0 )
+  eq_( char_offset, 0 )
+
 
 
 def _BuildLocations( start_line, start_column, end_line, end_column ):
@@ -1257,7 +1365,7 @@ def _BuildChunk( start_line,
         'column_num': end_column,
       },
     },
-    'replacement_text': replacement_text
+    'replacement_text': ToUnicode( replacement_text )
   }
 
 

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -600,6 +600,7 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
 
     # Only the error sign is placed.
     vim_command.assert_has_exact_calls( [
+      call( 'let g:syntastic_c_checkers = []' ),
       call( 'sign place 1 name=YcmError line=3 buffer=5' ),
     ] )
 
@@ -638,6 +639,7 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
     )
 
     vim_command.assert_has_exact_calls( [
+      call( 'let g:syntastic_c_checkers = []' ),
       call( 'sign place 2 name=YcmWarning line=3 buffer=5' ),
       call( 'try | exec "sign unplace 1 buffer=5" | catch /E158/ | endtry' )
     ] )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1057,3 +1057,16 @@ def _SetUpLoadedBuffer( command, filename, fix, position, watch ):
 
   if position == 'end':
     vim.command( 'silent! normal! Gzz' )
+
+
+def DisableSyntasticForFiletype( filetype ):
+  """Forcefully disable Syntastic diagnostics for the supplied filetype."""
+  # Syntastic and YCM diagnostics conflict. Importantly, there is no mechanism
+  # in Vim to have multiple (simultaneous) location lists in a way that works
+  # for a user. YCM's diagnostics support is superior (obviously), so we disable
+  # syntastic when we're using YCM's dianostics.
+  vim.command( 'let g:syntastic_' + filetype + '_checkers = []' )
+
+
+def DisableSyntasticInCurrentBuffer():
+  vim.command( "if exists( ':SyntasticReset' ) | SyntasticReset | endif" )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -30,7 +30,7 @@ import json
 import re
 from collections import defaultdict
 from ycmd.utils import ( ByteOffsetToCodepointOffset, GetCurrentDirectory,
-                         JoinLinesAsUnicode, ToBytes, ToUnicode )
+                         JoinLinesAsUnicode, ToBytes, ToUnicode, SplitLines )
 from ycmd import user_options_store
 
 BUFFER_COMMAND_MAP = { 'same-buffer'      : 'edit',
@@ -699,7 +699,7 @@ def _OpenFileInSplitIfNeeded( filepath ):
   return ( buffer_num, True )
 
 
-def ReplaceChunks( chunks ):
+def ReplaceChunks( chunks, silent=False ):
   """Apply the source file deltas supplied in |chunks| to arbitrary files.
   |chunks| is a list of changes defined by ycmd.responses.FixItChunk,
   which may apply arbitrary modifications to arbitrary files.
@@ -720,14 +720,15 @@ def ReplaceChunks( chunks ):
   # We sort the file list simply to enable repeatable testing
   sorted_file_list = sorted( iterkeys( chunks_by_file ) )
 
-  # Make sure the user is prepared to have her screen mutilated by the new
-  # buffers
-  num_files_to_open = _GetNumNonVisibleFiles( sorted_file_list )
+  if not silent:
+    # Make sure the user is prepared to have her screen mutilated by the new
+    # buffers
+    num_files_to_open = _GetNumNonVisibleFiles( sorted_file_list )
 
-  if num_files_to_open > 0:
-    if not Confirm(
+    if num_files_to_open > 0:
+      if not Confirm(
             FIXIT_OPENING_BUFFERS_MESSAGE_FORMAT.format( num_files_to_open ) ):
-      return
+        return
 
   # Store the list of locations where we applied changes. We use this to display
   # the quickfix window showing the user where we applied changes.
@@ -754,12 +755,13 @@ def ReplaceChunks( chunks ):
       vim.command( 'hide' )
 
   # Open the quickfix list, populated with entries for each location we changed.
-  if locations:
-    SetQuickFixList( locations )
-    OpenQuickFixList()
+  if not silent:
+    if locations:
+      SetQuickFixList( locations )
+      OpenQuickFixList()
 
-  PostVimMessage( 'Applied {0} changes'.format( len( chunks ) ),
-                  warning = False )
+    PostVimMessage( 'Applied {0} changes'.format( len( chunks ) ),
+                    warning = False )
 
 
 def ReplaceChunksInBuffer( chunks, vim_buffer, locations ):
@@ -767,7 +769,9 @@ def ReplaceChunksInBuffer( chunks, vim_buffer, locations ):
   chunk's start to the list |locations|"""
 
   # We need to track the difference in length, but ensuring we apply fixes
-  # in ascending order of insertion point.
+  # in ascending order of insertion point. Note that chunks with the same start
+  # point are applied in the sequence they appear in the list (python's sort is
+  # guaranteed to be stable).
   chunks.sort( key = lambda chunk: (
     chunk[ 'range' ][ 'start' ][ 'line_num' ],
     chunk[ 'range' ][ 'start' ][ 'column_num' ]
@@ -824,7 +828,8 @@ def ReplaceChunk( start, end, replacement_text, line_delta, char_delta,
 
   # NOTE: replacement_text is unicode, but all our offsets are byte offsets,
   # so we convert to bytes
-  replacement_lines = ToBytes( replacement_text ).splitlines( False )
+  replacement_lines = [ ToBytes( l ) for l in SplitLines( ToUnicode(
+    replacement_text ) ) ]
   if not replacement_lines:
     replacement_lines = [ bytes( b'' ) ]
   replacement_lines_count = len( replacement_lines )
@@ -873,7 +878,7 @@ def InsertNamespace( namespace ):
   if line:
     existing_line = LineTextInCurrentBuffer( line )
     existing_indent = re.sub( r"\S.*", "", existing_line )
-  new_line = "{0}using {1};\n\n".format( existing_indent, namespace )
+  new_line = "{0}using {1};\n".format( existing_indent, namespace )
   replace_pos = { 'line_num': line + 1, 'column_num': 1 }
   ReplaceChunk( replace_pos, replace_pos, new_line, 0, 0, vim.current.buffer )
   PostVimMessage( 'Add namespace: {0}'.format( namespace ), warning = False )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -412,6 +412,14 @@ class YouCompleteMe( object ):
     return True
 
 
+  def DisableSyntasticForCurrentBufferFiletypes( self ):
+    for filetype in vimsupport.CurrentFiletypes():
+      self._logger.info( 'Disabling syntastic for filetype: ' + filetype )
+      vimsupport.DisableSyntasticForFiletype( filetype )
+
+    vimsupport.DisableSyntasticInCurrentBuffer()
+
+
   def OnFileReadyToParse( self ):
     if not self.IsServerAlive():
       self.NotifyUserIfServerCrashed()
@@ -419,6 +427,17 @@ class YouCompleteMe( object ):
 
     if not self.IsServerReady():
       return
+
+    # TODO: The following involves a synchronous request to the server to check
+    # for the filetype completion being available in the current buffer
+    # filetype(s). This can lead to a startup lag, which is undesirable.
+    #
+    # FIXME: A solution would be to fire the completion available request
+    # asynchronously, and to just check for a response in this request and the
+    # periodic poll.
+    if ( self.DiagnosticUiSupportedForCurrentFiletype() and
+         self.NativeFiletypeCompletionUsable() ):
+      self.DisableSyntasticForCurrentBufferFiletypes()
 
     extra_data = {}
     self._AddTagsFilesIfNeeded( extra_data )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -124,15 +124,15 @@ class YouCompleteMe( object ):
     self._filetypes_with_keywords_loaded = set()
     self._ycmd_keepalive = YcmdKeepalive()
     self._server_is_ready_with_cache = False
-    self._SetupLogging()
-    self._SetupServer()
+    self._SetUpLogging()
+    self._SetUpServer()
     self._ycmd_keepalive.Start()
     self._complete_done_hooks = {
       'cs': lambda self: self._OnCompleteDone_Csharp()
     }
 
 
-  def _SetupServer( self ):
+  def _SetUpServer( self ):
     self._available_completers = {}
     self._user_notified_about_crash = False
     self._filetypes_with_keywords_loaded = set()
@@ -187,7 +187,7 @@ class YouCompleteMe( object ):
                                           stdout = PIPE, stderr = PIPE )
 
 
-  def _SetupLogging( self ):
+  def _SetUpLogging( self ):
     def FreeFileFromOtherProcesses( file_object ):
       if utils.OnWindows():
         from ctypes import windll
@@ -284,7 +284,7 @@ class YouCompleteMe( object ):
   def RestartServer( self ):
     vimsupport.PostVimMessage( 'Restarting ycmd server...' )
     self._ShutdownServer()
-    self._SetupServer()
+    self._SetUpServer()
 
 
   def SendCompletionRequest( self, force_semantic = False ):
@@ -686,7 +686,7 @@ class YouCompleteMe( object ):
     if '*' in filetype_to_disable:
       return False
     else:
-      return not any([ x in filetype_to_disable for x in filetypes ])
+      return not any( [ x in filetype_to_disable for x in filetypes ] )
 
 
   def ShowDetailedDiagnostic( self ):

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -33,7 +33,9 @@ import vim
 from subprocess import PIPE
 from tempfile import NamedTemporaryFile
 from ycm import base, paths, vimsupport
-from ycm.buffer import BufferDict
+from ycm.buffer import ( BufferDict,
+                         DIAGNOSTIC_UI_FILETYPES,
+                         DIAGNOSTIC_UI_ASYNC_FILETYPES )
 from ycmd import utils
 from ycmd import server_utils
 from ycmd.request_wrap import RequestWrap
@@ -51,6 +53,7 @@ from ycm.client.debug_info_request import ( SendDebugInfoRequest,
 from ycm.client.omni_completion_request import OmniCompletionRequest
 from ycm.client.event_notification import SendEventNotificationAsync
 from ycm.client.shutdown_request import SendShutdownRequest
+from ycm.client.messages_request import MessagesPoll
 
 
 def PatchNoProxy():
@@ -98,8 +101,6 @@ CORE_OUTDATED_MESSAGE = (
   'YCM core library too old; PLEASE RECOMPILE by running the install.py '
   'script. See the documentation for more details.' )
 SERVER_IDLE_SUICIDE_SECONDS = 1800  # 30 minutes
-DIAGNOSTIC_UI_FILETYPES = set( [ 'cpp', 'cs', 'c', 'objc', 'objcpp',
-                                 'typescript' ] )
 CLIENT_LOGFILE_FORMAT = 'ycm_'
 SERVER_LOGFILE_FORMAT = 'ycmd_{port}_{std}_'
 
@@ -137,6 +138,7 @@ class YouCompleteMe( object ):
     self._user_notified_about_crash = False
     self._filetypes_with_keywords_loaded = set()
     self._server_is_ready_with_cache = False
+    self._message_poll_request = None
 
     hmac_secret = os.urandom( HMAC_SECRET_LENGTH )
     options_dict = dict( self._user_options )
@@ -365,6 +367,51 @@ class YouCompleteMe( object ):
     return self.CurrentBuffer().NeedsReparse()
 
 
+  def UpdateWithNewDiagnosticsForFile( self, filepath, diagnostics ):
+    bufnr = vimsupport.GetBufferNumberForFilename( filepath )
+    if bufnr in self._buffers:
+      self._buffers[ bufnr ].UpdateWithNewDiagnostics( diagnostics )
+    else:
+      # The project contains errors in file "filepath", but that file is not
+      # open in any buffer. This happens for Language Server Protocol-based
+      # completers, as they return diagnostics for the entire "project"
+      # asynchronously (rather than per-file in the response to the parse
+      # request).
+      #
+      # There are a number of possible approaches for
+      # this, but for now we simply ignore them. Other options include:
+      # - Use the QuickFix list to report project errors?
+      # - Use a special buffer for project errors?
+      # - Put them in the location list of whatever the "current" buffer is
+      #
+      # However, none of those options are great, and lead to their own
+      # complexities. So for now, we just ignore these diagnostics for files not
+      # open in any buffer.
+      pass
+
+
+  def OnPeriodicTick( self ):
+    if not self.IsServerAlive():
+      # Server has died. We'll reset when the server is started again.
+      return False
+    elif not self.IsServerReady():
+      # Try again in a jiffy
+      return True
+
+    if not self._message_poll_request:
+      self._message_poll_request = MessagesPoll()
+
+    if not self._message_poll_request.Poll( self ):
+      # Don't poll again until some event which might change the server's mind
+      # about whether to provide messages for the current buffer (e.g. buffer
+      # visit, file ready to parse, etc.)
+      self._message_poll_request = None
+      return False
+
+    # Poll again in a jiffy
+    return True
+
+
   def OnFileReadyToParse( self ):
     if not self.IsServerAlive():
       self.NotifyUserIfServerCrashed()
@@ -537,7 +584,8 @@ class YouCompleteMe( object ):
 
 
   def DiagnosticUiSupportedForCurrentFiletype( self ):
-    return any( [ x in DIAGNOSTIC_UI_FILETYPES
+    return any( [ x in DIAGNOSTIC_UI_FILETYPES or
+                  x in DIAGNOSTIC_UI_ASYNC_FILETYPES
                   for x in vimsupport.CurrentFiletypes() ] )
 
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

[Edit: I haven't really supplied tests for this, so checking the box is a lie!]

# Why this change is necessary and useful

This is the client side implementation of the features required for Java support based on https://github.com/Valloric/ycmd/pull/857. The rationale for most of the decisions is over there.

This PR is really just to *open up discussion* and facilitate testing/feedback on https://github.com/Valloric/ycmd/pull/857.

 It is **incomplete** and **not fully tested yet**, but I thought I would get it out there to add some context to https://github.com/Valloric/ycmd/pull/857 and also to gather thoughts on some of the changes (which are nontrivial).The PR is actually multiple commits, and if anyone is going to look at the code, i'd recommend looking at it commit-wise (as they will form the individual PRs proper).

The main changes are:
 - Suport for the asynchronous message poll and asynchronous diagnostics. These use a 250ms timer that runs (roughly) constantly when a filetype that supports it is open. This has some nasties, such as - for no good reason - Vim redrawing the screen whenever a timer fires. I added Suspend/Resume for the timers for certain YCM requests, but this is only supported in a newer version of Vim :(
 - Rewriting the way we disable syntastic. This is now conditional on the native filetype available request. Note: again this is incomplete as this makes a blocking call on the first OnFileReadyToParse
 - support for post complete actions to apply FixIts for Java
 

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2827)
<!-- Reviewable:end -->