### PR TITLE
[READY] Do not return omnifunc suggestions if server crashed

### DIFF
--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -130,4 +130,4 @@ class OmniCompleter( Completer ):
 
     response = BaseRequest.PostDataToHandler( request_data,
                                               'filter_and_sort_candidates' )
-    return response if response is not None else candidates
+    return response if response is not None else []


### PR DESCRIPTION
We currently return unfiltered and unsorted suggestions from the omnifunc if the `filter_and_sort_candidates` request failed (generally because the server crashed). This behavior is confusing as it may let the user thinks that YCM is working (in a bad way) while in fact it doesn't. No suggestions should be returned in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2989)
<!-- Reviewable:end -->
