### PR TITLE
[READY] Use fnameescape to escape filepath

### DIFF
--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -47,6 +47,7 @@ MATCHADD_REGEX = re.compile(
 MATCHDELETE_REGEX = re.compile( '^matchdelete\((?P<id>\d+)\)$' )
 OMNIFUNC_REGEX_FORMAT = (
   '^{omnifunc_name}\((?P<findstart>[01]),[\'"](?P<base>.*)[\'"]\)$' )
+FNAMEESCAPE_REGEX = re.compile( '^fnameescape\(\'(?P<filepath>.+)\'\)$' )
 
 # One-and only instance of mocked Vim object. The first 'import vim' that is
 # executed binds the vim module to the instance of MagicMock that is created,
@@ -210,6 +211,10 @@ def _MockVimEval( value ):
   result = _MockVimMatchEval( value )
   if result is not None:
     return result
+
+  match = FNAMEESCAPE_REGEX.search( value )
+  if match:
+    return match.group( 'filepath' )
 
   raise ValueError( 'Unexpected evaluation: {0}'.format( value ) )
 

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1606,13 +1606,6 @@ def InsertNamespace_append_test( vim_current, *args ):
   AssertBuffersAreEqualAsBytes( expected_buffer, vim_current.buffer )
 
 
-def EscapedFilepath_test():
-  eq_( vimsupport.EscapedFilepath( '/path/ with /sp ac es' ),
-       '/path/\ with\ /sp\ ac\ es' )
-  eq_( vimsupport.EscapedFilepath( ' relative path/ with / spaces ' ),
-       '\ relative\ path/\ with\ /\ spaces\ ' )
-
-
 @patch( 'ycmd.user_options_store._USER_OPTIONS',
         { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command', new_callable = ExtendedMock )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -371,8 +371,9 @@ def BufferIsUsable( buffer_object ):
   return not BufferModified( buffer_object ) or HiddenEnabled( buffer_object )
 
 
-def EscapedFilepath( filepath ):
-  return filepath.replace( ' ' , r'\ ' )
+def EscapeFilepathForVimCommand( filepath ):
+  to_eval = "fnameescape('{0}')".format( EscapeForVim( filepath ) )
+  return GetVariableValue( to_eval )
 
 
 # Both |line| and |column| need to be 1-based
@@ -422,8 +423,8 @@ def JumpToLocation( filename, line, column ):
 
     vim_command = GetVimCommand( user_command )
     try:
-      vim.command( 'keepjumps {0} {1}'.format( vim_command,
-                                               EscapedFilepath( filename ) ) )
+      escaped_filename = EscapeFilepathForVimCommand( filename )
+      vim.command( 'keepjumps {0} {1}'.format( vim_command, escaped_filename ) )
     # When the file we are trying to jump to has a swap file
     # Vim opens swap-exists-choices dialog and throws vim.error with E325 error,
     # or KeyboardInterrupt after user selects one of the options.


### PR DESCRIPTION
Spaces are not the only characters that need to be escaped when passing a filepath to a Vim command: `*`, `?`, `[`, `{`, etc. should be escaped too. Instead of escaping each one of these characters in Python, we use [the Vim function `fnameescape`](http://vimdoc.sourceforge.net/htmldoc/eval.html#fnameescape()).

Closes #2623.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2834)
<!-- Reviewable:end -->
