### PR TITLE
[READY] Always supply working directory

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -28,7 +28,7 @@ import json
 from future.utils import native
 from base64 import b64decode, b64encode
 from ycm import vimsupport
-from ycmd.utils import ToBytes, urljoin, urlparse
+from ycmd.utils import ToBytes, urljoin, urlparse, GetCurrentDirectory
 from ycmd.hmac_utils import CreateRequestHmac, CreateHmac, SecureBytesEqual
 from ycmd.responses import ServerError, UnknownExtraConf
 
@@ -156,6 +156,7 @@ def BuildRequestData( filepath = None ):
   """Build request for the current buffer or the buffer corresponding to
   |filepath| if specified."""
   current_filepath = vimsupport.GetCurrentBufferFilepath()
+  working_dir = GetCurrentDirectory()
 
   if filepath and current_filepath != filepath:
     # Cursor position is irrelevant when filepath is not the current buffer.
@@ -163,6 +164,7 @@ def BuildRequestData( filepath = None ):
       'filepath': filepath,
       'line_num': 1,
       'column_num': 1,
+      'working_dir': working_dir,
       'file_data': vimsupport.GetUnsavedAndSpecifiedBufferData( filepath )
     }
 
@@ -172,6 +174,7 @@ def BuildRequestData( filepath = None ):
     'filepath': current_filepath,
     'line_num': line + 1,
     'column_num': column + 1,
+    'working_dir': working_dir,
     'file_data': vimsupport.GetUnsavedAndSpecifiedBufferData( current_filepath )
   }
 

--- a/python/ycm/tests/client/base_request_test.py
+++ b/python/ycm/tests/client/base_request_test.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2017 YouCompleteMe Contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+
+from ycm.tests.test_utils import MockVimModule
+MockVimModule()
+
+from hamcrest import assert_that, has_entry
+from mock import patch
+from ycm.client.base_request import BuildRequestData
+
+
+@patch( 'ycm.client.base_request.GetCurrentDirectory',
+        return_value = '/some/dir' )
+@patch( 'ycm.vimsupport.CurrentLineAndColumn', return_value = ( 1, 1 ) )
+def BuildRequestData_AddWorkingDir_test( *args ):
+  assert_that( BuildRequestData(), has_entry( 'working_dir', '/some/dir' ) )
+
+
+@patch( 'ycm.client.base_request.GetCurrentDirectory',
+        return_value = '/some/dir' )
+@patch( 'ycm.vimsupport.CurrentLineAndColumn', return_value = ( 1, 1 ) )
+def BuildRequestData_AddWorkingDirWithFileName_test( *args ):
+  assert_that( BuildRequestData( 'foo' ),
+               has_entry( 'working_dir', '/some/dir' ) )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -299,8 +299,6 @@ class YouCompleteMe( object ):
         self._latest_completion_request.Start()
         return
 
-    request_data[ 'working_dir' ] = utils.GetCurrentDirectory()
-
     self._AddExtraConfDataIfNeeded( request_data )
     self._latest_completion_request = CompletionRequest( request_data )
     self._latest_completion_request.Start()


### PR DESCRIPTION
This allows completer servers to detect the correct directory to launch
no matter what request initialises the completer server.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This change ensures that the client supplies the working directory to the server on each request, in particular, event notifications; the java and javascript completers use this to start the server in the `FileReadyToParse` event, rather than on construction of the completer. The subtle difference allows them to use the client's working directory, rather than the _server's_ working directory to do things like project detection.

See also:

* This is PR 1 of the set of changes related to #2827 - client changes required to support Java and other language-server protocols.
* ycmd change for javascript that makes use of this now: https://github.com/Valloric/ycmd/pull/886
* updated API doc: http://puremourning.github.io/ycmd-1

The ycmd API change is simply to allow `working_dir` on all requests.

cc for minor optional API change: @abingham @Qusic @LuckyGeck @mawww @richard1122 @jakeanq @orsonteodoro

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2861)
<!-- Reviewable:end -->
