### PR TITLE
[READY] Fix macOS builds on Travis

### DIFF
--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -2,6 +2,11 @@
 
 set -ev
 
+# RVM overrides the cd, popd, and pushd shell commands, causing the
+# "shell_session_update: command not found" error on macOS when executing those
+# commands.
+unset -f cd popd pushd
+
 ####################
 # OS-specific setup
 ####################


### PR DESCRIPTION
Fix the `shell_session_update: command not found` error in macOS builds on Travis by removing [the `cd`, `popd`, `pushd` functions defined by RVM](https://github.com/rvm/rvm/blob/ff63fa117bd05e581ecbf2b0378d9ddbb263deb1/scripts/cd#L14-L16). See https://github.com/travis-ci/travis-ci/issues/8703#issuecomment-347881274.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2840)
<!-- Reviewable:end -->
