### PR TITLE
[READY] Replace <range> with <count> in YcmCompleter command

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -821,7 +821,7 @@ function! s:SetUpCommands()
   command! -nargs=* -complete=custom,youcompleteme#LogsComplete
         \ YcmToggleLogs call s:ToggleLogs(<f-args>)
   command! -nargs=* -complete=custom,youcompleteme#SubCommandsComplete -range
-        \ YcmCompleter call s:CompleterCommand(<range>,
+        \ YcmCompleter call s:CompleterCommand(<count>,
         \                                      <line1>,
         \                                      <line2>,
         \                                      <f-args>)
@@ -863,7 +863,7 @@ function! youcompleteme#LogsComplete( arglead, cmdline, cursorpos )
 endfunction
 
 
-function! s:CompleterCommand( range, line1, line2, ... )
+function! s:CompleterCommand( count, line1, line2, ... )
   " CompleterCommand will call the OnUserCommand function of a completer. If
   " the first arguments is of the form "ft=..." it can be used to specify the
   " completer to use (for example "ft=cpp"). Else the native filetype completer
@@ -884,7 +884,7 @@ function! s:CompleterCommand( range, line1, line2, ... )
   exec s:python_command "ycm_state.SendCommandRequest(" .
         \ "vim.eval( 'l:arguments' )," .
         \ "vim.eval( 'l:completer' )," .
-        \ "vimsupport.GetBoolValue( 'a:range' )," .
+        \ "vimsupport.GetBoolValue( 'a:count != -1' )," .
         \ "vimsupport.GetIntValue( 'a:line1' )," .
         \ "vimsupport.GetIntValue( 'a:line2' ) )"
 endfunction


### PR DESCRIPTION
[`<range>` was introduced in Vim 8.0.1089](https://github.com/vim/vim/commit/c168bd4bd3a9b856fc410fc4515dcca1d10d7461). Use `<count>` instead.  It returns `-1` when no range is given.

Fixes #2913.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2914)
<!-- Reviewable:end -->
