### PR TITLE
[READY] Normalize buffer filepath

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -158,7 +158,7 @@ def BufferIsVisible( buffer_number ):
 
 def GetBufferFilepath( buffer_object ):
   if buffer_object.name:
-    return ToUnicode( buffer_object.name )
+    return os.path.normpath( ToUnicode( buffer_object.name ) )
   # Buffers that have just been created by a command like :enew don't have any
   # buffer name so we use the buffer number for that.
   return os.path.join( GetCurrentDirectory(), str( buffer_object.number ) )


### PR DESCRIPTION
On Windows, Vim returns buffer filepaths with forward slashes instead of backward ones if [the `shellslash` option](http://vimdoc.sourceforge.net/htmldoc/options.html#'shellslash') is set. Since the server always return paths with backslashes on that platform, [the paths comparison in `JumpToLocation`](https://github.com/Valloric/YouCompleteMe/blob/e8e144d446603fbaebf23c54491f43ccd79b65f4/python/ycm/vimsupport.py#L409) will incorrectly return `True` for two equivalent paths. We need to normalize the paths from Vim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2838)
<!-- Reviewable:end -->
