### PR TITLE
[READY] Fix error when filetype is a number

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -32,7 +32,7 @@ MockVimModule()
 
 from ycm import vimsupport
 from nose.tools import eq_
-from hamcrest import assert_that, calling, equal_to, has_entry, raises
+from hamcrest import assert_that, calling, contains, equal_to, has_entry, raises
 from mock import MagicMock, call, patch
 from ycmd.utils import ToBytes
 import os
@@ -1551,6 +1551,15 @@ def SelectFromList_Negative_test( vim_eval ):
   assert_that( calling( vimsupport.SelectFromList ).with_args( 'test',
                                                                [ 'a', 'b' ] ),
                raises( RuntimeError, vimsupport.NO_SELECTION_MADE_MSG ) )
+
+
+def Filetypes_IntegerFiletype_test():
+  current_buffer = VimBuffer( 'buffer', number = 1, filetype = '42' )
+  with MockVimBuffers( [ current_buffer ], current_buffer ):
+    assert_that( vimsupport.CurrentFiletypes(), contains( '42' ) )
+    assert_that( vimsupport.GetBufferFiletypes( 1 ), contains( '42' ) )
+    assert_that( vimsupport.FiletypesForBuffer( current_buffer ),
+                 contains( '42' ) )
 
 
 @patch( 'ycm.vimsupport.VariableExists', return_value = False )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -589,18 +589,18 @@ def EscapeForVim( text ):
 
 
 def CurrentFiletypes():
-  return VimExpressionToPythonType( "&filetype" ).split( '.' )
+  return ToUnicode( vim.eval( "&filetype" ) ).split( '.' )
 
 
 def GetBufferFiletypes( bufnr ):
   command = 'getbufvar({0}, "&ft")'.format( bufnr )
-  return VimExpressionToPythonType( command ).split( '.' )
+  return ToUnicode( vim.eval( command ) ).split( '.' )
 
 
 def FiletypesForBuffer( buffer_object ):
   # NOTE: Getting &ft for other buffers only works when the buffer has been
   # visited by the user at least once, which is true for modified buffers
-  return GetBufferOption( buffer_object, 'ft' ).split( '.' )
+  return ToUnicode( GetBufferOption( buffer_object, 'ft' ) ).split( '.' )
 
 
 def VariableExists( variable ):


### PR DESCRIPTION
When the filetype is set to a number (e.g. `set filetype=42`), YCM raises the following error:
```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\\Users\\micbou\\projects\\YouCompleteMe\\autoload\..\python\ycm\youcompleteme.py", line 571, in HandleFileParseRequest
    self.NativeFiletypeCompletionUsable() ):
  File "C:\\Users\\micbou\\projects\\YouCompleteMe\\autoload\..\python\ycm\youcompleteme.py", line 362, in NativeFiletypeCompletionUsable
    return ( self.CurrentFiletypeCompletionEnabled() and
  File "C:\\Users\\micbou\\projects\\YouCompleteMe\\autoload\..\python\ycm\youcompleteme.py", line 674, in CurrentFiletypeCompletionEnabled
    filetypes = vimsupport.CurrentFiletypes()
  File "C:\\Users\\micbou\\projects\\YouCompleteMe\\autoload\..\python\ycm\vimsupport.py", line 592, in CurrentFiletypes
    return VimExpressionToPythonType( "&filetype" ).split( '.' )
AttributeError: 'int' object has no attribute 'split'
```
This happens because `VimExpressionToPythonType` automatically converts a string representing a number to an integer and an integer cannot be split.

Closes https://github.com/Valloric/YouCompleteMe/pull/2762.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2833)
<!-- Reviewable:end -->
