### PR TITLE
[READY] Fix YcmShowDetailedDiagnostic command on line without diagnostic

### DIFF
--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1900,8 +1900,8 @@ The *GoToDeclaration* subcommand
 
 Looks up the symbol under the cursor and jumps to its declaration.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, cuda, cs, go, java, python, rust,
-typescript'
+Supported in filetypes: 'c, cpp, objc, objcpp, cuda, cs, go, java, python,
+rust, typescript'
 
 -------------------------------------------------------------------------------
 The *GoToDefinition* subcommand

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -388,6 +388,22 @@ def YouCompleteMe_ShowDetailedDiagnostic_MessageFromServer_test(
 
 @YouCompleteMeInstance()
 @patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
+def YouCompleteMe_ShowDetailedDiagnostic_Exception_test(
+  ycm, post_vim_message ):
+
+  current_buffer = VimBuffer( 'buffer' )
+  with MockVimBuffers( [ current_buffer ], current_buffer ):
+    with patch( 'ycm.client.base_request._JsonFromFuture',
+                side_effect = RuntimeError( 'Some exception' ) ):
+      ycm.ShowDetailedDiagnostic(),
+
+  post_vim_message.assert_has_exact_calls( [
+    call( 'Some exception', truncate = False )
+  ] )
+
+
+@YouCompleteMeInstance()
+@patch( 'ycm.vimsupport.PostVimMessage', new_callable = ExtendedMock )
 def YouCompleteMe_ShowDiagnostics_FiletypeNotSupported_test( ycm,
                                                              post_vim_message ):
 

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -660,7 +660,7 @@ class YouCompleteMe( object ):
     detailed_diagnostic = BaseRequest().PostDataToHandler(
         BuildRequestData(), 'detailed_diagnostic' )
 
-    if 'message' in detailed_diagnostic:
+    if detailed_diagnostic and 'message' in detailed_diagnostic:
       vimsupport.PostVimMessage( detailed_diagnostic[ 'message' ],
                                  warning = False )
 


### PR DESCRIPTION
The `YcmShowDetailedDiagnostic` command raises a `NoneType` exception on a line with no diagnostic;
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "YouCompleteMe/autoload\..\python\ycm\youcompleteme.py", line 663, in ShowDetailedDiagnostic
    if 'message' in detailed_diagnostic:
TypeError: argument of type 'NoneType' is not iterable
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3035)
<!-- Reviewable:end -->
