### PR TITLE
[READY] Don't open the quickfix window after FixIt/Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1766,10 +1766,10 @@ manually saved. A confirmation dialog is opened prior to doing this to remind
 you that this is about to happen.
 
 Once the modifications have been made, the quickfix list (see `:help quickfix`)
-is opened and populated with the locations of all modifications. This can be
-used to review all automatic changes made. Typically, use the `CTRL-W
-<enter>` combination to open the selected file in a new split. It is possible
-to customize how the quickfix window is opened by using [the `YcmQuickFixOpened`
+is populated with the locations of all modifications. This can be used to review
+all automatic changes made by using `:copen`. Typically, use the `CTRL-W
+<enter>` combination to open the selected file in a new split. It is possible to
+customize how the quickfix window is opened by using [the `YcmQuickFixOpened`
 autocommand](#the-ycmquickfixopened-autocommand).
 
 The buffers are *not* saved automatically. That is, you must save the modified

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -719,11 +719,6 @@ def ReplaceChunks_SingleFile_Open_test( vim_command,
       'type': 'F'
     } ] ) ) ),
   ] )
-  vim_command.assert_has_exact_calls( [
-    call( 'botright copen' ),
-    call( 'silent! wincmd p' )
-  ] )
-  set_fitting_height.assert_called_once_with()
 
   # And it is ReplaceChunks that prints the message showing the number of
   # changes
@@ -817,10 +812,7 @@ def ReplaceChunks_SingleFile_NotOpen_test( vim_command,
   vim_command.assert_has_exact_calls( [
     call( 'lclose' ),
     call( 'hide' ),
-    call( 'botright copen' ),
-    call( 'silent! wincmd p' )
   ] )
-  set_fitting_height.assert_called_once_with()
 
   # And update the quickfix list
   vim_eval.assert_has_exact_calls( [
@@ -1202,10 +1194,7 @@ def ReplaceChunks_MultiFile_Open_test( vim_command,
   vim_command.assert_has_exact_calls( [
     call( 'lclose' ),
     call( 'hide' ),
-    call( 'botright copen' ),
-    call( 'silent! wincmd p' )
   ] )
-  set_fitting_height.assert_called_once_with()
 
   # And update the quickfix list with each entry
   vim_eval.assert_has_exact_calls( [

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -832,7 +832,6 @@ def ReplaceChunks( chunks, silent=False ):
   if not silent:
     if locations:
       SetQuickFixList( locations )
-      OpenQuickFixList()
 
     PostVimMessage( 'Applied {0} changes'.format( len( chunks ) ),
                     warning = False )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

When FixIt was originally implemented, I decided to present the quick fix list containing the set of changes made to the buffers as it was thought this would be helpful and would reassure the user that the changes we made to their code made sense and were safe. Some large part of this decision was paranoia.

Since then we're using fixit code in a lot more places and the feature is pretty mature. I personally find the opening of the quick fix window to be a bit of a pain, and I quickly end up closing it manually to reclaim the space. I have literally never used it to jump to a location that was changed.

I have received recent feedback from users that "Why is it when I do a FixIt, this annoying window appears at the bottom of the screen that I can't get rid of?". Most users who are unhappy with the result of a FixIt can, and do, use the undo command as a matter of habit.

So I propose to just not auto-display the quick fix window anymore for FixIts, Renames, etc. We continue to populate the quick fix list, however, so `:copen` can be used to inspect the results, for those power users that know about quick fix lists.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2926)
<!-- Reviewable:end -->
