### PR TITLE
[READY] Write table in HTML in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,12 +861,45 @@ match uppercase letters in the completion strings (the lowercase letters still
 match both). On top of that, a letter with no diacritic marks will match that
 letter with or without marks:
 
-| matches | foo | føo | fOo | fØo |
-|---------|-----|-----|-----|-----|
-| **foo** |  ✔️  |  ✔️  |  ✔️  |  ✔️  |
-| **føo** |  ❌ |  ✔️  |  ❌ |  ✔️  |
-| **fOo** |  ❌ |  ❌ |  ✔️  |  ✔️  |
-| **fØo** |  ❌ |  ❌ |  ❌ |  ✔️  |
+<table>
+<tbody>
+<tr>
+  <th>matches</th>
+  <th>foo</th>
+  <th>føo</th>
+  <th>fOo</th>
+  <th>fØo</th>
+</tr>
+<tr>
+  <th>foo</th>
+  <td>✔️</td>
+  <td>✔️</td>
+  <td>✔️</td>
+  <td>✔️</td>
+</tr>
+<tr>
+  <th>føo</th>
+  <td>❌</td>
+  <td>✔️</td>
+  <td>❌</td>
+  <td>✔️</td>
+</tr>
+<tr>
+  <th>fOo</th>
+  <td>❌</td>
+  <td>❌</td>
+  <td>✔️</td>
+  <td>✔️</td>
+</tr>
+<tr>
+  <th>fØo</th>
+  <td>❌</td>
+  <td>❌</td>
+  <td>❌</td>
+  <td>✔️</td>
+</tr>
+</tbody>
+</table>
 
 Use the TAB key to accept a completion and continue pressing TAB to cycle
 through the completions. Use Shift-TAB to cycle backwards. Note that if you're

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1117,9 +1117,18 @@ uppercase letters in the completion strings (the lowercase letters still match
 both). On top of that, a letter with no diacritic marks will match that letter
 with or without marks:
 
-| matches | foo | føo | fOo | fØo | |---------|-----|-----|-----|-----| |
-**foo** | ✔️ | ✔️ | ✔️ | ✔️ | | **føo** | ❌ | ✔️ | ❌ | ✔️ | | **fOo** | ❌ | ❌ |
-✔️ | ✔️ | | **fØo** | ❌ | ❌ | ❌ | ✔️ |
+---------------------------------------------
+| _matches_ | _foo_ | _føo_ | _fOo_ | _fØo_ |
+---------------------------------------------
+|   _foo_   | ✔️    | ✔️    | ✔️    | ✔️    |
+---------------------------------------------
+|   _føo_   | ❌     | ✔️    | ❌     | ✔️    |
+---------------------------------------------
+|   _fOo_   | ❌     | ❌     | ✔️    | ✔️    |
+---------------------------------------------
+|   _fØo_   | ❌     | ❌     | ❌     | ✔️    |
+---------------------------------------------
+
 
 Use the TAB key to accept a completion and continue pressing TAB to cycle
 through the completions. Use Shift-TAB to cycle backwards. Note that if you're


### PR DESCRIPTION
The tools we are using to convert our `README.md` file into Vim docs ([html2vimdoc](https://github.com/xolox/vim-tools)) and into HTML for the YCM website ([Python-Markdown](https://python-markdown.github.io/#features)) don't support GitHub Markdown tables. We need to write the table in HTML and use @puremourning's changes to [html2vimdoc](https://github.com/xolox/vim-tools) which adds support for simple HTML tables. The result is not perfect but still better than what we currently have.

The html2vimdoc version used to generate the Vim docs can be found in [this branch](https://github.com/micbou/vim-tools/tree/ycm).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3000)
<!-- Reviewable:end -->
