### PR TITLE
[READY] Fix column clamping when highlighting diagnostics on Python 3

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1281,6 +1281,19 @@ def AddDiagnosticSyntaxMatch_WarningAtEndOfLine_test():
     )
 
 
+def AddDiagnosticSyntaxMatch_UnicodeAtEndOfLine_test():
+  current_buffer = VimBuffer(
+    'some_file',
+    contents = [ 'Highlight unicøde' ]
+  )
+
+  with patch( 'vim.current.buffer', current_buffer ):
+    assert_that(
+      vimsupport.GetDiagnosticMatchPattern( 1, 16, 1, 19 ),
+      equal_to( '\%1l\%16c\_.\{-}\%1l\%19c' )
+    )
+
+
 @patch( 'vim.command', new_callable=ExtendedMock )
 @patch( 'vim.current', new_callable=ExtendedMock)
 def WriteToPreviewWindow_test( vim_current, vim_command ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -267,7 +267,9 @@ def LineAndColumnNumbersClamped( line_num, column_num ):
   if line_num and line_num > max_line:
     new_line_num = max_line
 
-  max_column = len( vim.current.buffer[ new_line_num - 1 ] )
+  # Vim buffers are a list of byte objects on Python 2 but Unicode objects on
+  # Python 3.
+  max_column = len( ToBytes( vim.current.buffer[ new_line_num - 1 ] ) )
   if column_num and column_num > max_column:
     new_column_num = max_column
 


### PR DESCRIPTION
We need to convert the Vim buffer to bytes in the `LineAndColumnNumbersClamped` function to correctly compute the length of the line as a byte offset (and not a Unicode offset) on Python 3.

Before:

![column-clamping-before](https://user-images.githubusercontent.com/10026824/37876087-01f38dde-3048-11e8-93aa-0ce284b09b55.png)
After:

![column-clamping-after](https://user-images.githubusercontent.com/10026824/37876089-056db49e-3048-11e8-9d84-540fe67e6689.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2956)
<!-- Reviewable:end -->
