### PR TITLE
[READY] Improve diagnostic matches display

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -136,6 +136,7 @@ function! youcompleteme#Enable()
     autocmd InsertLeave * call s:OnInsertLeave()
     autocmd VimLeave * call s:OnVimLeave()
     autocmd CompleteDone * call s:OnCompleteDone()
+    autocmd BufEnter,WinEnter * call s:UpdateMatches()
   augroup END
 
   " The FileType event is not triggered for the first loaded file. We wait until
@@ -510,6 +511,11 @@ function! s:OnBufferUnload()
   endif
 
   exec s:python_command "ycm_state.OnBufferUnload( " . buffer_number . " )"
+endfunction
+
+
+function! s:UpdateMatches()
+  exec s:python_command "ycm_state.UpdateMatches()"
 endfunction
 
 

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -80,6 +80,10 @@ class Buffer( object ):
     self._diag_interface.UpdateWithNewDiagnostics( diagnostics )
 
 
+  def UpdateMatches( self ):
+    self._diag_interface.UpdateMatches()
+
+
   def PopulateLocationList( self ):
     return self._diag_interface.PopulateLocationList()
 

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -203,9 +203,9 @@ def _MockVimMatchEval( value ):
 
   match = MATCHDELETE_REGEX.search( value )
   if match:
-    identity = int( match.group( 'id' ) )
+    match_id = int( match.group( 'id' ) )
     for index, vim_match in enumerate( VIM_MATCHES ):
-      if vim_match.id == identity:
+      if vim_match.id == match_id:
         VIM_MATCHES.pop( index )
         return -1
     return 0
@@ -421,7 +421,7 @@ class VimBuffers( object ):
 class VimMatch( object ):
 
   def __init__( self, group, pattern ):
-    self.id = len( VIM_MATCHES )
+    self.id = len( VIM_MATCHES ) + 1
     self.group = group
     self.pattern = pattern
 

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1256,32 +1256,30 @@ def _BuildChunk( start_line,
   }
 
 
-@patch( 'vim.eval', new_callable = ExtendedMock )
-def AddDiagnosticSyntaxMatch_ErrorInMiddleOfLine_test( vim_eval ):
+def GetDiagnosticMatchPattern_ErrorInMiddleOfLine_test():
   current_buffer = VimBuffer(
     'some_file',
     contents = [ 'Highlight this error please' ]
   )
 
   with patch( 'vim.current.buffer', current_buffer ):
-    vimsupport.AddDiagnosticSyntaxMatch( 1, 16, 1, 21 )
+    assert_that(
+      vimsupport.GetDiagnosticMatchPattern( 1, 16, 1, 21 ),
+      equal_to( '\%1l\%16c\_.\{-}\%1l\%21c' )
+    )
 
-  vim_eval.assert_called_once_with(
-    r"matchadd('YcmErrorSection', '\%1l\%16c\_.\{-}\%1l\%21c')" )
 
-
-@patch( 'vim.eval', new_callable = ExtendedMock )
-def AddDiagnosticSyntaxMatch_WarningAtEndOfLine_test( vim_eval ):
+def AddDiagnosticSyntaxMatch_WarningAtEndOfLine_test():
   current_buffer = VimBuffer(
     'some_file',
     contents = [ 'Highlight this warning' ]
   )
 
   with patch( 'vim.current.buffer', current_buffer ):
-    vimsupport.AddDiagnosticSyntaxMatch( 1, 16, 1, 23, is_error = False )
-
-  vim_eval.assert_called_once_with(
-    r"matchadd('YcmWarningSection', '\%1l\%16c\_.\{-}\%1l\%23c')" )
+    assert_that(
+      vimsupport.GetDiagnosticMatchPattern( 1, 16, 1, 23 ),
+      equal_to( '\%1l\%16c\_.\{-}\%1l\%23c' )
+    )
 
 
 @patch( 'vim.command', new_callable=ExtendedMock )

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -664,6 +664,25 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
     )
 
 
+@YouCompleteMeInstance( { 'enable_diagnostic_highlighting': 1 } )
+def YouCompleteMe_UpdateMatches_ClearDiagnosticMatchesInNewBuffer_test( ycm ):
+  current_buffer = VimBuffer( 'buffer',
+                              filetype = 'c',
+                              number = 5,
+                              window = 2 )
+
+  test_utils.VIM_MATCHES = [
+    VimMatch( 'YcmWarningSection', '\%3l\%5c\_.\{-}\%3l\%7c' ),
+    VimMatch( 'YcmWarningSection', '\%3l\%3c\_.\{-}\%3l\%9c' ),
+    VimMatch( 'YcmErrorSection', '\%3l\%8c' )
+  ]
+
+  with MockVimBuffers( [ current_buffer ], current_buffer ):
+    ycm.UpdateMatches()
+
+    assert_that( test_utils.VIM_MATCHES, empty() )
+
+
 @YouCompleteMeInstance( { 'echo_current_diagnostic': 1,
                           'always_populate_location_list': 1 } )
 @patch.object( ycm_buffer_module,

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -461,6 +461,10 @@ class YouCompleteMe( object ):
     SendEventNotificationAsync( 'BufferUnload', deleted_buffer_number )
 
 
+  def UpdateMatches( self ):
+    self.CurrentBuffer().UpdateMatches()
+
+
   def OnBufferVisit( self ):
     extra_data = {}
     self._AddUltiSnipsDataIfNeeded( extra_data )


### PR DESCRIPTION
There are two issues with how we display diagnostic matches. The first issue is that if the current buffer contains diagnostic matches and is split in a new window, all the matches are cleared and only matches in the new window are shown. The second issue is that if a new buffer with no diagnostic support is open in the current window and that window already contained matches then the matches are still displayed. Here's an illustration of both issues (signs are disabled):

![diagnostic-matches-issue](https://user-images.githubusercontent.com/10026824/36352338-bfeb2092-14b7-11e8-88f4-ae8cf6903304.gif)

The solution is to add an autocommand that updates matches on the `BufEnter` and `WinEnter` events. Here's the result:

![diagnostic-matches-fix](https://user-images.githubusercontent.com/10026824/36352340-c2a64a8c-14b7-11e8-8db2-4f1f54448c65.gif)

Note that it's not perfect as multiple windows of the same buffer won't be updated simultaneously. Supporting that scenario is rather tricky because we would need to go through all the windows to update the matches and switching windows can lead to a lot of issues (like interrupting visual mode) so we don't.

This PR also improves how we update matches by only displaying matches that are not already present and then clearing the remaining ones (similarly to what we do with signs; see PR https://github.com/Valloric/YouCompleteMe/pull/2915) instead of always clearing all the matches then displaying the new ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2922)
<!-- Reviewable:end -->
