### PR TITLE
[READY] Resend request when extra conf is loaded or ignored

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -565,6 +565,9 @@ function! s:PollFileParseResponse( ... )
   endif
 
   exec s:python_command "ycm_state.HandleFileParseRequest()"
+  if s:Pyeval( "ycm_state.ShouldResendFileParseRequest()" )
+    call s:OnFileReadyToParse( 1 )
+  endif
 endfunction
 
 

--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -66,6 +66,10 @@ class Buffer( object ):
     return self._parse_tick != self._ChangedTick()
 
 
+  def ShouldResendParseRequest( self ):
+    return self._parse_request.ShouldResend()
+
+
   def UpdateDiagnostics( self, force=False ):
     if force or not self._async_diags:
       self.UpdateWithNewDiagnostics( self._parse_request.Response() )

--- a/python/ycm/client/ycmd_keepalive.py
+++ b/python/ycm/client/ycmd_keepalive.py
@@ -45,4 +45,4 @@ class YcmdKeepalive( object ):
     while True:
       time.sleep( self._ping_interval_seconds )
 
-      BaseRequest.GetDataFromHandler( 'healthy', display_message = False )
+      BaseRequest().GetDataFromHandler( 'healthy', display_message = False )

--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -128,6 +128,6 @@ class OmniCompleter( Completer ):
       'query': query
     }
 
-    response = BaseRequest.PostDataToHandler( request_data,
-                                              'filter_and_sort_candidates' )
+    response = BaseRequest().PostDataToHandler( request_data,
+                                                'filter_and_sort_candidates' )
     return response if response is not None else []

--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -64,7 +64,7 @@ def MakeUserOptions( custom_options = {} ):
 
 
 def _IsReady():
-  return BaseRequest.GetDataFromHandler( 'ready' )
+  return BaseRequest().GetDataFromHandler( 'ready' )
 
 
 def WaitUntilReady( timeout = 5 ):

--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -125,6 +125,8 @@ def EventNotification_FileReadyToParse_NonDiagnostic_Error_test(
         call( ERROR_TEXT, truncate = True )
       ] )
 
+      ok_( not ycm.ShouldResendFileParseRequest() )
+
       # But it does if a subsequent event raises again
       ycm.OnFileReadyToParse()
       ok_( ycm.FileParseRequestReady() )
@@ -133,6 +135,8 @@ def EventNotification_FileReadyToParse_NonDiagnostic_Error_test(
         call( ERROR_TEXT, truncate = True ),
         call( ERROR_TEXT, truncate = True )
       ] )
+
+      ok_( not ycm.ShouldResendFileParseRequest() )
 
 
 @YouCompleteMeInstance()
@@ -154,20 +158,16 @@ def EventNotification_FileReadyToParse_NonDiagnostic_Error_NonNative_test(
         test_utils.VIM_SIGNS,
         contains()
       )
+      ok_( not ycm.ShouldResendFileParseRequest() )
 
 
-@patch( 'ycm.client.base_request._LoadExtraConfFile',
-        new_callable = ExtendedMock )
-@patch( 'ycm.client.base_request._IgnoreExtraConfFile',
-        new_callable = ExtendedMock )
 @YouCompleteMeInstance()
 def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
-    ycm, ignore_extra_conf, load_extra_conf ):
+    ycm ):
 
   # This test validates the behaviour of YouCompleteMe.HandleFileParseRequest
   # in combination with YouCompleteMe.OnFileReadyToParse when the completer
   # raises the (special) UnknownExtraConf exception
-
   FILE_NAME = 'a_file'
   MESSAGE = ( 'Found ' + FILE_NAME + '. Load? \n\n(Question can be '
               'turned off with options, see YCM docs)' )
@@ -175,86 +175,98 @@ def EventNotification_FileReadyToParse_NonDiagnostic_ConfirmExtraConf_test(
   def UnknownExtraConfResponse( *args ):
     raise UnknownExtraConf( FILE_NAME )
 
-  with MockArbitraryBuffer( 'javascript' ):
-    with MockEventNotification( UnknownExtraConfResponse ):
+  with patch( 'ycm.client.base_request.BaseRequest.PostDataToHandler',
+              new_callable = ExtendedMock ) as post_data_to_handler:
+    with MockArbitraryBuffer( 'javascript' ):
+      with MockEventNotification( UnknownExtraConfResponse ):
 
-      # When the user accepts the extra conf, we load it
-      with patch( 'ycm.vimsupport.PresentDialog',
-                  return_value = 0,
-                  new_callable = ExtendedMock ) as present_dialog:
-        ycm.OnFileReadyToParse()
-        ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+        # When the user accepts the extra conf, we load it
+        with patch( 'ycm.vimsupport.PresentDialog',
+                    return_value = 0,
+                    new_callable = ExtendedMock ) as present_dialog:
+          ycm.OnFileReadyToParse()
+          ok_( ycm.FileParseRequestReady() )
+          ycm.HandleFileParseRequest()
 
-        present_dialog.assert_has_exact_calls( [
-          PresentDialog_Confirm_Call( MESSAGE ),
-        ] )
-        load_extra_conf.assert_has_exact_calls( [
-          call( FILE_NAME ),
-        ] )
+          present_dialog.assert_has_exact_calls( [
+            PresentDialog_Confirm_Call( MESSAGE ),
+          ] )
+          post_data_to_handler.assert_has_exact_calls( [
+            call( { 'filepath': FILE_NAME }, 'load_extra_conf_file' )
+          ] )
 
-        # Subsequent calls don't re-raise the warning
-        ycm.HandleFileParseRequest()
+          # Subsequent calls don't re-raise the warning
+          ycm.HandleFileParseRequest()
 
-        present_dialog.assert_has_exact_calls( [
-          PresentDialog_Confirm_Call( MESSAGE )
-        ] )
-        load_extra_conf.assert_has_exact_calls( [
-          call( FILE_NAME ),
-        ] )
+          present_dialog.assert_has_exact_calls( [
+            PresentDialog_Confirm_Call( MESSAGE )
+          ] )
+          post_data_to_handler.assert_has_exact_calls( [
+            call( { 'filepath': FILE_NAME }, 'load_extra_conf_file' )
+          ] )
 
-        # But it does if a subsequent event raises again
-        ycm.OnFileReadyToParse()
-        ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+          ok_( ycm.ShouldResendFileParseRequest() )
 
-        present_dialog.assert_has_exact_calls( [
-          PresentDialog_Confirm_Call( MESSAGE ),
-          PresentDialog_Confirm_Call( MESSAGE ),
-        ] )
-        load_extra_conf.assert_has_exact_calls( [
-          call( FILE_NAME ),
-          call( FILE_NAME ),
-        ] )
+          # But it does if a subsequent event raises again
+          ycm.OnFileReadyToParse()
+          ok_( ycm.FileParseRequestReady() )
+          ycm.HandleFileParseRequest()
 
-      # When the user rejects the extra conf, we reject it
-      with patch( 'ycm.vimsupport.PresentDialog',
-                  return_value = 1,
-                  new_callable = ExtendedMock ) as present_dialog:
-        ycm.OnFileReadyToParse()
-        ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+          present_dialog.assert_has_exact_calls( [
+            PresentDialog_Confirm_Call( MESSAGE ),
+            PresentDialog_Confirm_Call( MESSAGE ),
+          ] )
+          post_data_to_handler.assert_has_exact_calls( [
+            call( { 'filepath': FILE_NAME }, 'load_extra_conf_file' ),
+            call( { 'filepath': FILE_NAME }, 'load_extra_conf_file' )
+          ] )
 
-        present_dialog.assert_has_exact_calls( [
-          PresentDialog_Confirm_Call( MESSAGE ),
-        ] )
-        ignore_extra_conf.assert_has_exact_calls( [
-          call( FILE_NAME ),
-        ] )
+          ok_( ycm.ShouldResendFileParseRequest() )
 
-        # Subsequent calls don't re-raise the warning
-        ycm.HandleFileParseRequest()
+        post_data_to_handler.reset_mock()
 
-        present_dialog.assert_has_exact_calls( [
-          PresentDialog_Confirm_Call( MESSAGE )
-        ] )
-        ignore_extra_conf.assert_has_exact_calls( [
-          call( FILE_NAME ),
-        ] )
+        # When the user rejects the extra conf, we reject it
+        with patch( 'ycm.vimsupport.PresentDialog',
+                    return_value = 1,
+                    new_callable = ExtendedMock ) as present_dialog:
+          ycm.OnFileReadyToParse()
+          ok_( ycm.FileParseRequestReady() )
+          ycm.HandleFileParseRequest()
 
-        # But it does if a subsequent event raises again
-        ycm.OnFileReadyToParse()
-        ok_( ycm.FileParseRequestReady() )
-        ycm.HandleFileParseRequest()
+          present_dialog.assert_has_exact_calls( [
+            PresentDialog_Confirm_Call( MESSAGE ),
+          ] )
+          post_data_to_handler.assert_has_exact_calls( [
+            call( { 'filepath': FILE_NAME }, 'ignore_extra_conf_file' )
+          ] )
 
-        present_dialog.assert_has_exact_calls( [
-          PresentDialog_Confirm_Call( MESSAGE ),
-          PresentDialog_Confirm_Call( MESSAGE ),
-        ] )
-        ignore_extra_conf.assert_has_exact_calls( [
-          call( FILE_NAME ),
-          call( FILE_NAME ),
-        ] )
+          # Subsequent calls don't re-raise the warning
+          ycm.HandleFileParseRequest()
+
+          present_dialog.assert_has_exact_calls( [
+            PresentDialog_Confirm_Call( MESSAGE )
+          ] )
+          post_data_to_handler.assert_has_exact_calls( [
+            call( { 'filepath': FILE_NAME }, 'ignore_extra_conf_file' )
+          ] )
+
+          ok_( ycm.ShouldResendFileParseRequest() )
+
+          # But it does if a subsequent event raises again
+          ycm.OnFileReadyToParse()
+          ok_( ycm.FileParseRequestReady() )
+          ycm.HandleFileParseRequest()
+
+          present_dialog.assert_has_exact_calls( [
+            PresentDialog_Confirm_Call( MESSAGE ),
+            PresentDialog_Confirm_Call( MESSAGE ),
+          ] )
+          post_data_to_handler.assert_has_exact_calls( [
+            call( { 'filepath': FILE_NAME }, 'ignore_extra_conf_file' ),
+            call( { 'filepath': FILE_NAME }, 'ignore_extra_conf_file' )
+          ] )
+
+          ok_( ycm.ShouldResendFileParseRequest() )
 
 
 @YouCompleteMeInstance()
@@ -302,6 +314,8 @@ def _Check_FileReadyToParse_Diagnostic_Error( ycm ):
       eq_( ycm.GetErrorCount(), 1 )
       eq_( ycm.GetWarningCount(), 0 )
 
+      ok_( not ycm.ShouldResendFileParseRequest() )
+
       # New identical requests should result in the same diagnostics.
       ycm.OnFileReadyToParse()
       ok_( ycm.FileParseRequestReady() )
@@ -314,6 +328,8 @@ def _Check_FileReadyToParse_Diagnostic_Error( ycm ):
       )
       eq_( ycm.GetErrorCount(), 1 )
       eq_( ycm.GetWarningCount(), 0 )
+
+      ok_( not ycm.ShouldResendFileParseRequest() )
 
 
 def _Check_FileReadyToParse_Diagnostic_Warning( ycm ):
@@ -353,6 +369,8 @@ def _Check_FileReadyToParse_Diagnostic_Warning( ycm ):
       eq_( ycm.GetErrorCount(), 0 )
       eq_( ycm.GetWarningCount(), 1 )
 
+      ok_( not ycm.ShouldResendFileParseRequest() )
+
 
 def _Check_FileReadyToParse_Diagnostic_Clean( ycm ):
   # Tests Vim sign unplacement and error/warning count python API
@@ -368,6 +386,7 @@ def _Check_FileReadyToParse_Diagnostic_Clean( ycm ):
       )
       eq_( ycm.GetErrorCount(), 0 )
       eq_( ycm.GetWarningCount(), 0 )
+      ok_( not ycm.ShouldResendFileParseRequest() )
 
 
 @patch( 'ycm.youcompleteme.YouCompleteMe._AddUltiSnipsDataIfNeeded' )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -228,7 +228,7 @@ class YouCompleteMe( object ):
 
   def CheckIfServerIsReady( self ):
     if not self._server_is_ready_with_cache and self.IsServerAlive():
-      self._server_is_ready_with_cache = BaseRequest.GetDataFromHandler(
+      self._server_is_ready_with_cache = BaseRequest().GetDataFromHandler(
           'ready', display_message = False )
     return self._server_is_ready_with_cache
 
@@ -329,8 +329,8 @@ class YouCompleteMe( object ):
 
 
   def GetDefinedSubcommands( self ):
-    subcommands = BaseRequest.PostDataToHandler( BuildRequestData(),
-                                                 'defined_subcommands' )
+    subcommands = BaseRequest().PostDataToHandler( BuildRequestData(),
+                                                   'defined_subcommands' )
     return subcommands if subcommands else []
 
 
@@ -555,6 +555,10 @@ class YouCompleteMe( object ):
       current_buffer.MarkResponseHandled()
 
 
+  def ShouldResendFileParseRequest( self ):
+    return self.CurrentBuffer().ShouldResendParseRequest()
+
+
   def DebugInfo( self ):
     debug_info = ''
     if self._client_logfile:
@@ -644,7 +648,7 @@ class YouCompleteMe( object ):
 
 
   def ShowDetailedDiagnostic( self ):
-    detailed_diagnostic = BaseRequest.PostDataToHandler(
+    detailed_diagnostic = BaseRequest().PostDataToHandler(
         BuildRequestData(), 'detailed_diagnostic' )
 
     if 'message' in detailed_diagnostic:


### PR DESCRIPTION
When the client sends a request to the server, if an extra conf file is found that is not already white/blacklisted, the server stops processing the request and tells the client that an unknown extra conf file has been found. The client then asks the user if that file should be loaded or not. Depending on the
user's answer, the client sends a request to the server to load or ignore the extra conf file. Finally, the server loads the file or adds it to the blacklist. However, the initial request was not processed by the server and should be sent again.

Here's a demo illustrating the current situation:

![extra-conf-request-not-resent](https://user-images.githubusercontent.com/10026824/38840090-2d700936-41de-11e8-8b76-87c3eab960cc.gif)

As you can see, the file is not parsed after loading the extra conf file. With the proposed changes:

![extra-conf-request-resent](https://user-images.githubusercontent.com/10026824/38840137-67126670-41de-11e8-8707-88441ab35ac3.gif)

Fixes #2962.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2988)
<!-- Reviewable:end -->
