### PR TITLE
[READY] Update diagnostic matches for all windows

### DIFF
--- a/python/ycm/tests/client/base_request_test.py
+++ b/python/ycm/tests/client/base_request_test.py
@@ -34,7 +34,7 @@ from ycm.client.base_request import BuildRequestData
         return_value = '/some/dir' )
 def BuildRequestData_AddWorkingDir_test( *args ):
   current_buffer = VimBuffer( 'foo' )
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 1 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     assert_that( BuildRequestData(), has_entry( 'working_dir', '/some/dir' ) )
 
 
@@ -42,6 +42,6 @@ def BuildRequestData_AddWorkingDir_test( *args ):
         return_value = '/some/dir' )
 def BuildRequestData_AddWorkingDirWithFileName_test( *args ):
   current_buffer = VimBuffer( 'foo' )
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 1 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     assert_that( BuildRequestData( current_buffer.number ),
                  has_entry( 'working_dir', '/some/dir' ) )

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -34,7 +34,7 @@ from ycm.tests import YouCompleteMeInstance
 @YouCompleteMeInstance( { 'g:ycm_extra_conf_vim_data': [ 'tempname()' ] } )
 def SendCommandRequest_ExtraConfVimData_Works_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
       ycm.SendCommandRequest( [ 'GoTo' ], 'python', False, 1, 1 )
       assert_that(
@@ -59,7 +59,7 @@ def SendCommandRequest_ExtraConfVimData_Works_test( ycm ):
 @YouCompleteMeInstance( { 'g:ycm_extra_conf_vim_data': [ 'undefined_value' ] } )
 def SendCommandRequest_ExtraConfData_UndefinedValue_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
       ycm.SendCommandRequest( [ 'GoTo' ], 'python', False, 1, 1 )
       assert_that(
@@ -82,7 +82,7 @@ def SendCommandRequest_ExtraConfData_UndefinedValue_test( ycm ):
 def SendCommandRequest_BuildRange_NoVisualMarks_test( ycm, *args ):
   current_buffer = VimBuffer( 'buffer', contents = [ 'first line',
                                                      'second line' ] )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
       ycm.SendCommandRequest( [ 'GoTo' ], 'python', True, 1, 2 )
       send_request.assert_called_once_with(
@@ -114,7 +114,7 @@ def SendCommandRequest_BuildRange_VisualMarks_test( ycm, *args ):
                                            'second line' ],
                               visual_start = [ 1, 4 ],
                               visual_end = [ 2, 8 ] )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
       ycm.SendCommandRequest( [ 'GoTo' ], 'python', True, 1, 2 )
       send_request.assert_called_once_with(

--- a/python/ycm/tests/completion_test.py
+++ b/python/ycm/tests/completion_test.py
@@ -66,7 +66,7 @@ def SendCompletionRequest_UnicodeWorkingDirectory_test( ycm ):
     return { 'completions': [], 'completion_start_column': 1 }
 
   with CurrentWorkingDirectory( unicode_dir ):
-    with MockVimBuffers( [ current_buffer ], current_buffer ):
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
       with MockCompletionRequest( ServerResponse ):
         ycm.SendCompletionRequest()
         ok_( ycm.CompletionRequestReady() )
@@ -106,7 +106,7 @@ def SendCompletionRequest_ResponseContainingError_test( ycm, post_vim_message ):
       } ]
     }
 
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with MockCompletionRequest( ServerResponse ):
       ycm.SendCompletionRequest()
       ok_( ycm.CompletionRequestReady() )
@@ -138,7 +138,7 @@ def SendCompletionRequest_ErrorFromServer_test( ycm,
                                                 post_vim_message,
                                                 logger ):
   current_buffer = VimBuffer( 'buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with MockCompletionRequest( ServerError( 'Server error' ) ):
       ycm.SendCompletionRequest()
       ok_( ycm.CompletionRequestReady() )

--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -57,10 +57,9 @@ def MockArbitraryBuffer( filetype ):
 
   # Arbitrary, but valid, single buffer open.
   current_buffer = VimBuffer( os.path.realpath( 'TEST_BUFFER' ),
-                              window = 1,
                               filetype = filetype )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     yield
 
 
@@ -402,7 +401,7 @@ def EventNotification_FileReadyToParse_TagFiles_UnicodeWorkingDirectory_test(
   with patch( 'ycm.client.event_notification.EventNotification.'
               'PostDataToHandlerAsync' ) as post_data_to_handler_async:
     with CurrentWorkingDirectory( unicode_dir ):
-      with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 5 ) ):
+      with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 5 ) ):
         ycm.OnFileReadyToParse()
 
     assert_that(
@@ -455,7 +454,7 @@ def EventNotification_BufferVisit_BuildRequestForCurrentAndUnsavedBuffers_test(
   with patch( 'ycm.client.event_notification.EventNotification.'
               'PostDataToHandlerAsync' ) as post_data_to_handler_async:
     with MockVimBuffers( [ current_buffer, modified_buffer, unmodified_buffer ],
-                         current_buffer,
+                         [ current_buffer ],
                          ( 1, 5 ) ):
       ycm.OnBufferVisit()
 
@@ -503,7 +502,8 @@ def EventNotification_BufferUnload_BuildRequestForDeletedAndUnsavedBuffers_test(
 
   with patch( 'ycm.client.event_notification.EventNotification.'
               'PostDataToHandlerAsync' ) as post_data_to_handler_async:
-    with MockVimBuffers( [ current_buffer, deleted_buffer ], current_buffer ):
+    with MockVimBuffers( [ current_buffer, deleted_buffer ],
+                         [ current_buffer ] ):
       ycm.OnBufferUnload( deleted_buffer.number )
 
   assert_that(
@@ -543,7 +543,7 @@ def EventNotification_FileReadyToParse_SyntaxKeywords_SeedWithCache_test(
 
   with patch( 'ycm.client.event_notification.EventNotification.'
               'PostDataToHandlerAsync' ) as post_data_to_handler_async:
-    with MockVimBuffers( [ current_buffer ], current_buffer ):
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
       ycm.OnFileReadyToParse()
       assert_that(
         # Positional arguments passed to PostDataToHandlerAsync.
@@ -578,7 +578,7 @@ def EventNotification_FileReadyToParse_SyntaxKeywords_ClearCacheIfRestart_test(
 
   with patch( 'ycm.client.event_notification.EventNotification.'
               'PostDataToHandlerAsync' ) as post_data_to_handler_async:
-    with MockVimBuffers( [ current_buffer ], current_buffer ):
+    with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
       ycm.OnFileReadyToParse()
       assert_that(
         # Positional arguments passed to PostDataToHandlerAsync.

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -52,7 +52,7 @@ def OmniCompleter_GetCompletions_Cache_List_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 5 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 5 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -76,7 +76,7 @@ def OmniCompleter_GetCompletions_Cache_ListFilter_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -100,7 +100,7 @@ def OmniCompleter_GetCompletions_NoCache_List_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 5 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 5 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -124,7 +124,7 @@ def OmniCompleter_GetCompletions_NoCache_ListFilter_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest()
     # Actual result is that the results are not filtered, as we expect the
     # omnifunc or vim itself to do this filtering.
@@ -150,7 +150,7 @@ def OmniCompleter_GetCompletions_NoCache_UseFindStart_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest()
     # Actual result is that the results are not filtered, as we expect the
     # omnifunc or vim itself to do this filtering.
@@ -176,7 +176,7 @@ def OmniCompleter_GetCompletions_Cache_UseFindStart_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest()
     # There are no results because the query 'test.t' doesn't match any
     # candidate (and cache_omnifunc=1, so we FilterAndSortCandidates).
@@ -202,7 +202,7 @@ def OmniCompleter_GetCompletions_Cache_Object_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -241,7 +241,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectList_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 7 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -286,7 +286,7 @@ def OmniCompleter_GetCompletions_NoCache_ObjectList_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 7 ) ):
     ycm.SendCompletionRequest()
     # We don't filter the result - we expect the omnifunc to do that
     # based on the query we supplied (Note: that means no fuzzy matching!).
@@ -339,7 +339,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectListObject_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 7 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -384,7 +384,7 @@ def OmniCompleter_GetCompletions_NoCache_ObjectListObject_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 7 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 7 ) ):
     ycm.SendCompletionRequest()
     # No FilterAndSortCandidates for cache_omnifunc=0 (we expect the omnifunc
     # to do the filtering?)
@@ -422,7 +422,7 @@ def OmniCompleter_GetCompletions_Cache_List_Unicode_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 12 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 12 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -448,7 +448,7 @@ def OmniCompleter_GetCompletions_NoCache_List_Unicode_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 12 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 12 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -474,7 +474,7 @@ def OmniCompleter_GetCompletions_Cache_List_Filter_Unicode_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 17 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 17 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -498,7 +498,7 @@ def OmniCompleter_GetCompletions_NoCache_List_Filter_Unicode_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 17 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 17 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -537,7 +537,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectList_Unicode_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 17 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 17 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -591,7 +591,7 @@ def OmniCompleter_GetCompletions_Cache_ObjectListObject_Unicode_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 13 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 13 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -634,7 +634,7 @@ def OmniCompleter_GetCompletions_RestoreCursorPositionAfterOmnifuncCall_test(
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 3, 5 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 3, 5 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       vimsupport.CurrentLineAndColumn(),
@@ -662,7 +662,7 @@ def OmniCompleter_GetCompletions_NoCache_NoSemanticTrigger_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 3 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 3 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -686,7 +686,7 @@ def OmniCompleter_GetCompletions_NoCache_ForceSemantic_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 3 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 3 ) ):
     ycm.SendCompletionRequest( force_semantic = True )
     assert_that(
       ycm.GetCompletionResponse(),
@@ -712,7 +712,7 @@ def OmniCompleter_GetCompletions_FiletypeDisabled_SemanticTrigger_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -740,7 +740,7 @@ def OmniCompleter_GetCompletions_AllFiletypesDisabled_SemanticTrigger_test(
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest()
     assert_that(
       ycm.GetCompletionResponse(),
@@ -766,7 +766,7 @@ def OmniCompleter_GetCompletions_FiletypeDisabled_ForceSemantic_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest( force_semantic = True )
     assert_that(
       ycm.GetCompletionResponse(),
@@ -792,7 +792,7 @@ def OmniCompleter_GetCompletions_AllFiletypesDisabled_ForceSemantic_test( ycm ):
                               filetype = FILETYPE,
                               omnifunc = Omnifunc )
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 6 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 6 ) ):
     ycm.SendCompletionRequest( force_semantic = True )
     assert_that(
       ycm.GetCompletionResponse(),

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -28,8 +28,8 @@ MockVimModule()
 
 import os
 import sys
-from hamcrest import ( assert_that, contains, empty, equal_to, is_in, is_not,
-                       matches_regexp )
+from hamcrest import ( assert_that, contains, empty, equal_to, has_entries,
+                       is_in, is_not, matches_regexp )
 from mock import call, MagicMock, patch
 
 from ycm.paths import _PathToPythonUsedDuringBuild
@@ -194,8 +194,8 @@ def YouCompleteMe_DebugInfo_ServerRunning_test( ycm ):
   extra_conf = os.path.join( dir_of_script, 'testdata', '.ycm_extra_conf.py' )
   _LoadExtraConfFile( extra_conf )
 
-  current_buffer = VimBuffer( buf_name, filetype='cpp' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  current_buffer = VimBuffer( buf_name, filetype = 'cpp' )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     assert_that(
       ycm.DebugInfo(),
       matches_regexp(
@@ -224,7 +224,7 @@ def YouCompleteMe_DebugInfo_ServerNotRunning_test( ycm ):
   StopServer( ycm )
 
   current_buffer = VimBuffer( 'current_buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     assert_that(
       ycm.DebugInfo(),
       matches_regexp(
@@ -264,8 +264,8 @@ def YouCompleteMe_OnVimLeave_KeepClientLogfile_test( ycm ):
 def YouCompleteMe_ToggleLogs_WithParameters_test( ycm,
                                                   open_filename,
                                                   close_buffers_for_filename ):
-  logfile_buffer = VimBuffer( ycm._client_logfile, window = 1 )
-  with MockVimBuffers( [ logfile_buffer ], logfile_buffer ):
+  logfile_buffer = VimBuffer( ycm._client_logfile )
+  with MockVimBuffers( [ logfile_buffer ], [ logfile_buffer ] ):
     ycm.ToggleLogs( os.path.basename( ycm._client_logfile ),
                     'nonexisting_logfile',
                     os.path.basename( ycm._server_stdout ) )
@@ -290,7 +290,7 @@ def YouCompleteMe_ToggleLogs_WithoutParameters_SelectLogfileNotAlreadyOpen_test(
   ycm, open_filename, *args ):
 
   current_buffer = VimBuffer( 'current_buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     ycm.ToggleLogs()
 
   open_filename.assert_has_exact_calls( [
@@ -309,8 +309,8 @@ def YouCompleteMe_ToggleLogs_WithoutParameters_SelectLogfileNotAlreadyOpen_test(
 def YouCompleteMe_ToggleLogs_WithoutParameters_SelectLogfileAlreadyOpen_test(
   ycm, close_buffers_for_filename, *args ):
 
-  logfile_buffer = VimBuffer( ycm._server_stdout, window = 1 )
-  with MockVimBuffers( [ logfile_buffer ], logfile_buffer ):
+  logfile_buffer = VimBuffer( ycm._server_stdout )
+  with MockVimBuffers( [ logfile_buffer ], [ logfile_buffer ] ):
     ycm.ToggleLogs()
 
   close_buffers_for_filename.assert_has_exact_calls( [
@@ -326,7 +326,7 @@ def YouCompleteMe_ToggleLogs_WithoutParameters_NoSelection_test(
   ycm, post_vim_message, *args ):
 
   current_buffer = VimBuffer( 'current_buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     ycm.ToggleLogs()
 
   assert_that(
@@ -339,7 +339,7 @@ def YouCompleteMe_ToggleLogs_WithoutParameters_NoSelection_test(
 @YouCompleteMeInstance()
 def YouCompleteMe_GetDefinedSubcommands_ListFromServer_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.client.base_request._JsonFromFuture',
                 return_value = [ 'SomeCommand', 'AnotherCommand' ] ):
       assert_that(
@@ -358,7 +358,7 @@ def YouCompleteMe_GetDefinedSubcommands_ErrorFromServer_test( ycm,
                                                               post_vim_message,
                                                               logger ):
   current_buffer = VimBuffer( 'buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.client.base_request._JsonFromFuture',
                 side_effect = ServerError( 'Server error' ) ):
       result = ycm.GetDefinedSubcommands()
@@ -376,7 +376,7 @@ def YouCompleteMe_ShowDetailedDiagnostic_MessageFromServer_test(
   ycm, post_vim_message ):
 
   current_buffer = VimBuffer( 'buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.client.base_request._JsonFromFuture',
                 return_value = { 'message': 'some_detailed_diagnostic' } ):
       ycm.ShowDetailedDiagnostic(),
@@ -392,7 +392,7 @@ def YouCompleteMe_ShowDetailedDiagnostic_Exception_test(
   ycm, post_vim_message ):
 
   current_buffer = VimBuffer( 'buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.client.base_request._JsonFromFuture',
                 side_effect = RuntimeError( 'Some exception' ) ):
       ycm.ShowDetailedDiagnostic(),
@@ -408,7 +408,7 @@ def YouCompleteMe_ShowDiagnostics_FiletypeNotSupported_test( ycm,
                                                              post_vim_message ):
 
   current_buffer = VimBuffer( 'buffer', filetype = 'not_supported' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     ycm.ShowDiagnostics()
 
   post_vim_message.assert_called_once_with(
@@ -424,8 +424,8 @@ def YouCompleteMe_ShowDiagnostics_FiletypeNotSupported_test( ycm,
 def YouCompleteMe_ShowDiagnostics_NoDiagnosticsDetected_test(
   ycm, set_location_list_for_window, post_vim_message, *args ):
 
-  current_buffer = VimBuffer( 'buffer', filetype = 'cpp', window = 99 )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  current_buffer = VimBuffer( 'buffer', filetype = 'cpp' )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.client.event_notification.EventNotification.Response',
                 return_value = {} ):
       ycm.ShowDiagnostics()
@@ -436,7 +436,7 @@ def YouCompleteMe_ShowDiagnostics_NoDiagnosticsDetected_test(
     call( 'Diagnostics refreshed', warning = False ),
     call( 'No warnings or errors detected.', warning = False )
   ] )
-  set_location_list_for_window.assert_called_once_with( 0, [] )
+  set_location_list_for_window.assert_called_once_with( 1, [] )
 
 
 @YouCompleteMeInstance( { 'g:ycm_log_level': 'debug',
@@ -461,9 +461,8 @@ def YouCompleteMe_ShowDiagnostics_DiagnosticsFound_DoNotOpenLocationList_test(
 
   current_buffer = VimBuffer( 'buffer',
                               filetype = 'cpp',
-                              number = 3,
-                              window = 99 )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+                              number = 3 )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.client.event_notification.EventNotification.Response',
                 return_value = [ diagnostic ] ):
       ycm.ShowDiagnostics()
@@ -473,7 +472,7 @@ def YouCompleteMe_ShowDiagnostics_DiagnosticsFound_DoNotOpenLocationList_test(
           warning = False ),
     call( 'Diagnostics refreshed', warning = False )
   ] )
-  set_location_list_for_window.assert_called_once_with( 0, [ {
+  set_location_list_for_window.assert_called_once_with( 1, [ {
       'bufnr': 3,
       'lnum': 19,
       'col': 2,
@@ -508,9 +507,8 @@ def YouCompleteMe_ShowDiagnostics_DiagnosticsFound_OpenLocationList_test(
 
   current_buffer = VimBuffer( 'buffer',
                               filetype = 'cpp',
-                              number = 3,
-                              window = 99 )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+                              number = 3 )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.client.event_notification.EventNotification.Response',
                 return_value = [ diagnostic ] ):
       ycm.ShowDiagnostics()
@@ -520,7 +518,7 @@ def YouCompleteMe_ShowDiagnostics_DiagnosticsFound_OpenLocationList_test(
           warning = False ),
     call( 'Diagnostics refreshed', warning = False )
   ] )
-  set_location_list_for_window.assert_called_once_with( 0, [ {
+  set_location_list_for_window.assert_called_once_with( 1, [ {
       'bufnr': 3,
       'lnum': 19,
       'col': 2,
@@ -607,13 +605,12 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
   current_buffer = VimBuffer( 'buffer',
                               filetype = 'c',
                               contents = contents.splitlines(),
-                              number = 5,
-                              window = 2 )
+                              number = 5 )
 
-  test_utils.VIM_MATCHES = []
+  test_utils.VIM_MATCHES_FOR_WINDOW.clear()
   test_utils.VIM_SIGNS = []
 
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 3, 1 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 3, 1 ) ):
     with patch( 'ycm.client.event_notification.EventNotification.Response',
                 return_value = diagnostics ):
       ycm.OnFileReadyToParse()
@@ -626,12 +623,14 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
 
     # Error match is added after warning matches.
     assert_that(
-      test_utils.VIM_MATCHES,
-      contains(
-        VimMatch( 'YcmWarningSection', '\%3l\%5c\_.\{-}\%3l\%7c' ),
-        VimMatch( 'YcmWarningSection', '\%3l\%3c\_.\{-}\%3l\%9c' ),
-        VimMatch( 'YcmErrorSection', '\%3l\%8c' )
-      )
+      test_utils.VIM_MATCHES_FOR_WINDOW,
+      has_entries( {
+        1: contains(
+          VimMatch( 'YcmWarningSection', '\%3l\%5c\_.\{-}\%3l\%7c' ),
+          VimMatch( 'YcmWarningSection', '\%3l\%3c\_.\{-}\%3l\%9c' ),
+          VimMatch( 'YcmErrorSection', '\%3l\%8c' )
+        )
+      } )
     )
 
     # Only the error sign is placed.
@@ -643,19 +642,19 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
     )
 
   # The error is not echoed again when moving the cursor along the line.
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 3, 2 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 3, 2 ) ):
     post_vim_message.reset_mock()
     ycm.OnCursorMoved()
     post_vim_message.assert_not_called()
 
   # The error is cleared when moving the cursor to another line.
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 2, 2 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 2, 2 ) ):
     post_vim_message.reset_mock()
     ycm.OnCursorMoved()
     post_vim_message.assert_called_once_with( "", warning = False )
 
   # The error is echoed when moving the cursor back.
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 3, 2 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 3, 2 ) ):
     post_vim_message.reset_mock()
     ycm.OnCursorMoved()
     post_vim_message.assert_called_once_with(
@@ -668,11 +667,13 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
       ycm.HandleFileParseRequest( block = True )
 
     assert_that(
-      test_utils.VIM_MATCHES,
-      contains(
-        VimMatch( 'YcmWarningSection', '\%3l\%5c\_.\{-}\%3l\%7c' ),
-        VimMatch( 'YcmWarningSection', '\%3l\%3c\_.\{-}\%3l\%9c' )
-      )
+      test_utils.VIM_MATCHES_FOR_WINDOW,
+      has_entries( {
+        1: contains(
+          VimMatch( 'YcmWarningSection', '\%3l\%5c\_.\{-}\%3l\%7c' ),
+          VimMatch( 'YcmWarningSection', '\%3l\%3c\_.\{-}\%3l\%9c' )
+        )
+      } )
     )
 
     assert_that(
@@ -687,23 +688,25 @@ def YouCompleteMe_UpdateDiagnosticInterface_PrioritizeErrorsOverWarnings_test(
 def YouCompleteMe_UpdateMatches_ClearDiagnosticMatchesInNewBuffer_test( ycm ):
   current_buffer = VimBuffer( 'buffer',
                               filetype = 'c',
-                              number = 5,
-                              window = 2 )
+                              number = 5 )
 
-  test_utils.VIM_MATCHES = [
+  test_utils.VIM_MATCHES_FOR_WINDOW.clear()
+  test_utils.VIM_MATCHES_FOR_WINDOW[ 1 ] = [
     VimMatch( 'YcmWarningSection', '\%3l\%5c\_.\{-}\%3l\%7c' ),
     VimMatch( 'YcmWarningSection', '\%3l\%3c\_.\{-}\%3l\%9c' ),
     VimMatch( 'YcmErrorSection', '\%3l\%8c' )
   ]
 
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     ycm.UpdateMatches()
 
-    assert_that( test_utils.VIM_MATCHES, empty() )
+  assert_that( test_utils.VIM_MATCHES_FOR_WINDOW,
+               has_entries( { 1: empty() } ) )
 
 
 @YouCompleteMeInstance( { 'g:ycm_echo_current_diagnostic': 1,
-                          'g:ycm_always_populate_location_list': 1 } )
+                          'g:ycm_always_populate_location_list': 1,
+                          'g:ycm_enable_diagnostic_highlighting': 1 } )
 @patch.object( ycm_buffer_module,
                'DIAGNOSTIC_UI_ASYNC_FILETYPES',
                [ 'ycmtest' ] )
@@ -731,6 +734,19 @@ def YouCompleteMe_AsyncDiagnosticUpdate_SingleFile_test( ycm,
         'line_num': 1,
         'column_num': 1
       },
+      'location_extent': {
+        'start': {
+          'filepath': '/current',
+          'line_num': 1,
+          'column_num': 1,
+        },
+        'end': {
+          'filepath': '/current',
+          'line_num': 1,
+          'column_num': 1,
+        }
+      },
+      'ranges': []
     },
     {
       'kind': 'ERROR',
@@ -740,6 +756,19 @@ def YouCompleteMe_AsyncDiagnosticUpdate_SingleFile_test( ycm,
         'line_num': 4,
         'column_num': 2
       },
+      'location_extent': {
+        'start': {
+          'filepath': '/has_diags',
+          'line_num': 4,
+          'column_num': 2,
+        },
+        'end': {
+          'filepath': '/has_diags',
+          'line_num': 4,
+          'column_num': 2,
+        }
+      },
+      'ranges': []
     },
     {
       'kind': 'ERROR',
@@ -749,76 +778,99 @@ def YouCompleteMe_AsyncDiagnosticUpdate_SingleFile_test( ycm,
         'line_num': 8,
         'column_num': 4
       },
-    },
+      'location_extent': {
+        'start': {
+          'filepath': '/not_open',
+          'line_num': 8,
+          'column_num': 4,
+        },
+        'end': {
+          'filepath': '/not_open',
+          'line_num': 8,
+          'column_num': 4,
+        }
+      },
+      'ranges': []
+    }
   ]
 
   current_buffer = VimBuffer( '/current',
                               filetype = 'ycmtest',
-                              number = 1,
-                              window = 10 )
-  buffers = [
-    current_buffer,
-    VimBuffer( '/no_diags',
-               filetype = 'ycmtest',
-               number = 2,
-               window = 9 ),
-    VimBuffer( '/has_diags',
-               filetype = 'ycmtest',
-               number = 3,
-               window = 8 ),
-  ]
+                              contents = [ 'current' ] * 10,
+                              number = 1 )
+  no_diags_buffer = VimBuffer( '/no_diags',
+                               filetype = 'ycmtest',
+                               contents = [ 'nodiags' ] * 10,
+                               number = 2 )
+  hidden_buffer = VimBuffer( '/has_diags',
+                             filetype = 'ycmtest',
+                             contents = [ 'hasdiags' ] * 10,
+                             number = 3 )
+
+  buffers = [ current_buffer, no_diags_buffer, hidden_buffer ]
+  windows = [ current_buffer, no_diags_buffer ]
 
   # Register each buffer internally with YCM
   for current in buffers:
-    with MockVimBuffers( buffers, current, ( 1, 1 ) ):
+    with MockVimBuffers( buffers, [ current ] ):
       ycm.OnFileReadyToParse()
 
   with patch( 'ycm.vimsupport.SetLocationListForWindow',
               new_callable = ExtendedMock ) as set_location_list_for_window:
-    with MockVimBuffers( buffers, current_buffer, ( 1, 1 ) ):
+    with MockVimBuffers( buffers, windows ):
       ycm.UpdateWithNewDiagnosticsForFile( '/current', diagnostics )
 
-    # We update the diagnostic on the current cursor position
-    post_vim_message.assert_has_exact_calls( [
-      call( "error text in current buffer", truncate = True, warning = False ),
-    ] )
+  # We update the diagnostic on the current cursor position
+  post_vim_message.assert_has_exact_calls( [
+    call( "error text in current buffer", truncate = True, warning = False ),
+  ] )
 
-    # Ensure we included all the diags though
-    set_location_list_for_window.assert_has_exact_calls( [
-      call( 0, [
-        {
-          'lnum': 1,
-          'col': 1,
-          'bufnr': 1,
-          'valid': 1,
-          'type': 'E',
-          'text': 'error text in current buffer',
-        },
-        {
-          'lnum': 4,
-          'col': 2,
-          'bufnr': 3,
-          'valid': 1,
-          'type': 'E',
-          'text': 'error text in hidden buffer',
-        },
-        {
-          'lnum': 8,
-          'col': 4,
-          'bufnr': -1, # sic: Our mocked bufnr function actually returns -1,
-                       # even though YCM is passing "create if needed".
-                       # FIXME? we shouldn't do that, and we should pass
-                       # filename instead
-          'valid': 1,
-          'type': 'E',
-          'text': 'error text in buffer not open in Vim'
-        }
-      ] )
+  # Ensure we included all the diags though
+  set_location_list_for_window.assert_has_exact_calls( [
+    call( 1, [
+      {
+        'lnum': 1,
+        'col': 1,
+        'bufnr': 1,
+        'valid': 1,
+        'type': 'E',
+        'text': 'error text in current buffer',
+      },
+      {
+        'lnum': 4,
+        'col': 2,
+        'bufnr': 3,
+        'valid': 1,
+        'type': 'E',
+        'text': 'error text in hidden buffer',
+      },
+      {
+        'lnum': 8,
+        'col': 4,
+        'bufnr': -1, # sic: Our mocked bufnr function actually returns -1,
+                     # even though YCM is passing "create if needed".
+                     # FIXME? we shouldn't do that, and we should pass
+                     # filename instead
+        'valid': 1,
+        'type': 'E',
+        'text': 'error text in buffer not open in Vim'
+      }
     ] )
+  ] )
+
+  assert_that(
+    test_utils.VIM_MATCHES_FOR_WINDOW,
+    has_entries( {
+      1: contains(
+        VimMatch( 'YcmErrorSection', '\%1l\%1c\_.\{-}\%1l\%1c' )
+      )
+    } )
+  )
 
 
 @YouCompleteMeInstance( { 'g:ycm_echo_current_diagnostic': 1,
-                          'g:ycm_always_populate_location_list': 1 } )
+                          'g:ycm_always_populate_location_list': 1,
+                          'g:ycm_enable_diagnostic_highlighting': 1 } )
 @patch.object( ycm_buffer_module,
                'DIAGNOSTIC_UI_ASYNC_FILETYPES',
                [ 'ycmtest' ] )
@@ -835,87 +887,175 @@ def YouCompleteMe_AsyncDiagnosticUpdate_PerFile_test( ycm,
   # Ordered to ensure that the calls to update are deterministic
   diagnostics_per_file = [
     ( '/current', [ {
-      'kind': 'ERROR',
-      'text': 'error text in current buffer',
-      'location': {
-        'filepath': '/current',
-        'line_num': 1,
-        'column_num': 1
-      }, }, ] ),
-    ( '/has_diags', [ {
-      'kind': 'ERROR',
-      'text': 'error text in hidden buffer',
-      'location': {
-        'filepath': '/has_diags',
-        'line_num': 4,
-        'column_num': 2
-      }, }, ] ),
+        'kind': 'ERROR',
+        'text': 'error text in current buffer',
+        'location': {
+          'filepath': '/current',
+          'line_num': 1,
+          'column_num': 1
+        },
+        'location_extent': {
+          'start': {
+            'filepath': '/current',
+            'line_num': 1,
+            'column_num': 1,
+          },
+          'end': {
+            'filepath': '/current',
+            'line_num': 1,
+            'column_num': 1,
+          }
+        },
+        'ranges': [],
+      } ] ),
+    ( '/separate_window', [ {
+        'kind': 'ERROR',
+        'text': 'error text in a buffer open in a separate window',
+        'location': {
+          'filepath': '/separate_window',
+          'line_num': 3,
+          'column_num': 3
+        },
+        'location_extent': {
+          'start': {
+            'filepath': '/separate_window',
+            'line_num': 3,
+            'column_num': 3,
+          },
+          'end': {
+            'filepath': '/separate_window',
+            'line_num': 3,
+            'column_num': 3,
+          }
+        },
+        'ranges': []
+      } ] ),
+    ( '/hidden', [ {
+        'kind': 'ERROR',
+        'text': 'error text in hidden buffer',
+        'location': {
+          'filepath': '/hidden',
+          'line_num': 4,
+          'column_num': 2
+        },
+        'location_extent': {
+          'start': {
+            'filepath': '/hidden',
+            'line_num': 4,
+            'column_num': 2,
+          },
+          'end': {
+            'filepath': '/hidden',
+            'line_num': 4,
+            'column_num': 2,
+          }
+        },
+        'ranges': []
+      } ] ),
     ( '/not_open', [ {
-      'kind': 'ERROR',
-      'text': 'error text in buffer not open in Vim',
-      'location': {
-        'filepath': '/not_open',
-        'line_num': 8,
-        'column_num': 4
-      }, }, ] )
+        'kind': 'ERROR',
+        'text': 'error text in buffer not open in Vim',
+        'location': {
+          'filepath': '/not_open',
+          'line_num': 8,
+          'column_num': 4
+        },
+        'location_extent': {
+          'start': {
+            'filepath': '/not_open',
+            'line_num': 8,
+            'column_num': 4,
+          },
+          'end': {
+            'filepath': '/not_open',
+            'line_num': 8,
+            'column_num': 4,
+          }
+        },
+        'ranges': []
+      } ] )
   ]
 
   current_buffer = VimBuffer( '/current',
                               filetype = 'ycmtest',
-                              number = 1,
-                              window = 10 )
+                              contents = [ 'current' ] * 10,
+                              number = 1 )
+  no_diags_buffer = VimBuffer( '/no_diags',
+                               filetype = 'ycmtest',
+                               contents = [ 'no_diags' ] * 10,
+                               number = 2 )
+  separate_window = VimBuffer( '/separate_window',
+                               filetype = 'ycmtest',
+                               contents = [ 'separate_window' ] * 10,
+                               number = 3 )
+  hidden_buffer = VimBuffer( '/hidden',
+                             filetype = 'ycmtest',
+                             contents = [ 'hidden' ] * 10,
+                             number = 4 )
   buffers = [
     current_buffer,
-    VimBuffer( '/no_diags',
-               filetype = 'ycmtest',
-               number = 2,
-               window = 9 ),
-    VimBuffer( '/has_diags',
-               filetype = 'ycmtest',
-               number = 3,
-               window = 8 ),
+    no_diags_buffer,
+    separate_window,
+    hidden_buffer
+  ]
+  windows = [
+    current_buffer,
+    no_diags_buffer,
+    separate_window
   ]
 
   # Register each buffer internally with YCM
   for current in buffers:
-    with MockVimBuffers( buffers, current, ( 1, 1 ) ):
+    with MockVimBuffers( buffers, [ current ] ):
       ycm.OnFileReadyToParse()
 
   with patch( 'ycm.vimsupport.SetLocationListForWindow',
               new_callable = ExtendedMock ) as set_location_list_for_window:
-    with MockVimBuffers( buffers, current_buffer, ( 1, 1 ) ):
+    with MockVimBuffers( buffers, windows ):
       for filename, diagnostics in diagnostics_per_file:
         ycm.UpdateWithNewDiagnosticsForFile( filename, diagnostics )
 
-    # We update the diagnostic on the current cursor position
-    post_vim_message.assert_has_exact_calls( [
-      call( "error text in current buffer", truncate = True, warning = False ),
-    ] )
+  # We update the diagnostic on the current cursor position
+  post_vim_message.assert_has_exact_calls( [
+    call( "error text in current buffer", truncate = True, warning = False ),
+  ] )
 
-    # Ensure we included all the diags though
-    set_location_list_for_window.assert_has_exact_calls( [
-      call( 0, [
-        {
-          'lnum': 1,
-          'col': 1,
-          'bufnr': 1,
-          'valid': 1,
-          'type': 'E',
-          'text': 'error text in current buffer',
-        },
-      ] ),
+  # Ensure we included all the diags though
+  set_location_list_for_window.assert_has_exact_calls( [
+    call( 1, [
+      {
+        'lnum': 1,
+        'col': 1,
+        'bufnr': 1,
+        'valid': 1,
+        'type': 'E',
+        'text': 'error text in current buffer',
+      },
+    ] ),
 
-      call( 8, [
-        {
-          'lnum': 4,
-          'col': 2,
-          'bufnr': 3,
-          'valid': 1,
-          'type': 'E',
-          'text': 'error text in hidden buffer',
-        },
-      ] )
+    call( 3, [
+      {
+        'lnum': 3,
+        'col': 3,
+        'bufnr': 3,
+        'valid': 1,
+        'type': 'E',
+        'text': 'error text in a buffer open in a separate window',
+      },
     ] )
+  ] )
+
+  assert_that(
+    test_utils.VIM_MATCHES_FOR_WINDOW,
+    has_entries( {
+      1: contains(
+        VimMatch( 'YcmErrorSection', '\%1l\%1c\_.\{-}\%1l\%1c' )
+      ),
+      3: contains(
+        VimMatch( 'YcmErrorSection', '\%3l\%3c\_.\{-}\%3l\%3c' )
+      )
+    } )
+  )
 
 
 @YouCompleteMeInstance()
@@ -945,12 +1085,10 @@ def YouCompleteMe_OnPeriodicTick_DontRetry_test( ycm,
 
   current_buffer = VimBuffer( '/current',
                               filetype = 'ycmtest',
-                              number = 1,
-                              window = 10 )
-  buffers = [ current_buffer ]
+                              number = 1 )
 
   # Create the request and make the first poll; we expect no response
-  with MockVimBuffers( buffers, current_buffer, ( 1, 1 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 1 ) ):
     assert_that( ycm.OnPeriodicTick(), equal_to( True ) )
     post_data_to_handler_async.assert_called()
 
@@ -996,12 +1134,10 @@ def YouCompleteMe_OnPeriodicTick_Exception_test( ycm,
 
   current_buffer = VimBuffer( '/current',
                               filetype = 'ycmtest',
-                              number = 1,
-                              window = 10 )
-  buffers = [ current_buffer ]
+                              number = 1 )
 
   # Create the request and make the first poll; we expect no response
-  with MockVimBuffers( buffers, current_buffer, ( 1, 1 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 1 ) ):
     assert_that( ycm.OnPeriodicTick(), equal_to( True ) )
     post_data_to_handler_async.assert_called()
 
@@ -1036,12 +1172,10 @@ def YouCompleteMe_OnPeriodicTick_ValidResponse_test( ycm,
 
   current_buffer = VimBuffer( '/current',
                               filetype = 'ycmtest',
-                              number = 1,
-                              window = 10 )
-  buffers = [ current_buffer ]
+                              number = 1 )
 
   # Create the request and make the first poll; we expect no response
-  with MockVimBuffers( buffers, current_buffer, ( 1, 1 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 1 ) ):
     assert_that( ycm.OnPeriodicTick(), equal_to( True ) )
     post_data_to_handler_async.assert_called()
 
@@ -1065,7 +1199,7 @@ def YouCompleteMe_OnPeriodicTick_ValidResponse_test( ycm,
 def YouCompleteMe_OnCompleteDone_CompletionRequest_test( ycm,
                                                          on_complete_done ):
   current_buffer = VimBuffer( 'current_buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer, ( 1, 1 ) ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 1 ) ):
     ycm.SendCompletionRequest()
   ycm.OnCompleteDone()
   on_complete_done.assert_called()
@@ -1082,5 +1216,5 @@ def YouCompleteMe_OnCompleteDone_NoCompletionRequest_test( ycm,
 @YouCompleteMeInstance()
 def YouCompleteMe_ShouldResendFileParseRequest_NoParseRequest_test( ycm ):
   current_buffer = VimBuffer( 'current_buffer' )
-  with MockVimBuffers( [ current_buffer ], current_buffer ):
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     assert_that( ycm.ShouldResendFileParseRequest(), equal_to( False ) )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -385,7 +385,7 @@ class YouCompleteMe( object ):
     bufnr = vimsupport.GetBufferNumberForFilename( filepath )
     if bufnr in self._buffers and vimsupport.BufferIsVisible( bufnr ):
       # Note: We only update location lists, etc. for visible buffers, because
-      # otherwise we defualt to using the curren location list and the results
+      # otherwise we default to using the current location list and the results
       # are that non-visible buffer errors clobber visible ones.
       self._buffers[ bufnr ].UpdateWithNewDiagnostics( diagnostics )
     else:


### PR DESCRIPTION
Since the `getmatches` and `setmatches` Vim functions only allow manipulating matches for the current window, we shouldn't update diagnostic matches if the buffer is not the current window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3024)
<!-- Reviewable:end -->
