### PR TITLE
[READY] Prefix commands with python in Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,12 +438,12 @@ support for C-family languages.
 Compiling YCM **with** semantic support for C-family languages:
 
     cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-    install.py --clang-completer
+    python install.py --clang-completer
 
 Compiling YCM **without** semantic support for C-family languages:
 
     cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-    install.py
+    python install.py
 
 The following additional language support options are available:
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -653,12 +653,12 @@ Download and install the following software:
 Compiling YCM **with** semantic support for C-family languages:
 >
   cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-  install.py --clang-completer
+  python install.py --clang-completer
 <
 Compiling YCM **without** semantic support for C-family languages:
 >
   cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
-  install.py
+  python install.py
 <
 The following additional language support options are available:
 


### PR DESCRIPTION
Arguments may be ignored when running the `install.py` script in a `cmd.exe` prompt if the command associated to Python files is incorrect. Update the Windows instructions by prefixing the commands with `python`.

Fixes #2929.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2931)
<!-- Reviewable:end -->
