### PR TITLE
use rogpeppe/godef instead of Manishearth/godef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Nodejs
+package-lock.json
+node_modules
+
 # Compiled Object files
 *.slo
 *.lo
@@ -22,6 +26,7 @@ install_manifest.txt
 
 # Python
 *.py[cod]
+.ropeproject
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -3366,7 +3366,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [Bear]: https://github.com/rizsotto/Bear
 [ygen]: https://github.com/rdnetto/YCM-Generator
 [Gocode]: https://github.com/nsf/gocode
-[Godef]: https://github.com/Manishearth/godef
+[Godef]: https://github.com/rogpeppe/godef
 [TSServer]: https://github.com/Microsoft/TypeScript/tree/master/src/server
 [vim-win-download]: https://bintray.com/micbou/generic/vim
 [python-win-download]: https://www.python.org/downloads/windows/

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3648,7 +3648,7 @@ References ~
 [13] https://github.com/vheon/JediHTTP
 [14] https://github.com/OmniSharp/omnisharp-server
 [15] https://github.com/nsf/gocode
-[16] https://github.com/Manishearth/godef
+[16] https://github.com/rogpeppe/godef
 [17] https://github.com/Microsoft/TypeScript/tree/master/src/server
 [18] http://ternjs.net
 [19] https://github.com/phildawes/racer


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Manishearth/godef](https://github.com/Manishearth/godef) contains bug which have been fixed in [upstream](https://github.com/rogpeppe/godef), and is unmaintained for over a year now.

To be specific, the forked godef cannot jump to the go vendor directory, while the upstream version work as expected:

```shell
$  godef -debug -f=/Users/timfeirg/gocode/src/golang.guazi-corp.com/medusa/saber/config/config.go -json -o=1314
2018/04/20 16:48:23 exprType tuple:false pkg: *ast.SelectorExpr viper.SetConfigName [
2018/04/20 16:48:23 exprType tuple:false pkg: *ast.Ident viper [
2018/04/20 16:48:23 exprType tuple:false pkg: *ast.ImportSpec "github.com/spf13/viper" [
2018/04/20 16:48:23 ] -> 0x0, Type{package "" *ast.ImportSpec "github.com/spf13/viper"}
2018/04/20 16:48:23 ] -> 0xc420202280, Type{package "" *ast.ImportSpec "github.com/spf13/viper"}
2018/04/20 16:48:23 member Type{package "" *ast.ImportSpec "github.com/spf13/viper"} 'SetConfigName' {
2018/04/20 16:48:23 } -> &{func SetConfigName 0xc420152ed0 <nil> <nil>}
2018/04/20 16:48:23 exprType tuple:false pkg: *ast.Ident SetConfigName [
2018/04/20 16:48:23 exprType tuple:false pkg: *ast.FuncType func(in string) [
2018/04/20 16:48:23 ] -> 0x0, Type{type "" *ast.FuncType func(in string)}
2018/04/20 16:48:23 ] -> 0xc420154320, Type{func "" *ast.FuncType func(in string)}
2018/04/20 16:48:23 ] -> 0xc420154320, Type{func "github.com/spf13/viper" *ast.FuncType func(in string)}
{"filename":"/Users/timfeirg/gocode/src/golang.guazi-corp.com/medusa/saber/vendor/github.com/spf13/viper/viper.go","line":1686,"column":6}

$  ~/.nvim/plugged/YouCompleteMe/third_party/ycmd/third_party/godef/godef -debug -f=/Users/timfeirg/gocode/src/golang.guazi-corp.com/medusa/saber/config/config.go -json -o=1314
2018/04/20 16:49:10 exprType tuple:false pkg: *ast.SelectorExpr viper.SetConfigName [
2018/04/20 16:49:10 exprType tuple:false pkg: *ast.Ident viper [
2018/04/20 16:49:10 exprType tuple:false pkg: *ast.ImportSpec "github.com/spf13/viper" [
2018/04/20 16:49:10 ] -> 0x0, Type{package "" *ast.ImportSpec "github.com/spf13/viper"}
2018/04/20 16:49:10 ] -> 0xc42000f450, Type{package "" *ast.ImportSpec "github.com/spf13/viper"}
2018/04/20 16:49:10 member Type{package "" *ast.ImportSpec "github.com/spf13/viper"} 'SetConfigName' {
2018/04/20 16:49:10 } -> &{func SetConfigName 0xc4201c1f80 <nil> <nil>}
2018/04/20 16:49:10 exprType tuple:false pkg: *ast.Ident SetConfigName [
2018/04/20 16:49:10 exprType tuple:false pkg: *ast.FuncType func(in string) [
2018/04/20 16:49:10 ] -> 0x0, Type{type "" *ast.FuncType func(in string)}
2018/04/20 16:49:10 ] -> 0xc4201bf5e0, Type{func "" *ast.FuncType func(in string)}
2018/04/20 16:49:10 ] -> 0xc4201bf5e0, Type{func "github.com/spf13/viper" *ast.FuncType func(in string)}
{"column":"6","filename":"/Users/timfeirg/gocode/src/github.com/spf13/viper/viper.go","line":"1686"}
```

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

I'll provide actual golang examples that'll reproduce this bug if that's required.

I'll create the corresponding PR to ycmd if this PR is approved.

I think this PR closes https://github.com/Valloric/YouCompleteMe/issues/2985, cc @jiajunhuang

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2991)
<!-- Reviewable:end -->
