### PR TITLE
[READY] Update MSBuild command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,10 +679,9 @@ process.
       Navigate to `YouCompleteMe/third_party/ycmd/third_party/OmniSharpServer`
       and run
 
-          msbuild /property:Configuration=Release /property:TargetFrameworkVersion=v4.5
+          msbuild /property:Configuration=Release /property:Platform="Any CPU" /property:TargetFrameworkVersion=v4.5
 
-      Replace `msbuild` by `xbuild` if `msbuild` is not available. On Windows,
-      be sure that [the build utility `msbuild` is in your
+      On Windows, be sure that [the build utility `msbuild` is in your
       PATH][add-msbuild-to-path].
 
     - Go support: install [Go][go-install] and add it to your path. Navigate to

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -897,11 +897,11 @@ will notify you to recompile it. You should then rerun the install process.
    - C# support: install Mono on non-Windows platforms [41]. Navigate to
      'YouCompleteMe/third_party/ycmd/third_party/OmniSharpServer' and run
 
-     msbuild /property:Configuration=Release
+     msbuild /property:Configuration=Release /property:Platform="Any CPU"
      /property:TargetFrameworkVersion=v4.5
 
-   Replace 'msbuild' by 'xbuild' if 'msbuild' is not available. On Windows,
-   be sure that the build utility 'msbuild' is in your PATH [38].
+   On Windows, be sure that the build utility 'msbuild' is in your PATH
+   [38].
 
    - Go support: install Go [27] and add it to your path. Navigate to
      'YouCompleteMe/third_party/ycmd/third_party/gocode' and run 'go


### PR DESCRIPTION
See PR https://github.com/Valloric/ycmd/pull/884. Also, remove the part where we suggest to replace `msbuild` with `xbuild` since [`xbuild` is deprecated](http://www.mono-project.com/docs/about-mono/releases/5.0.0/#xbuild).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2848)
<!-- Reviewable:end -->
