### PR TITLE
[READY] Test for Python 3.6 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ environment:
   COVERAGE: true
   matrix:
   - arch: 32
-    python: 35
+    python: 36
   # We only test Python 2.7 on 64 bits.
   - arch: 64
     python: 27
   - arch: 64
-    python: 35
+    python: 36
 install:
   - ci\appveyor\appveyor_install.bat
 build_script:


### PR DESCRIPTION
We should always test for the latest version of Python on AppVeyor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2908)
<!-- Reviewable:end -->
