### PR TITLE
[READY] Do not disable omnifunc when filetype completion is disabled

### DIFF
--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -57,8 +57,12 @@ class OmniCompleter( Completer ):
 
 
   def ShouldUseNowInner( self, request_data ):
-    if request_data.get( 'force_semantic', False ):
+    if request_data[ 'force_semantic' ]:
       return True
+    disabled_filetypes = self.user_options[
+      'filetype_specific_completion_to_disable' ]
+    if not vimsupport.CurrentFiletypesEnabled( disabled_filetypes ):
+      return False
     return super( OmniCompleter, self ).ShouldUseNowInner( request_data )
 
 

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -675,3 +675,109 @@ def OmniCompleter_GetCompletions_NoCache_ForceSemantic_test( ycm ):
         'completion_start_column': 1
       } )
     )
+
+
+@YouCompleteMeInstance( {
+  'cache_omnifunc': 0,
+  'filetype_specific_completion_to_disable': { FILETYPE: 1 },
+  'semantic_triggers': TRIGGERS } )
+def OmniCompleter_GetCompletions_FiletypeDisabled_SemanticTrigger_test( ycm ):
+  def Omnifunc( findstart, base ):
+    if findstart:
+      return 5
+    return [ 'a', 'b', 'cdef' ]
+
+  current_buffer = VimBuffer( 'buffer',
+                              contents = [ 'test.' ],
+                              filetype = FILETYPE,
+                              omnifunc = Omnifunc )
+
+  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+    ycm.SendCompletionRequest()
+    assert_that(
+      ycm.GetCompletionResponse(),
+      has_entries( {
+        'completions': empty(),
+        'completion_start_column': 6
+      } )
+    )
+
+
+@YouCompleteMeInstance( {
+  'cache_omnifunc': 0,
+  'filetype_specific_completion_to_disable': { '*': 1 },
+  'semantic_triggers': TRIGGERS } )
+def OmniCompleter_GetCompletions_AllFiletypesDisabled_SemanticTrigger_test(
+  ycm ):
+
+  def Omnifunc( findstart, base ):
+    if findstart:
+      return 5
+    return [ 'a', 'b', 'cdef' ]
+
+  current_buffer = VimBuffer( 'buffer',
+                              contents = [ 'test.' ],
+                              filetype = FILETYPE,
+                              omnifunc = Omnifunc )
+
+  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+    ycm.SendCompletionRequest()
+    assert_that(
+      ycm.GetCompletionResponse(),
+      has_entries( {
+        'completions': empty(),
+        'completion_start_column': 6
+      } )
+    )
+
+
+@YouCompleteMeInstance( {
+  'cache_omnifunc': 0,
+  'filetype_specific_completion_to_disable': { FILETYPE: 1 },
+  'semantic_triggers': TRIGGERS } )
+def OmniCompleter_GetCompletions_FiletypeDisabled_ForceSemantic_test( ycm ):
+  def Omnifunc( findstart, base ):
+    if findstart:
+      return 5
+    return [ 'a', 'b', 'cdef' ]
+
+  current_buffer = VimBuffer( 'buffer',
+                              contents = [ 'test.' ],
+                              filetype = FILETYPE,
+                              omnifunc = Omnifunc )
+
+  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+    ycm.SendCompletionRequest( force_semantic = True )
+    assert_that(
+      ycm.GetCompletionResponse(),
+      has_entries( {
+        'completions': ToBytesOnPY2( [ 'a', 'b', 'cdef' ] ),
+        'completion_start_column': 6
+      } )
+    )
+
+
+@YouCompleteMeInstance( {
+  'cache_omnifunc': 0,
+  'filetype_specific_completion_to_disable': { '*': 1 },
+  'semantic_triggers': TRIGGERS } )
+def OmniCompleter_GetCompletions_AllFiletypesDisabled_ForceSemantic_test( ycm ):
+  def Omnifunc( findstart, base ):
+    if findstart:
+      return 5
+    return [ 'a', 'b', 'cdef' ]
+
+  current_buffer = VimBuffer( 'buffer',
+                              contents = [ 'test.' ],
+                              filetype = FILETYPE,
+                              omnifunc = Omnifunc )
+
+  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+    ycm.SendCompletionRequest( force_semantic = True )
+    assert_that(
+      ycm.GetCompletionResponse(),
+      has_entries( {
+        'completions': ToBytesOnPY2( [ 'a', 'b', 'cdef' ] ),
+        'completion_start_column': 6
+      } )
+    )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -664,6 +664,15 @@ def CurrentFiletypes():
   return ToUnicode( vim.eval( "&filetype" ) ).split( '.' )
 
 
+def CurrentFiletypesEnabled( disabled_filetypes ):
+  """Return False if one of the current filetypes is disabled, True otherwise.
+  |disabled_filetypes| must be a dictionary where keys are the disabled
+  filetypes and values are unimportant. The special key '*' matches all
+  filetypes."""
+  return ( '*' not in disabled_filetypes and
+           not any( [ x in disabled_filetypes for x in CurrentFiletypes() ] ) )
+
+
 def GetBufferFiletypes( bufnr ):
   command = 'getbufvar({0}, "&ft")'.format( bufnr )
   return ToUnicode( vim.eval( command ) ).split( '.' )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -301,8 +301,7 @@ class YouCompleteMe( object ):
   def SendCompletionRequest( self, force_semantic = False ):
     request_data = BuildRequestData()
     request_data[ 'force_semantic' ] = force_semantic
-    if ( not self.NativeFiletypeCompletionAvailable() and
-         self.CurrentFiletypeCompletionEnabled() ):
+    if not self.NativeFiletypeCompletionUsable():
       wrapped_request_data = RequestWrap( request_data )
       if self._omnicomp.ShouldUseNow( wrapped_request_data ):
         self._latest_completion_request = OmniCompletionRequest(
@@ -380,7 +379,9 @@ class YouCompleteMe( object ):
 
 
   def NativeFiletypeCompletionUsable( self ):
-    return ( self.CurrentFiletypeCompletionEnabled() and
+    disabled_filetypes = self._user_options[
+      'filetype_specific_completion_to_disable' ]
+    return ( vimsupport.CurrentFiletypesEnabled( disabled_filetypes ) and
              self.NativeFiletypeCompletionAvailable() )
 
 
@@ -806,16 +807,6 @@ class YouCompleteMe( object ):
         continue
 
       self._CloseLogfile( logfile )
-
-
-  def CurrentFiletypeCompletionEnabled( self ):
-    filetypes = vimsupport.CurrentFiletypes()
-    filetype_to_disable = self._user_options[
-      'filetype_specific_completion_to_disable' ]
-    if '*' in filetype_to_disable:
-      return False
-    else:
-      return not any( [ x in filetype_to_disable for x in filetypes ] )
 
 
   def ShowDetailedDiagnostic( self ):


### PR DESCRIPTION
Prior to PR https://github.com/Valloric/YouCompleteMe/pull/2657, it was possible to trigger Vim's omnifunc with `<C-Space>` even if semantic completion was disabled for the current filetype through the `g:ycm_filetype_specific_completion_to_disable` option. It worked because `<C-Space>` was mapped to `<C-X><C-O><C-P>`, which are the keys to trigger the omnifunc. PR https://github.com/Valloric/YouCompleteMe/pull/2657 changed that by making `<C-Space>` directly call the `SendCompletionRequest` function with `force_semantic` sets to `True`. This change was necessary to get fuzzy matching with the omnifunc (see issue https://github.com/Valloric/YouCompleteMe/issues/961) but broke the `<C-Space>` behavior when filetype completion is disabled. This PR restores that behavior.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2950.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2978)
<!-- Reviewable:end -->
