### PR TITLE
[READY] Support for additional FixIts on java completions, e.g. for automatic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ Quick Feature Summary
 **NOTE**: Java support is currently experimental. Please let us know your
 [feedback](#contact).
 
-* Semantic auto-completion
+* Semantic auto-completion with automatic import insertion
 * Go to definition (`GoTo`, `GoToDefinition`, and `GoToDeclaration` are
   identical)
 * Reference finding (`GoToReferences`)
@@ -834,7 +834,7 @@ Quick Feature Summary
 * Renaming symbols (`RefactorRename <new name>`)
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
-* Automatically fix certain errors (`FixIt`)
+* Automatically fix certain errors including code generation  (`FixIt`)
 * Detection of java projects
 * Management of `jdt.ls` server instance
 
@@ -1184,6 +1184,9 @@ package you have in the virtual environment.
 3. If you previously used Eclim or Syntastic for Java, disable them for Java.
 
 4. Edit a Java file from your project.
+
+For the best experience, we highly recommend at least Vim 8.0.1493 when using
+Java support with YouCompleteMe.
 
 #### Java Project Files
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1074,7 +1074,7 @@ Java ~
 **NOTE**: Java support is currently experimental. Please let us know your
 feedback.
 
-- Semantic auto-completion
+- Semantic auto-completion with automatic import insertion
 - Go to definition (|GoTo|, |GoToDefinition|, and |GoToDeclaration| are
   identical)
 - Reference finding (|GoToReferences|)
@@ -1082,7 +1082,7 @@ feedback.
 - Renaming symbols ('RefactorRename <new name>')
 - View documentation comments for identifiers (|GetDoc|)
 - Type information for identifiers (|GetType|)
-- Automatically fix certain errors (|FixIt|)
+- Automatically fix certain errors including code generation (|FixIt|)
 - Detection of java projects
 - Management of 'jdt.ls' server instance
 
@@ -1453,6 +1453,9 @@ Java quick Start ~
    Java.
 
 4. Edit a Java file from your project.
+
+For the best experience, we highly recommend at least Vim 8.0.1493 when using
+Java support with YouCompleteMe.
 
 -------------------------------------------------------------------------------
                                              *youcompleteme-java-project-files*

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -69,7 +69,7 @@ class CompletionRequest( BaseRequest ):
     return response
 
 
-def ConvertCompletionDataToVimData( completion_data ):
+def ConvertCompletionDataToVimData( completion_identifier, completion_data ):
   # see :h complete-items for a description of the dictionary fields
   vim_data = {
     'word'  : '',
@@ -100,9 +100,19 @@ def ConvertCompletionDataToVimData( completion_data ):
   elif doc_string:
     vim_data[ 'info' ] = doc_string
 
+  # We store the completion item index as a string in the completion user_data.
+  # This allows us to identify the _exact_ item that was completed in the
+  # CompleteDone handler, by inspecting this item from v:completed_item
+  #
+  # We convert to string because completion user data items must be strings.
+  #
+  # Note: Not all versions of Vim support this (added in 8.0.1483), but adding
+  # the item to the dictionary is harmless in earlier Vims.
+  vim_data[ 'user_data' ] = str( completion_identifier )
+
   return vim_data
 
 
 def _ConvertCompletionDatasToVimDatas( response_data ):
-  return [ ConvertCompletionDataToVimData( x )
-           for x in response_data ]
+  return [ ConvertCompletionDataToVimData( i, x )
+           for i, x in enumerate( response_data ) ]

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -33,8 +33,9 @@ class ConvertCompletionResponseToVimDatas_test( object ):
   """ This class tests the
       completion_request._ConvertCompletionResponseToVimDatas method """
 
-  def _Check( self, completion_data, expected_vim_data ):
+  def _Check( self, completion_id, completion_data, expected_vim_data ):
     vim_data = completion_request.ConvertCompletionDataToVimData(
+        completion_id,
         completion_data )
 
     try:
@@ -48,7 +49,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
 
 
   def All_Fields_test( self ):
-    self._Check( {
+    self._Check( 0, {
       'insertion_text':  'INSERTION TEXT',
       'menu_text':       'MENU TEXT',
       'extra_menu_info': 'EXTRA MENU INFO',
@@ -58,36 +59,38 @@ class ConvertCompletionResponseToVimDatas_test( object ):
         'doc_string':    'DOC STRING',
       },
     }, {
-      'word' : 'INSERTION TEXT',
-      'abbr' : 'MENU TEXT',
-      'menu' : 'EXTRA MENU INFO',
-      'kind' : 'k',
-      'info' : 'DETAILED INFO\nDOC STRING',
-      'dup'  : 1,
-      'empty': 1,
+      'word'     : 'INSERTION TEXT',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'info'     : 'DETAILED INFO\nDOC STRING',
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': '0',
     } )
 
 
   def Just_Detailed_Info_test( self ):
-    self._Check( {
+    self._Check( 9999999999, {
       'insertion_text':  'INSERTION TEXT',
       'menu_text':       'MENU TEXT',
       'extra_menu_info': 'EXTRA MENU INFO',
       'kind':            'K',
       'detailed_info':   'DETAILED INFO',
     }, {
-      'word' : 'INSERTION TEXT',
-      'abbr' : 'MENU TEXT',
-      'menu' : 'EXTRA MENU INFO',
-      'kind' : 'k',
-      'info' : 'DETAILED INFO',
-      'dup'  : 1,
-      'empty': 1,
+      'word'     : 'INSERTION TEXT',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'info'     : 'DETAILED INFO',
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': '9999999999',
     } )
 
 
   def Just_Doc_String_test( self ):
-    self._Check( {
+    self._Check( 'not_an_int', {
       'insertion_text':  'INSERTION TEXT',
       'menu_text':       'MENU TEXT',
       'extra_menu_info': 'EXTRA MENU INFO',
@@ -96,18 +99,19 @@ class ConvertCompletionResponseToVimDatas_test( object ):
         'doc_string':    'DOC STRING',
       },
     }, {
-      'word' : 'INSERTION TEXT',
-      'abbr' : 'MENU TEXT',
-      'menu' : 'EXTRA MENU INFO',
-      'kind' : 'k',
-      'info' : 'DOC STRING',
-      'dup'  : 1,
-      'empty': 1,
+      'word'     : 'INSERTION TEXT',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'info'     : 'DOC STRING',
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': 'not_an_int',
     } )
 
 
   def Extra_Info_No_Doc_String_test( self ):
-    self._Check( {
+    self._Check( 0, {
       'insertion_text':  'INSERTION TEXT',
       'menu_text':       'MENU TEXT',
       'extra_menu_info': 'EXTRA MENU INFO',
@@ -115,17 +119,18 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'extra_data': {
       },
     }, {
-      'word' : 'INSERTION TEXT',
-      'abbr' : 'MENU TEXT',
-      'menu' : 'EXTRA MENU INFO',
-      'kind' : 'k',
-      'dup'  : 1,
-      'empty': 1,
+      'word'     : 'INSERTION TEXT',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': '0',
     } )
 
 
   def Extra_Info_No_Doc_String_With_Detailed_Info_test( self ):
-    self._Check( {
+    self._Check( '0', {
       'insertion_text':  'INSERTION TEXT',
       'menu_text':       'MENU TEXT',
       'extra_menu_info': 'EXTRA MENU INFO',
@@ -134,18 +139,19 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'extra_data': {
       },
     }, {
-      'word' : 'INSERTION TEXT',
-      'abbr' : 'MENU TEXT',
-      'menu' : 'EXTRA MENU INFO',
-      'kind' : 'k',
-      'info' : 'DETAILED INFO',
-      'dup'  : 1,
-      'empty': 1,
+      'word'     : 'INSERTION TEXT',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'info'     : 'DETAILED INFO',
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': '0',
     } )
 
 
   def Empty_Insertion_Text_test( self ):
-    self._Check( {
+    self._Check( 0, {
       'insertion_text':  '',
       'menu_text':       'MENU TEXT',
       'extra_menu_info': 'EXTRA MENU INFO',
@@ -155,18 +161,19 @@ class ConvertCompletionResponseToVimDatas_test( object ):
         'doc_string':    'DOC STRING',
       },
     }, {
-      'word' : '',
-      'abbr' : 'MENU TEXT',
-      'menu' : 'EXTRA MENU INFO',
-      'kind' : 'k',
-      'info' : 'DETAILED INFO\nDOC STRING',
-      'dup'  : 1,
-      'empty': 1,
+      'word'     : '',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'info'     : 'DETAILED INFO\nDOC STRING',
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': '0',
     } )
 
 
   def No_Insertion_Text_test( self ):
-    self._Check( {
+    self._Check( 0, {
       'menu_text':       'MENU TEXT',
       'extra_menu_info': 'EXTRA MENU INFO',
       'kind':            'K',
@@ -175,11 +182,12 @@ class ConvertCompletionResponseToVimDatas_test( object ):
         'doc_string':    'DOC STRING',
       },
     }, {
-      'word' : '',
-      'abbr' : 'MENU TEXT',
-      'menu' : 'EXTRA MENU INFO',
-      'kind' : 'k',
-      'info' : 'DETAILED INFO\nDOC STRING',
-      'dup'  : 1,
-      'empty': 1,
+      'word'     : '',
+      'abbr'     : 'MENU TEXT',
+      'menu'     : 'EXTRA MENU INFO',
+      'kind'     : 'k',
+      'info'     : 'DETAILED INFO\nDOC STRING',
+      'dup'      : 1,
+      'empty'    : 1,
+      'user_data': '0'
     } )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -735,7 +735,7 @@ def _OpenFileInSplitIfNeeded( filepath ):
   return ( buffer_num, True )
 
 
-def ReplaceChunks( chunks ):
+def ReplaceChunks( chunks, silent=False ):
   """Apply the source file deltas supplied in |chunks| to arbitrary files.
   |chunks| is a list of changes defined by ycmd.responses.FixItChunk,
   which may apply arbitrary modifications to arbitrary files.
@@ -755,14 +755,15 @@ def ReplaceChunks( chunks ):
   # We sort the file list simply to enable repeatable testing.
   sorted_file_list = sorted( iterkeys( chunks_by_file ) )
 
-  # Make sure the user is prepared to have her screen mutilated by the new
-  # buffers.
-  num_files_to_open = _GetNumNonVisibleFiles( sorted_file_list )
+  if not silent:
+    # Make sure the user is prepared to have her screen mutilated by the new
+    # buffers.
+    num_files_to_open = _GetNumNonVisibleFiles( sorted_file_list )
 
-  if num_files_to_open > 0:
-    if not Confirm(
+    if num_files_to_open > 0:
+      if not Confirm(
             FIXIT_OPENING_BUFFERS_MESSAGE_FORMAT.format( num_files_to_open ) ):
-      return
+        return
 
   # Store the list of locations where we applied changes. We use this to display
   # the quickfix window showing the user where we applied changes.
@@ -788,12 +789,13 @@ def ReplaceChunks( chunks ):
       vim.command( 'hide' )
 
   # Open the quickfix list, populated with entries for each location we changed.
-  if locations:
-    SetQuickFixList( locations )
-    OpenQuickFixList()
+  if not silent:
+    if locations:
+      SetQuickFixList( locations )
+      OpenQuickFixList()
 
-  PostVimMessage( 'Applied {0} changes'.format( len( chunks ) ),
-                  warning = False )
+    PostVimMessage( 'Applied {0} changes'.format( len( chunks ) ),
+                    warning = False )
 
 
 def ReplaceChunksInBuffer( chunks, vim_buffer ):


### PR DESCRIPTION
Java completer can include FixIts which are applied when a completion
entry is selected. We use the existing mechanism implemented for c-sharp
to perform these edits using the CompleteDone autocommand.

However, the existing mechanism relies on pattern matching the source to
work out which item was completed. Vim patch 8.0.1493 introduces support
for user_data on completion items, so when available we populate it with
the completion array index of the item and use that to get the exact
element that was selected. This is both a lot faster and a lot more
accirate.

Of course when applying these 'FixIts' we don't interrupt the user with
confirmation or the quickfix list as this would just be annoying. If the
server reports that an edit must be made, we just make the edit.

## Use SplitLines in ReplaceChunk to allow newlines to be inserted.

The Java completer frequently inserts newlines as part of its FixIts. We
previously used the base python splitlines implementation which consumed
terminating newlines and also consumed empty strings.

We can therefore now remove the duplicate newline in InsertNamespace, as
this was only to work around the splitlines behaviour.

In the tests, be clear that replacement_text in ReplaceChunks is Unicode

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [X] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Automatic addition of import statements is a highly desirable feature when working with languages like java where it is idiomatic to literally import everything by name. Users expect this function: it was the first question I got when i put java live at work. 

I was at first reticent to include it due to the irksome complete_done interface, but since Bram merged my PR: https://github.com/vim/vim/commit/9b56a57cdae31f7a2c85d440392bf63d3253a158 we can now identify the exact completion selected which makes this a _lot_ more robust.

We can't just remove the old code as nobody will actually have that version yet, but I have tested before and after and it is fully backwardly compatible.

# Test case

A simple way to verify this is with the ycmd tests:

* open `third_party/ycmd/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/TestFactory.java`
* Invoke completion for `CUTHBERT` on line 19 (replace to end of line)
* select one of the enum values

You should get the enum value automatically imported at the top of the file.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2907)
<!-- Reviewable:end -->
