### PR TITLE
Support java source from jar package

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -140,6 +140,7 @@ function! youcompleteme#Enable()
     autocmd VimLeave * call s:OnVimLeave()
     autocmd CompleteDone * call s:OnCompleteDone()
     autocmd BufEnter,WinEnter * call s:UpdateMatches()
+    autocmd BufReadCmd jdt://contents/**/*.class call s:ReadClassFileFromJDT()
   augroup END
 
   " The FileType event is not triggered for the first loaded file. We wait until
@@ -823,6 +824,12 @@ function! s:Complete()
     " until he explicitly chooses to replace it with a completion.
     call s:SendKeys( "\<C-X>\<C-U>\<C-P>" )
   endif
+endfunction
+
+
+function s:ReadClassFileFromJDT()
+  set filetype=java
+  YcmCompleter ClassFileContents
 endfunction
 
 

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -79,6 +79,9 @@ class CommandRequest( BaseRequest ):
     if 'detailed_info' in self._response:
       return self._HandleDetailedInfoResponse()
 
+    if 'ClassFileContents' == self._command:
+      return self._HandleClassFileContentsResponse()
+
     # The only other type of response we understand is GoTo, and that is the
     # only one that we can't detect just by inspecting the response (it should
     # either be a single location or a list)
@@ -129,6 +132,10 @@ class CommandRequest( BaseRequest ):
 
   def _HandleDetailedInfoResponse( self ):
     vimsupport.WriteToPreviewWindow( self._response[ 'detailed_info' ] )
+
+
+  def _HandleClassFileContentsResponse( self ):
+    vimsupport.WriteToJDTBuffer( self._response[ 'result' ] )
 
 
 def SendCommandRequest( arguments, completer, extra_data = None ):

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -31,6 +31,7 @@ from collections import defaultdict, namedtuple
 from ycmd.utils import ( ByteOffsetToCodepointOffset, GetCurrentDirectory,
                          JoinLinesAsUnicode, ToBytes, ToUnicode )
 from ycmd import user_options_store
+from ycmd.responses import IsJdtContentUri
 
 BUFFER_COMMAND_MAP = { 'same-buffer'      : 'edit',
                        'horizontal-split' : 'split',
@@ -159,6 +160,8 @@ def BufferIsVisible( buffer_number ):
 
 def GetBufferFilepath( buffer_object ):
   if buffer_object.name:
+    if IsJdtContentUri( buffer_object.name ):
+      return buffer_object.name
     return os.path.normpath( ToUnicode( buffer_object.name ) )
   # Buffers that have just been created by a command like :enew don't have any
   # buffer name so we use the buffer number for that.
@@ -1053,6 +1056,11 @@ def WriteToPreviewWindow( message ):
     # the information we have. The only remaining option is to echo to the
     # status area.
     PostVimMessage( message, warning = False )
+
+
+def WriteToJDTBuffer( filecontent ):
+  vim.command( 'setlocal buftype=nofile' )
+  vim.current.buffer[:] = filecontent.splitlines()
 
 
 def BufferIsVisibleForFilename( filename ):


### PR DESCRIPTION
eclipse.jdt.ls returns uri for class from jar package in scheme like 'jdt://contents/.*\.class.*', please see https://github.com/eclipse/eclipse.jdt.ls/blob/ae0081c28744dcdda117e97bf14b1bec9ca7f911/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManager.java#L40

This change is to use [java/classFileContents](https://github.com/eclipse/eclipse.jdt.ls/wiki/Language-Server-Protocol-Extensions) to fetch source from jdt.ls for class file, so that we could view source of classes from jar package.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

With this PR, java developers could view source code from jar package.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3018)
<!-- Reviewable:end -->
