### PR TITLE
[READY] Remove Java from the GoToImplementation command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1602,7 +1602,7 @@ Looks up the symbol under the cursor and jumps to its implementation (i.e.
 non-interface). If there are multiple implementations, instead provides a list
 of implementations to choose from.
 
-Supported in filetypes: `cs, java`
+Supported in filetypes: `cs`
 
 #### The `GoToImplementationElseDeclaration` subcommand
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1898,7 +1898,7 @@ Looks up the symbol under the cursor and jumps to its implementation (i.e. non-
 interface). If there are multiple implementations, instead provides a list of
 implementations to choose from.
 
-Supported in filetypes: 'cs, java'
+Supported in filetypes: 'cs'
 
 -------------------------------------------------------------------------------
 The *GoToImplementationElseDeclaration* subcommand


### PR DESCRIPTION
The Java completer does not provide a `GoToImplementation` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2980)
<!-- Reviewable:end -->
