### PR TITLE
[READY] Prompt the user to select a logfile with the YcmToggleLogs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,9 +1283,15 @@ completion engine.
 
 ### The `:YcmToggleLogs` command
 
-This command opens in separate windows the logfiles given as arguments or closes
-them if they are already open in the editor. When no argument is given, list the
-available logfiles. Only for debugging purpose.
+This command presents the list of logfiles created by YCM, the [ycmd
+server][ycmd], and the semantic engine server for the current filetype, if any.
+One of these logfiles can be opened in the editor (or closed if already open) by
+entering the corresponding number or by clicking on it with the mouse.
+Additionally, this command can take the logfile names as arguments. Use the
+`<TAB>` key (or any other key defined by the `wildchar` option) to complete the
+arguments or to cycle through them (depending on the value of the `wildmode`
+option). Each logfile given as an argument is directly opened (or closed if
+already open) in the editor. Only for debugging purposes.
 
 ### The `:YcmCompleter` command
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1553,9 +1553,15 @@ semantic completion engine.
 -------------------------------------------------------------------------------
 The *:YcmToggleLogs* command
 
-This command opens in separate windows the logfiles given as arguments or
-closes them if they are already open in the editor. When no argument is given,
-list the available logfiles. Only for debugging purpose.
+This command presents the list of logfiles created by YCM, the ycmd server
+[43], and the semantic engine server for the current filetype, if any. One of
+these logfiles can be opened in the editor (or closed if already open) by
+entering the corresponding number or by clicking on it with the mouse.
+Additionally, this command can take the logfile names as arguments. Use the
+'<TAB>' key (or any other key defined by the 'wildchar' option) to complete the
+arguments or to cycle through them (depending on the value of the 'wildmode'
+option). Each logfile given as an argument is directly opened (or closed if
+already open) in the editor. Only for debugging purposes.
 
 -------------------------------------------------------------------------------
 The *:YcmCompleter* command

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -542,8 +542,8 @@ def SelectFromList( prompt, items ):
 
   |items| should not contain leading ordinals: they are added automatically.
 
-  Returns the 0-based index in the list |items| that the user selected, or a
-  negative number if no valid item was selected.
+  Returns the 0-based index in the list |items| that the user selected, or an
+  exception if no valid item was selected.
 
   See also :help inputlist()."""
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -652,9 +652,20 @@ class YouCompleteMe( object ):
   def ToggleLogs( self, *filenames ):
     logfiles = self.GetLogfiles()
     if not filenames:
-      vimsupport.PostVimMessage(
-          'Available logfiles are:\n'
-          '{0}'.format( '\n'.join( sorted( list( logfiles ) ) ) ) )
+      sorted_logfiles = sorted( list( logfiles ) )
+      try:
+        logfile_index = vimsupport.SelectFromList(
+          'Which logfile do you wish to open (or close if already open)?',
+          sorted_logfiles )
+      except RuntimeError as e:
+        vimsupport.PostVimMessage( str( e ) )
+        return
+
+      logfile = logfiles[ sorted_logfiles[ logfile_index ] ]
+      if not vimsupport.BufferIsVisibleForFilename( logfile ):
+        self._OpenLogfile( logfile )
+      else:
+        self._CloseLogfile( logfile )
       return
 
     for filename in set( filenames ):


### PR DESCRIPTION
Instead of displaying the list of available logfiles, prompt the user to open (or close if already
open) one of them when running the `:YcmToggleLogs` command with no arguments. Keep the current behavior when one or more arguments are given.

![toggle-logs-prompt](https://user-images.githubusercontent.com/10026824/34301520-39affee2-e72d-11e7-9c94-9a37beaabcce.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2860)
<!-- Reviewable:end -->
