### PR TITLE
[READY] Increase Python 2 requirement to 2.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2805,7 +2805,7 @@ let g:ycm_disable_for_files_larger_than_kb = 1000
 This option specifies the Python interpreter to use to run the [jedi][]
 completion library.  Specify the Python interpreter to use to get completions.
 By default the Python under which [ycmd][] runs is used ([ycmd][] runs on
-Python 2.7 or 3.4+).
+Python 2.7.1+ or 3.4+).
 
 Default: `''`
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3061,7 +3061,7 @@ The *g:ycm_python_binary_path* option
 This option specifies the Python interpreter to use to run the jedi [12]
 completion library. Specify the Python interpreter to use to get completions.
 By default the Python under which ycmd [47] runs is used (ycmd [47] runs on
-Python 2.7 or 3.4+).
+Python 2.7.1+ or 3.4+).
 
 Default: "''"
 >

--- a/install.py
+++ b/install.py
@@ -11,11 +11,11 @@ import sys
 import os.path as p
 import glob
 
-PY_MAJOR, PY_MINOR = sys.version_info[ 0 : 2 ]
-if not ( ( PY_MAJOR == 2 and PY_MINOR >= 6 ) or
-         ( PY_MAJOR == 3 and PY_MINOR >= 3 ) or
+PY_MAJOR, PY_MINOR, PY_PATCH = sys.version_info[ 0 : 3 ]
+if not ( ( PY_MAJOR == 2 and PY_MINOR == 7 and PY_PATCH >= 1 ) or
+         ( PY_MAJOR == 3 and PY_MINOR >= 4 ) or
          PY_MAJOR > 3 ):
-  sys.exit( 'YouCompleteMe requires Python >= 2.6 or >= 3.3; '
+  sys.exit( 'YouCompleteMe requires Python >= 2.7.1 or >= 3.4; '
             'your version of Python is ' + sys.version )
 
 DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -57,7 +57,7 @@ elseif !has( 'timers' )
 elseif !has( 'python' ) && !has( 'python3' )
   echohl WarningMsg |
         \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .
-        \ "Python (2.7 or 3.4+) support." |
+        \ "Python (2.7.1+ or 3.4+) support." |
         \ echohl None
   call s:restore_cpo()
   finish


### PR DESCRIPTION
Issues https://github.com/Valloric/YouCompleteMe/issues/2525 and https://github.com/Valloric/YouCompleteMe/issues/2992 are due to YCM being incompatible with Python 2.7.0 for the reason mentioned in our Travis script:
> Tests are failing on Python 2.7.0 with the exception "TypeError: argument can't be <type 'unicode'>"

Increase the Python 2 requirement to 2.7.1.

Closes https://github.com/Valloric/YouCompleteMe/issues/2525.
Closes https://github.com/Valloric/YouCompleteMe/issues/2992.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/2998)
<!-- Reviewable:end -->
