### PR TITLE
[READY] Ask users to set the log level to debug when including the contents of the logfiles

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -62,8 +62,9 @@ quickly and that neither your nor our time is needlessly wasted.
 
 ## Contents of YCM, ycmd and completion engine logfiles
 
-> Include link here to a [gist][] containing the entire logfiles for ycm, ycmd
-> and any completer logfiles listed by `:YcmToggleLogs`.
+> Add `let g:ycm_log_level = 'debug'` to vimrc, restart Vim, reproduce the
+> issue, and include link here to a [gist][] containing the entire logfiles for
+> ycm, ycmd and any completer logfiles listed by `:YcmToggleLogs`.
 
 ## OS version, distribution, etc.
 


### PR DESCRIPTION
When reporting an issue, users may include the contents of the logfiles with the default log level `info`, which is not really useful. Ask them to set the log level to `debug`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3012)
<!-- Reviewable:end -->
