### PR TITLE
[READY] Refactor CompleteDone logic

### DIFF
--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -34,7 +34,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       completion_request._ConvertCompletionResponseToVimDatas method """
 
   def _Check( self, completion_id, completion_data, expected_vim_data ):
-    vim_data = completion_request.ConvertCompletionDataToVimData(
+    vim_data = completion_request._ConvertCompletionDataToVimData(
         completion_id,
         completion_data )
 

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 YouCompleteMe contributors
+# Copyright (C) 2016-2018 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -1039,3 +1039,22 @@ def YouCompleteMe_OnPeriodicTick_ValidResponse_test( ycm,
     mock_future.result.assert_called()
     post_data_to_handler_async.assert_called() # Poll again!
     assert_that( ycm._message_poll_request is not None )
+
+
+@YouCompleteMeInstance()
+@patch( 'ycm.client.completion_request.CompletionRequest.OnCompleteDone' )
+def YouCompleteMe_OnCompleteDone_CompletionRequest_test( ycm,
+                                                         on_complete_done ):
+  current_buffer = VimBuffer( 'current_buffer' )
+  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 1 ) ):
+    ycm.SendCompletionRequest()
+  ycm.OnCompleteDone()
+  on_complete_done.assert_called()
+
+
+@YouCompleteMeInstance()
+@patch( 'ycm.client.completion_request.CompletionRequest.OnCompleteDone' )
+def YouCompleteMe_OnCompleteDone_NoCompletionRequest_test( ycm,
+                                                           on_complete_done ):
+  ycm.OnCompleteDone()
+  on_complete_done.assert_not_called()


### PR DESCRIPTION
Since the `CompleteDone` code only depends on the completion request, it makes sense to move its logic to the `CompletionRequest` class. This is also going to help fixing the issue where a FixIt is applied twice when selecting a completion:

![completedone-bug](https://user-images.githubusercontent.com/10026824/38029281-bc09d224-3295-11e8-9976-d4dd031f2cca.gif)

Finally, this reduces the time it takes to run the tests because the ycmd server is not started anymore in the `postcomplete` tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2963)
<!-- Reviewable:end -->
