### PR TITLE
[READY] Fix debug info test on Python 2 with Clang support

### DIFF
--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -209,7 +209,7 @@ def YouCompleteMe_DebugInfo_ServerRunning_test( ycm ):
         'Extra configuration path: .*testdata[/\\\\]\\.ycm_extra_conf\\.py\n'
         '(?(CLANG)C-family completer debug information:\n'
         '  Compilation database path: None\n'
-        '  Flags: \\[\'_TEMP_FILE_\'.*\\]\n'
+        '  Flags: \\[u?\'_TEMP_FILE_\'.*\\]\n'
         '  Translation unit: .+\n)'
         'Server running at: .+\n'
         'Server process ID: \d+\n'


### PR DESCRIPTION
Since PR https://github.com/Valloric/ycmd/pull/925, the list of flags returned by ycmd are prefixed with `u` on Python 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3027)
<!-- Reviewable:end -->
