### PR TITLE
[RFC] Merge all non full installtion guides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ will notify you to recompile it. You should then rerun the install process.
 
 ##### Compatible Vim
 
-###### Mac OS X
+###### macOS
 
 Install the latest version of [MacVim][]. Yes, MacVim. And yes, the _latest_.
 
@@ -191,7 +191,7 @@ _If_ you have installed a Homebrew MacVim, see this
 [_FAQ_](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
 for details.
 
-###### Unix
+###### Linux
 
 Make sure you have Vim 7.4.1578 with Python 2 or Python 3 support. Ubuntu 16.04
 and later have a Vim that's recent enough. You can see the version of Vim
@@ -221,12 +221,12 @@ You can do that by specifying [the `++enc` argument][++enc] to the `:e` command.
 
 ##### Build Tools
 
-###### Mac OS X
+###### macOS
 
 Install CMake. Preferably with [Homebrew][brew], but here's the [stand-alone
 CMake installer][cmake-download].
 
-###### Unix
+###### Linux
 
 Here we'll list the packages you need to install as they are named under the
 different distributions. Use the proper package manager for your distribution.
@@ -260,13 +260,13 @@ looking for Python 2.7 and the latter indicates that Vim is looking for
 Python 3.5. You'll need one or the other installed, matching the version
 number exactly.
 
-###### Mac OS X
+###### macOS
 
 _If_ you have installed a Homebrew Python, see this
 [_FAQ_](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
 for details.
 
-###### Unix
+###### Linux
 
 Here we'll list the packages you need to install as they are named under the
 different distributions. Use the proper package manager for your distribution.
@@ -277,14 +277,14 @@ different distributions. Use the proper package manager for your distribution.
 
 ##### C-family completion support requirements
 
-###### Mac OS X only
+###### macOS
 
-For all C languages, completion support on Mac OS X requires the latest Xcode
+For all C languages, completion support on macOS requires the latest Xcode
 installed along with the latest Command Line Tools (they are installed
 automatically when you run `clang` for the first time, or manually by running
 `xcode-select --install`).
 
-###### Unix
+###### Linux
 
 For all C languages except for C#, support is enabled automatically during
 compilation. For C# completion support, you'll need to install
@@ -306,7 +306,7 @@ Inside the `YouCompleteMe` directory, there is a python script called
 `install.py`, it will be found on the following locations for the following
 OSs:
 
-- Mac OS X / Unix: `~/.vim/bundle/YouCompleteMe`
+- macOS / Linux: `~/.vim/bundle/YouCompleteMe`
 - Windows: `%USERPROFILE%/vimfiles/bundle/YouCompleteMe`
 
 Compiling YCM **with** semantic support for C-family languages:
@@ -355,7 +355,7 @@ that are conservatively turned off by default that you may want to turn on.
 
 ### Full Installation Guide
 
-These are the steps necessary to get YCM working on a Unix OS and on Windows.
+These are the steps necessary to get YCM working on a Linux, macOS and on Windows.
 
 **Note to Windows users:** we assume that you are running the `cmd.exe` command
 prompt and that the needed executables are in the PATH environment variable. Do
@@ -424,7 +424,7 @@ process.
     You will need to have `cmake` installed in order to generate the required
     makefiles.
     - Linux users can install cmake with their package manager (usually the package is just called `cmake` on most distributions).
-    - Mac OS X users can get it through [Homebrew][brew] with `brew install
+    - macOS users can get it through [Homebrew][brew] with `brew install
     cmake`
     - Windows users and everyone else can can [download and install][
     cmake-download] cmake from its project site.
@@ -432,7 +432,7 @@ process.
     In addition, you need to make sure you have Python headers installed.
     - On Debian-like Linux distros, you'll install them with be `sudo apt-get
     install python-dev python3-dev`.
-    - On Mac OS X, they are usually already installed.
+    - On macOS, they are usually already installed.
     - On Windows, you need to download and install [Python 2 or
     Python 3][python-win-download].
 
@@ -458,7 +458,7 @@ process.
 
     The `<generator>` is different for different OSs:
 
-    - For Linux and Mac OS X:
+    - For Linux and macOS:
 
         cmake -G "Unix Makefiles" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
 
@@ -504,7 +504,7 @@ process.
         cmake --build . --target ycm_core --config Release
 
     The `--config Release` part is specific to Windows and will be ignored on a
-    Unix OS.
+    Linux OS.
 
     For those who want to use the system version of libclang, you would pass
     `-DUSE_SYSTEM_LIBCLANG=ON` to cmake _instead of_ the
@@ -2962,7 +2962,7 @@ one) option because YCM needs the `language:<lang>` field in the tags output.
 `*.h` files as `C++`. If you have C (not C++) project, consider giving parameter
 `--langmap=c:.c.h` to ctags to see tags from `*.h` files.
 
-**NOTE:** Mac OS X comes with "plain" ctags installed by default. `brew install
+**NOTE:** macOS comes with "plain" ctags installed by default. `brew install
 ctags` will get you the Exuberant Ctags version.
 
 Also make sure that your Vim `tags` option is set correctly. See `:h 'tags'` for
@@ -3107,7 +3107,7 @@ This is caused by an issue with libclang that only affects some operating
 systems. Compiling with `clang` the binary will use the correct default header
 search paths but compiling with `libclang.so` (which YCM uses) does not.
 
-Mac OS X is normally affected, but there's a workaround in YCM for that specific
+macOS is normally affected, but there's a workaround in YCM for that specific
 OS. If you're not running that OS but still have the same problem, continue
 reading.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ will notify you to recompile it. You should then rerun the install process.
 
 #### Requirements
 
+- [Compatible Vim](#compatible-vim)
+- [Build Tools](#build-tools)
+- [Python](#python)
+- [C-family completion support requirements](#c-family-completion-support-requirements)
+
 ##### Compatible Vim
 
 ###### Mac OS X

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ and a completer that integrates with [UltiSnips][].
 Installation
 ------------
 
-### TL;DR
+### Quick Installation Guide
 
 **Remember:** YCM is a plugin with a compiled component. If you **update** YCM
 using Vundle and the ycm_core library APIs have changed (happens rarely), YCM

--- a/README.md
+++ b/README.md
@@ -182,11 +182,20 @@ environment variable.
 
 ##### Compatible Vim
 
+Make sure you have at least Vim 7.4.1578 with Python 2 or Python 3 support. You
+can check the version and which Python is supported by typing `:version` inside
+Vim. Look at the features included: `+python/dyn` for Python 2 and
+`+python3/dyn` for Python 3. If the version is too old, you may need to
+[compile Vim from source][vim-build] (don't worry, it's easy).
+
+If using macOS or Windows, refer to the following additional instructions:
+
 ###### macOS
 
-Either install MacVim with Homebrew using `brew install macvim
---with-override-system-vim`. _If_ you have installed a Homebrew MacVim, see
-[this _FAQ_ entry](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
+If you'd prefer not to compile Vim from source, on macOS you can install MacVim
+with Homebrew using `brew install macvim --with-override-system-vim`. _If_ you
+have installed a Homebrew MacVim, see [this _FAQ_
+entry](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
 for details.
 
 If you don't use the MacVim GUI, it is recommended to use the Vim binary that is
@@ -196,22 +205,12 @@ local binary folder (for example `/usr/local/bin/mvim`) and then symlink it:
 
     ln -s /usr/local/bin/mvim vim
 
-###### Linux
-
-Make sure you have Vim 7.4.1578 with Python 2 or Python 3 support. Ubuntu 16.04
-and later have a Vim that's recent enough. You can see the version of Vim
-installed by running `vim --version`. If the version is too old, you may need to
-[compile Vim from source][vim-build] (don't worry, it's easy).
-
 ###### Windows
 
-Make sure you have at least Vim 7.4.1578 with Python 2 or Python 3 support. You
-can check the version and which Python is supported by typing `:version` inside
-Vim. Look at the features included: `+python/dyn` for Python 2 and
-`+python3/dyn` for Python 3. Take note of the Vim architecture, i.e. 32 or
-64-bit. It will be important when choosing the Python installer. We recommend
-using a 64-bit client. [Daily updated copies of 32-bit and 64-bit Vim with
-Python 2 and Python 3 support][vim-win-download] are available.
+Take note of your Vim architecture, i.e. 32 or 64-bit. It will be important
+when choosing the Python installer. We recommend using a 64-bit client. [Daily
+updated copies of 32-bit and 64-bit Vim with Python 2 and Python
+3 support][vim-win-download] are available.
 
 Add the line:
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ process.
     - Linux users can install cmake with their package manager (usually the package is just called `cmake` on most distributions).
     - macOS users can get it through [Homebrew][brew] with `brew install
     cmake`
-    - Windows users and everyone else can can [download and install][
+    - Windows users and everyone else can [download and install][
     cmake-download] cmake from its project site.
 
     In addition, you need to make sure you have Python headers installed.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ Navigate to the YouCompleteMe directory:
 - on UNIX platforms, `cd ~/.vim/bundle/YouCompleteMe`
 - on Windows, `cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe`
 
+If you are not using [Vundle][], remember to recursively update the submodules
+with `git submodule update --init --recursive`.
+
 When running `install.py`, follow these instructions for adding support for
 these languages:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ YouCompleteMe is a fast, as-you-type, fuzzy-search code completion engine for
 - a [Clang][]-based engine that provides native semantic code
   completion for C/C++/Objective-C/Objective-C++ (from now on referred to as
   "the C-family languages"),
-- a [Jedi][]-based completion engine for Python 2 and 3 (using the [JediHTTP][] wrapper),
+- a [Jedi][]-based completion engine for Python 2 and 3 (using the [JediHTTP][]
+  wrapper),
 - an [OmniSharp][]-based completion engine for C#,
 - a combination of [Gocode][] and [Godef][] semantic engines for Go,
 - a [TSServer][]-based completion engine for TypeScript,
@@ -234,7 +235,8 @@ different distributions. Use the proper package manager for your distribution.
 
 - Ubuntu: `build-essential` `cmake`
 - Older Ubuntu (e.g. Ubuntu 14.04): `build-essential` `cmake3`
-- Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs][aur-ncurses5-compat-libs] (see [#778][issue-778])
+* Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs]
+  [aur-ncurses5-compat-libs] (see [#778][issue-778])
 - Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
 
 ###### Windows
@@ -355,7 +357,8 @@ that are conservatively turned off by default that you may want to turn on.
 
 ### Full Installation Guide
 
-These are the steps necessary to get YCM working on a Linux, macOS and on Windows.
+These are the steps necessary to get YCM working on a Linux, macOS and on
+Windows.
 
 **Note to Windows users:** we assume that you are running the `cmd.exe` command
 prompt and that the needed executables are in the PATH environment variable. Do
@@ -423,11 +426,12 @@ process.
 
     You will need to have `cmake` installed in order to generate the required
     makefiles.
-    - Linux users can install cmake with their package manager (usually the package is just called `cmake` on most distributions).
+    - Linux users can install cmake with their package manager (usually the
+      package is just called `cmake` on most distributions).
     - macOS users can get it through [Homebrew][brew] with `brew install
     cmake`
     - Windows users and everyone else can [download and install][
-    cmake-download] cmake from its project site.
+      cmake-download] cmake from its project site.
 
     In addition, you need to make sure you have Python headers installed.
     - On Debian-like Linux distros, you'll install them with `sudo apt-get
@@ -1142,9 +1146,10 @@ Completion and GoTo commands work out of the box with no additional
 configuration. Those features are provided by the [jedi][] library which
 supports a variety of Python versions (2.6, 2.7, 3.2+) as long as it
 runs in the corresponding Python interpreter. By default YCM runs [jedi][] with
-the same Python interpreter used by the [ycmd server][ycmd], so if you would like to
-use a different interpreter, use the following option specifying the Python
-binary to use. For example, to provide Python 3 completion in your project, set:
+the same Python interpreter used by the [ycmd server][ycmd], so if you would
+like to use a different interpreter, use the following option specifying the
+Python binary to use. For example, to provide Python 3 completion in your
+project, set:
 
 ```viml
 let g:ycm_python_binary_path = '/usr/bin/python3'
@@ -1159,7 +1164,7 @@ let g:ycm_python_binary_path = 'python'
 ```
 
 YCM will use the first `python` executable it finds in the PATH to run
-[jedi][]. This means that if you are in a virtual environment and you start vim
+[jedi][]. This means that if you are in a virtual environment and you start Vim
 in that directory, the first `python` that YCM will find will be the one in the
 virtual environment, so [jedi][] will be able to provide completions for every
 package you have in the virtual environment.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ different distributions. Use the proper package manager for your distribution.
 - Ubuntu: `build-essential` `cmake`
 - Older Ubuntu (e.g. Ubuntu 14.04): `build-essential` `cmake3`
 - Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs][aur-ncurses5-compat-libs] (see [#778][issue-778])
-* Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
+- Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
 
 ###### Windows
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Installation
 using Vundle and the ycm_core library APIs have changed (happens rarely), YCM
 will notify you to recompile it. You should then rerun the install process.
 
+**Important note for Windows users:** we assume that you are using the
+`cmd.exe` command prompt and that you know how to add an executable to the PATH
+environment variable.
+
 #### Requirements
 
 - [Compatible Vim](#compatible-vim)
@@ -199,9 +203,6 @@ installed by running `vim --version`. If the version is too old, you may need to
 [compile Vim from source][vim-build] (don't worry, it's easy).
 
 ###### Windows
-
-**Important:** we assume that you are using the `cmd.exe` command prompt and
-that you know how to add an executable to the PATH environment variable.
 
 Make sure you have at least Vim 7.4.1578 with Python 2 or Python 3 support. You
 can check the version and which Python is supported by typing `:version` inside

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ except for C# completion support for which you'll need to install
 [Mono][mono-install-windows]. Be sure that [the build utility `msbuild` is in
 your PATH][add-msbuild-to-path].
 
-#### Installation - using `install.py`
+#### Installation
 
 Install YouCompleteMe with [Vundle][] or any other Vim plugin manager of your
 choice.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ environment variable.
 - [Compatible Vim](#compatible-vim)
 - [Build Tools](#build-tools)
 - [Python](#python)
-- [C-family completion support requirements](#c-family-completion-support-requirements)
+- [C-family completion support requirements (macOS only)](#c-family-completion-support-requirements-macos-only)
+- [C# completion support requirements](c#-completion-support-requirements)
 
 ##### Compatible Vim
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ different distributions. Use the proper package manager for your distribution.
 - Older Ubuntu (e.g. Ubuntu 14.04): `build-essential` `cmake3`
 - Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs]
   [aur-ncurses5-compat-libs] (see [#778][issue-778])
-- Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
+- Fedora: `gcc` `gcc-c++` `cmake` `ncurses-compat-libs`
+- Gentoo: `ncurses:5`
 
 ###### Windows
 

--- a/README.md
+++ b/README.md
@@ -460,19 +460,11 @@ process.
 
         cmake -G "<generator>" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
 
-    The `<generator>` is different for different OSs:
+    where `<generator>` is `Unix Makefiles` on Unix systems and one of the
+    following Visual Studio generators on Windows:
 
-    - For Linux and macOS:
-
-        cmake -G "Unix Makefiles" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
-
-    - For 65 bit Windows with Visual Studio 14:
-
-        cmake -G "Visual Studio 14 Win64" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
-
-    - For 64 bit Windows with Visual Studio 15:
-
-        cmake -G "Visual Studio 14 Win64" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
+    - `Visual Studio 14 Win64`
+    - `Visual Studio 15 Win64`
 
     Remove the `Win64` part in these generators if your Vim architecture is
     32-bit.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ required. However, _If_ you have installed a Homebrew Python, see this
 [_FAQ_](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
 for details.
 
-###### Linux
+<h6 id="python-headers-on-different-linux-distros-installation">Linux</h6>
 
 Here we'll list the packages you need to install as they are named under the
 different distributions. Use the proper package manager for your distribution.
@@ -431,7 +431,8 @@ process.
       cmake-download] cmake from its project site.
 
     In addition, you need to make sure you have Python headers installed.
-    - On Debian-like Linux distros, you'll install them with `sudo apt-get
+    - If on Linux, refer to the [quick installation instructions for python
+      headers](#python-headers-on-different-linux-distros-installation)
     install python-dev python3-dev`.
     - On macOS, they are already installed.
     - On Windows, you need to download and install [Python 2 or

--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ automatically when you run `clang` for the first time, or manually by running
 
 ###### Unix
 
-For all C languages, support is enabled automatically during compilation,
-except for C# completion support for which you'll need to install
+For all C languages except for C#, support is enabled automatically during
+compilation. For C# completion support, you'll need to install
 [Mono][mono-install-linux].
 
 ###### Windows

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ different distributions. Use the proper package manager for your distribution.
 
 - Ubuntu: `build-essential` `cmake`
 - Older Ubuntu (e.g. Ubuntu 14.04): `build-essential` `cmake3`
-* Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs]
+- Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs]
   [aur-ncurses5-compat-libs] (see [#778][issue-778])
 - Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
 

--- a/README.md
+++ b/README.md
@@ -429,9 +429,9 @@ process.
     cmake-download] cmake from its project site.
 
     In addition, you need to make sure you have Python headers installed.
-    - On Debian-like Linux distros, you'll install them with be `sudo apt-get
+    - On Debian-like Linux distros, you'll install them with `sudo apt-get
     install python-dev python3-dev`.
-    - On macOS, they are usually already installed.
+    - On macOS, they are already installed.
     - On Windows, you need to download and install [Python 2 or
     Python 3][python-win-download].
 
@@ -535,7 +535,7 @@ process.
         cmake -G "<generator>" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/cregex
         cmake --build . --target _regex --config Release
 
-    where `<generator>` is the same generator used in the previous steps.
+    where `<generator>` is the same generator used in the previous step.
 
 6.  Set up support for additional languages, as desired:
 

--- a/README.md
+++ b/README.md
@@ -302,18 +302,17 @@ your PATH][add-msbuild-to-path].
 Install YouCompleteMe with [Vundle][] or any other Vim plugin manager of your
 choice.
 
-Inside the `YouCompleteMe` directory, there is a python script called
-`install.py`, it will be found on the following locations for the following
-OSs:
+Navigate to the YouCompleteMe directory: 
 
-- macOS / Linux: `~/.vim/bundle/YouCompleteMe`
-- Windows: `%USERPROFILE%/vimfiles/bundle/YouCompleteMe`
+- on UNIX platforms, `cd ~/.vim/bundle/YouCompleteMe`
+- on Windows, `cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe`
 
-Compiling YCM **with** semantic support for C-family languages:
+
+Compile YCM **with** semantic support for C-family languages:
 
     python install.py --clang-completer
 
-Compiling YCM **without** semantic support for C-family languages:
+Compile YCM **without** semantic support for C-family languages:
 
     python install.py
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ During setup, select _Desktop development with C++_ in _Workloads_.
 
 ###### macOS
 
-_If_ you have installed a Homebrew Python, see this
+YouCompleteMe is supported using system python on macOS, so no installation is
+required. However, _If_ you have installed a Homebrew Python, see this
 [_FAQ_](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
 for details.
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ process.
     - On Windows, you need to download and install [Python 2 or
     Python 3][python-win-download].
 
-    On windows only, you'll also need Microsoft Visual C++ (MSVC) to build YCM.
+    On Windows only, you'll also need Microsoft Visual C++ (MSVC) to build YCM.
     You can obtain it by installing [Visual Studio][visual-studio-download].
     MSVC 14 (Visual Studio 2015) and 15 (2017) are officially supported.
 

--- a/README.md
+++ b/README.md
@@ -247,20 +247,6 @@ During setup, select _Desktop development with C++_ in _Workloads_.
 
 ##### Python
 
-###### Windows
-
-[Python 2 or Python 3][python-win-download]. Be sure to pick the version
-corresponding to your Vim architecture. It is _Windows x86_ for a 32-bit Vim
-and _Windows x86-64_ for a 64-bit Vim. We recommend installing Python 3.
-Additionally, the version of Python you install must match up exactly with
-the version of Python that Vim is looking for. Type `:version` and look at the
-bottom of the page at the list of compiler flags. Look for flags that look
-similar to `-DDYNAMIC_PYTHON_DLL=\"python27.dll\"` and
-`-DDYNAMIC_PYTHON3_DLL=\"python35.dll\"`. The former indicates that Vim is
-looking for Python 2.7 and the latter indicates that Vim is looking for
-Python 3.5. You'll need one or the other installed, matching the version
-number exactly.
-
 ###### macOS
 
 _If_ you have installed a Homebrew Python, see this
@@ -275,6 +261,20 @@ different distributions. Use the proper package manager for your distribution.
 - Ubuntu: `python-dev` `python3-dev`
 - Fedora: `python-devel` `python3-devel`
 - Arch Linux: `python`
+
+###### Windows
+
+[Python 2 or Python 3][python-win-download]. Be sure to pick the version
+corresponding to your Vim architecture. It is _Windows x86_ for a 32-bit Vim
+and _Windows x86-64_ for a 64-bit Vim. We recommend installing Python 3.
+Additionally, the version of Python you install must match up exactly with
+the version of Python that Vim is looking for. Type `:version` and look at the
+bottom of the page at the list of compiler flags. Look for flags that look
+similar to `-DDYNAMIC_PYTHON_DLL=\"python27.dll\"` and
+`-DDYNAMIC_PYTHON3_DLL=\"python35.dll\"`. The former indicates that Vim is
+looking for Python 2.7 and the latter indicates that Vim is looking for
+Python 3.5. You'll need one or the other installed, matching the version
+number exactly.
 
 ##### C-family completion support requirements (macOS only)
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,7 @@ Contents
 
 - [Intro](#intro)
 - [Installation](#installation)
-    - [Mac OS X](#mac-os-x)
-    - [Ubuntu Linux x64](#ubuntu-linux-x64)
-    - [Fedora Linux x64](#fedora-linux-x64)
-    - [Windows](#windows)
-    - [FreeBSD/OpenBSD](#freebsdopenbsd)
+    - [Quick Installation Guide](#quick-installation-guide)
     - [Full Installation Guide](#full-installation-guide)
 - [Quick Feature Summary](#quick-feature-summary)
 - [User Guide](#user-guide)

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ different distributions. Use the proper package manager for your distribution.
 
 - Ubuntu: `build-essential` `cmake`
 - Older Ubuntu (e.g. Ubuntu 14.04): `build-essential` `cmake3`
-* Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs][aur-ncurses5-compat-libs] (see [#778][issue-778])
+- Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs][aur-ncurses5-compat-libs] (see [#778][issue-778])
 * Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
 
 ###### Windows
@@ -273,7 +273,7 @@ different distributions. Use the proper package manager for your distribution.
 
 - Ubuntu: `python-dev` `python3-dev`
 - Fedora: `python-devel` `python3-devel`
-* Arch Linux: `python`
+- Arch Linux: `python`
 
 ##### C-family completion support requirements (macOS only)
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ process.
     - On Mac OS X, they are usually already installed.
     - On Windows, you need to download and install [Python 2 or
     Python 3][python-win-download].
-    
+
     On windows only, you'll also need Microsoft Visual C++ (MSVC) to build YCM.
     You can obtain it by installing [Visual Studio][visual-studio-download].
     MSVC 14 (Visual Studio 2015) and 15 (2017) are officially supported.

--- a/README.md
+++ b/README.md
@@ -165,12 +165,17 @@ and a completer that integrates with [UltiSnips][].
 Installation
 ------------
 
-### Mac OS X
+### TL;DR
 
-These instructions (using `install.py`) are the quickest way to install
-YouCompleteMe, however they may not work for everyone. If the following
-instructions don't work for you, check out the [full installation
-guide](#full-installation-guide).
+**Remember:** YCM is a plugin with a compiled component. If you **update** YCM
+using Vundle and the ycm_core library APIs have changed (happens rarely), YCM
+will notify you to recompile it. You should then rerun the install process.
+
+#### Requirements
+
+##### Compatible Vim
+
+###### Mac OS X
 
 Install the latest version of [MacVim][]. Yes, MacVim. And yes, the _latest_.
 
@@ -181,216 +186,18 @@ local binary folder (for example `/usr/local/bin/mvim`) and then symlink it:
 
     ln -s /usr/local/bin/mvim vim
 
-Install YouCompleteMe with [Vundle][].
-
-**Remember:** YCM is a plugin with a compiled component. If you **update** YCM
-using Vundle and the ycm_core library APIs have changed (happens
-rarely), YCM will notify you to recompile it. You should then rerun the install
-process.
-
-**NOTE:** If you want C-family completion, you MUST have the latest Xcode
-installed along with the latest Command Line Tools (they are installed
-automatically when you run `clang` for the first time, or manually by running
-`xcode-select --install`)
-
-Install CMake. Preferably with [Homebrew][brew], but here's the [stand-alone
-CMake installer][cmake-download].
-
-_If_ you have installed a Homebrew Python and/or Homebrew MacVim, see the _FAQ_
+_If_ you have installed a Homebrew MacVim, see this
+[_FAQ_](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
 for details.
 
-Compiling YCM **with** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer
-
-Compiling YCM **without** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py
-
-The following additional language support options are available:
-
-- C# support: install Mono with [Homebrew][brew] or by downloading the [Mono Mac
-  package][mono-install-osx] and add `--cs-completer` when calling
-  `./install.py`.
-- Go support: install [Go][go-install] and add `--go-completer` when calling
-  `./install.py`.
-- TypeScript support: install [Node.js and npm][npm-install] then install the
-  TypeScript SDK with `npm install -g typescript`.
-- JavaScript support: install [Node.js and npm][npm-install] and add
-  `--js-completer` when calling `./install.py`.
-- Rust support: install [Rust][rust-install] and add
-  `--rust-completer` when calling `./install.py`.
-- Java support: install [JDK8 (version 8 required)][jdk-install] and add
-  `--java-completer` when calling `./install.py`.
-
-To simply compile with everything enabled, there's a `--all` flag.  So, to
-install with all language features, ensure `xbuild`, `go`, `tsserver`, `node`,
-`npm`, `rustc`, and `cargo` tools are installed and in your `PATH`, then
-simply run:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --all
-
-That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
-Don't forget that if you want the C-family semantic completion engine to work,
-you will need to provide the compilation flags for your project to YCM. It's all
-in the User Guide.
-
-YCM comes with sane defaults for its options, but you still may want to take a
-look at what's available for configuration. There are a few interesting options
-that are conservatively turned off by default that you may want to turn on.
-
-### Ubuntu Linux x64
-
-These instructions (using `install.py`) are the quickest way to install
-YouCompleteMe, however they may not work for everyone. If the following
-instructions don't work for you, check out the [full installation
-guide](#full-installation-guide).
+###### Unix
 
 Make sure you have Vim 7.4.1578 with Python 2 or Python 3 support. Ubuntu 16.04
 and later have a Vim that's recent enough. You can see the version of Vim
 installed by running `vim --version`. If the version is too old, you may need to
 [compile Vim from source][vim-build] (don't worry, it's easy).
 
-Install YouCompleteMe with [Vundle][].
-
-**Remember:** YCM is a plugin with a compiled component. If you **update** YCM
-using Vundle and the ycm_core library APIs have changed (happens
-rarely), YCM will notify you to recompile it. You should then rerun the install
-process.
-
-Install development tools and CMake:
-
-    sudo apt-get install build-essential cmake
-
-**Note:** On older systems (e.g. Ubuntu 14.04) you may run into compilation
-issues with `cmake`. Therefore, install the following instead:
-
-    sudo apt-get install build-essential cmake3
-
-Make sure you have Python headers installed:
-
-    sudo apt-get install python-dev python3-dev
-
-Compiling YCM **with** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer
-
-Compiling YCM **without** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py
-
-The following additional language support options are available:
-
-- C# support: install [Mono][mono-install-ubuntu] and add `--cs-completer`
-  when calling `./install.py`.
-- Go support: install [Go][go-install] and add `--go-completer` when calling
-  `./install.py`.
-- TypeScript support: install [Node.js and npm][npm-install] then install the
-  TypeScript SDK with `npm install -g typescript`.
-- JavaScript support: install [Node.js and npm][npm-install] and add
-  `--js-completer` when calling `./install.py`.
-- Rust support: install [Rust][rust-install] and add `--rust-completer` when
-  calling `./install.py`.
-- Java support: install [JDK8 (version 8 required)][jdk-install] and add
-  `--java-completer` when calling `./install.py`.
-
-To simply compile with everything enabled, there's a `--all` flag.  So, to
-install with all language features, ensure `xbuild`, `go`, `tsserver`, `node`,
-`npm`, `rustc`, and `cargo` tools are installed and in your `PATH`, then
-simply run:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --all
-
-That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
-Don't forget that if you want the C-family semantic completion engine to work,
-you will need to provide the compilation flags for your project to YCM. It's all
-in the User Guide.
-
-YCM comes with sane defaults for its options, but you still may want to take a
-look at what's available for configuration. There are a few interesting options
-that are conservatively turned off by default that you may want to turn on.
-
-### Fedora Linux x64
-
-These instructions (using `install.py`) are the quickest way to install
-YouCompleteMe, however they may not work for everyone. If the following
-instructions don't work for you, check out the [full installation
-guide](#full-installation-guide).
-
-Make sure you have Vim 7.4.1578 with Python 2 or Python 3 support. Fedora 21 and
-later have a Vim that's recent enough. You can see the version of Vim installed
-by running `vim --version`. If the version is too old, you may need to [compile
-Vim from source][vim-build] (don't worry, it's easy).
-
-Install YouCompleteMe with [Vundle][].
-
-**Remember:** YCM is a plugin with a compiled component. If you **update** YCM
-using Vundle and the ycm_core library APIs have changed (happens
-rarely), YCM will notify you to recompile it. You should then rerun the install
-process.
-
-Install development tools and CMake:
-
-    sudo dnf install automake gcc gcc-c++ kernel-devel cmake
-
-Make sure you have Python headers installed:
-
-    sudo dnf install python-devel python3-devel
-
-Compiling YCM **with** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer
-
-Compiling YCM **without** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py
-
-The following additional language support options are available:
-
-- C# support: install [Mono][mono-install-fedora] and add `--cs-completer`
-  when calling `./install.py`.
-- Go support: install [Go][go-install] and add `--go-completer` when calling
-  `./install.py`.
-- TypeScript support: install [Node.js and npm][npm-install] then install the
-  TypeScript SDK with `npm install -g typescript`.
-- JavaScript support: install [Node.js and npm][npm-install] and add
-  `--js-completer` when calling `./install.py`.
-- Rust support: install [Rust][rust-install] and add `--rust-completer` when
-  calling `./install.py`.
-- Java support: install [JDK8 (version 8 required)][jdk-install] and add
-  `--java-completer` when calling `./install.py`.
-
-To simply compile with everything enabled, there's a `--all` flag.  So, to
-install with all language features, ensure `xbuild`, `go`, `tsserver`, `node`,
-`npm`, `rustc`, and `cargo` tools are installed and in your `PATH`, then
-simply run:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --all
-
-That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
-Don't forget that if you want the C-family semantic completion engine to work,
-you will need to provide the compilation flags for your project to YCM. It's all
-in the User Guide.
-
-YCM comes with sane defaults for its options, but you still may want to take a
-look at what's available for configuration. There are a few interesting options
-that are conservatively turned off by default that you may want to turn on.
-
-### Windows
-
-These instructions (using `install.py`) are the quickest way to install
-YouCompleteMe, however they may not work for everyone. If the following
-instructions don't work for you, check out the [full installation
-guide](#full-installation-guide).
+###### Windows
 
 **Important:** we assume that you are using the `cmd.exe` command prompt and
 that you know how to add an executable to the PATH environment variable.
@@ -411,45 +218,107 @@ to your [vimrc][] if not already present. This option is required by YCM. Note
 that it does not prevent you from editing a file in another encoding than UTF-8.
 You can do that by specifying [the `++enc` argument][++enc] to the `:e` command.
 
-Install YouCompleteMe with [Vundle][].
+##### Build Tools
 
-**Remember:** YCM is a plugin with a compiled component. If you **update** YCM
-using Vundle and the ycm_core library APIs have changed (happens
-rarely), YCM will notify you to recompile it. You should then rerun the install
-process.
+###### Mac OS X
 
-Download and install the following software:
+Install CMake. Preferably with [Homebrew][brew], but here's the [stand-alone
+CMake installer][cmake-download].
 
-- [Python 2 or Python 3][python-win-download]. Be sure to pick the version
-  corresponding to your Vim architecture. It is _Windows x86_ for a 32-bit Vim
-  and _Windows x86-64_ for a 64-bit Vim. We recommend installing Python 3.
-  Additionally, the version of Python you install must match up exactly with
-  the version of Python that Vim is looking for. Type `:version` and look at the
-  bottom of the page at the list of compiler flags. Look for flags that look
-  similar to `-DDYNAMIC_PYTHON_DLL=\"python27.dll\"` and
-  `-DDYNAMIC_PYTHON3_DLL=\"python35.dll\"`. The former indicates that Vim is
-  looking for Python 2.7 and the latter indicates that Vim is looking for
-  Python 3.5. You'll need one or the other installed, matching the version
-  number exactly.
-- [CMake][cmake-download]. Add CMake executable to the PATH environment
+###### Unix
+
+Here we'll list the packages you need to install as they are named under the
+different distributions. Use the proper package manager for your distribution.
+
+- Ubuntu: `build-essential` `cmake`
+- Older Ubuntu (e.g. Ubuntu 14.04): `build-essential` `cmake3`
+* Arch Linux: `cmake` `base-devel`
+* Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
+
+###### Windows
+
+Install [CMake][cmake-download]. Add CMake executable to the PATH environment
 variable.
-- [Visual Studio][visual-studio-download]. Download the community edition.
+
+Install [Visual Studio][visual-studio-download]. Download the community edition.
 During setup, select _Desktop development with C++_ in _Workloads_.
+
+##### Python
+
+###### Windows
+
+[Python 2 or Python 3][python-win-download]. Be sure to pick the version
+corresponding to your Vim architecture. It is _Windows x86_ for a 32-bit Vim
+and _Windows x86-64_ for a 64-bit Vim. We recommend installing Python 3.
+Additionally, the version of Python you install must match up exactly with
+the version of Python that Vim is looking for. Type `:version` and look at the
+bottom of the page at the list of compiler flags. Look for flags that look
+similar to `-DDYNAMIC_PYTHON_DLL=\"python27.dll\"` and
+`-DDYNAMIC_PYTHON3_DLL=\"python35.dll\"`. The former indicates that Vim is
+looking for Python 2.7 and the latter indicates that Vim is looking for
+Python 3.5. You'll need one or the other installed, matching the version
+number exactly.
+
+###### Mac OS X
+
+_If_ you have installed a Homebrew Python, see this
+[_FAQ_](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
+for details.
+
+###### Unix
+
+Here we'll list the packages you need to install as they are named under the
+different distributions. Use the proper package manager for your distribution.
+
+- Ubuntu: `python-dev` `python3-dev`
+- Fedora: `python-devel` `python3-devel`
+* Arch Linux: `python`
+
+##### C-family completion support requirements
+
+###### Mac OS X only
+
+For all C languages, completion support on Mac OS X requires the latest Xcode
+installed along with the latest Command Line Tools (they are installed
+automatically when you run `clang` for the first time, or manually by running
+`xcode-select --install`).
+
+###### Unix
+
+For all C languages, support is enabled automatically during compilation,
+except for C# completion support for which you'll need to install
+[Mono][mono-install-linux].
+
+###### Windows
+
+For all C languages, support is enabled automatically during compilation,
+except for C# completion support for which you'll need to install
+[Mono][mono-install-windows]. Be sure that [the build utility `msbuild` is in
+your PATH][add-msbuild-to-path].
+
+#### Installation - using `install.py`
+
+Install YouCompleteMe with [Vundle][] or any other Vim plugin manager of your
+choice.
+
+Inside the `YouCompleteMe` directory, there is a python script called
+`install.py`, it will be found on the following locations for the following
+OSs:
+
+- Mac OS X / Unix: `~/.vim/bundle/YouCompleteMe`
+- Windows: `%USERPROFILE%/vimfiles/bundle/YouCompleteMe`
 
 Compiling YCM **with** semantic support for C-family languages:
 
-    cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
     python install.py --clang-completer
 
 Compiling YCM **without** semantic support for C-family languages:
 
-    cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
     python install.py
 
 The following additional language support options are available:
 
 - C# support: add `--cs-completer` when calling `install.py`.
-  Be sure that [the build utility `msbuild` is in your PATH][add-msbuild-to-path].
 - Go support: install [Go][go-install] and add `--go-completer` when calling
   `install.py`.
 - TypeScript support: install [Node.js and npm][npm-install] then install the
@@ -462,85 +331,17 @@ The following additional language support options are available:
   `--java-completer` when calling `./install.py`.
 
 To simply compile with everything enabled, there's a `--all` flag.  So, to
-install with all language features, ensure `msbuild`, `go`, `tsserver`, `node`,
+install with all language features, ensure `xbuild`, `go`, `tsserver`, `node`,
 `npm`, and `cargo` tools are installed and in your `PATH`, then simply run:
 
-    cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe
     python install.py --all
+
+##### Windows specific options
 
 You can specify the Microsoft Visual C++ (MSVC) version using the `--msvc`
 option. YCM officially supports MSVC 14 (Visual Studio 2015) and 15 (2017).
 
-That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
-Don't forget that if you want the C-family semantic completion engine to work,
-you will need to provide the compilation flags for your project to YCM. It's all
-in the User Guide.
-
-YCM comes with sane defaults for its options, but you still may want to take a
-look at what's available for configuration. There are a few interesting options
-that are conservatively turned off by default that you may want to turn on.
-
-### FreeBSD/OpenBSD
-
-These instructions (using `install.py`) are the quickest way to install
-YouCompleteMe, however they may not work for everyone. If the following
-instructions don't work for you, check out the [full installation
-guide](#full-installation-guide).
-
-**NOTE:** OpenBSD / FreeBSD are not officially supported platforms by YCM.
-
-Make sure you have Vim 7.4.1578 with Python 2 or Python 3 support.
-
-OpenBSD 5.5 and later have a Vim that's recent enough. You can see the version of
-Vim installed by running `vim --version`.
-
-For FreeBSD 11.x, the requirement is cmake:
-
-    pkg install cmake
-
-Install YouCompleteMe with [Vundle][].
-
-**Remember:** YCM is a plugin with a compiled component. If you **update** YCM
-using Vundle and the ycm_core library APIs have changed (happens
-rarely), YCM will notify you to recompile it. You should then rerun the install
-process.
-
-Compiling YCM **with** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --clang-completer
-
-Compiling YCM **without** semantic support for C-family languages:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py
-
-If the `python` executable is not present, or the default `python` is not the
-one that should be compiled against, specify the python interpreter explicitly:
-
-    python3 install.py --clang-completer
-
-The following additional language support options are available:
-
-- C# support: install Mono and add `--cs-completer` when calling
-  `./install.py`.
-- Go support: install [Go][go-install] and add `--go-completer` when calling
-  `./install.py`.
-- TypeScript support: install [Node.js and npm][npm-install] then install the
-  TypeScript SDK with `npm install -g typescript`.
-- JavaScript support: install [Node.js and npm][npm-install] and add
-  `--js-completer` when calling `./install.py`.
-- Rust support: install [Rust][rust-install] and add `--rust-completer` when
-  calling `./install.py`.
-- Java support: install [JDK8 (version 8 required)][jdk-install] and add
-  `--java-completer` when calling `./install.py`.
-
-To simply compile with everything enabled, there's a `--all` flag.  So, to
-install with all language features, ensure `xbuild`, `go`, `tsserver`, `node`,
-`npm`, and `cargo` tools are installed and in your `PATH`, then simply run:
-
-    cd ~/.vim/bundle/YouCompleteMe
-    ./install.py --all
+#### Final notes
 
 That's it. You're done. Refer to the _User Guide_ section on how to use YCM.
 Don't forget that if you want the C-family semantic completion engine to work,
@@ -620,18 +421,21 @@ process.
     is the C++ engine that YCM uses to get fast completions.
 
     You will need to have `cmake` installed in order to generate the required
-    makefiles. Linux users can install cmake with their package manager (`sudo
-    apt-get install cmake` for Ubuntu) whereas other users can [download and
-    install][cmake-download] cmake from its project site. Mac users can also get
-    it through [Homebrew][brew] with `brew install cmake`.
+    makefiles.
+    - Linux users can install cmake with their package manager (usually the package is just called `cmake` on most distributions).
+    - Mac OS X users can get it through [Homebrew][brew] with `brew install
+    cmake`
+    - Windows users and everyone else can can [download and install][
+    cmake-download] cmake from its project site.
 
-    On a Unix OS, you need to make sure you have Python headers installed. On a
-    Debian-like Linux distro, this would be `sudo apt-get install python-dev
-    python3-dev`. On Mac they should already be present.
-
-    On Windows, you need to download and install [Python 2 or
-    Python 3][python-win-download]. Pick the version corresponding to your Vim
-    architecture. You will also need Microsoft Visual C++ (MSVC) to build YCM.
+    In addition, you need to make sure you have Python headers installed.
+    - On Debian-like Linux distros, you'll install them with be `sudo apt-get
+    install python-dev python3-dev`.
+    - On Mac OS X, they are usually already installed.
+    - On Windows, you need to download and install [Python 2 or
+    Python 3][python-win-download].
+    
+    On windows only, you'll also need Microsoft Visual C++ (MSVC) to build YCM.
     You can obtain it by installing [Visual Studio][visual-studio-download].
     MSVC 14 (Visual Studio 2015) and 15 (2017) are officially supported.
 
@@ -651,11 +455,19 @@ process.
 
         cmake -G "<generator>" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
 
-    where `<generator>` is `Unix Makefiles` on Unix systems and one of the
-    following Visual Studio generators on Windows:
+    The `<generator>` is different for different OSs:
 
-    - `Visual Studio 14 Win64`
-    - `Visual Studio 15 Win64`
+    - For Linux and Mac OS X:
+
+        cmake -G "Unix Makefiles" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
+
+    - For 65 bit Windows with Visual Studio 14:
+
+        cmake -G "Visual Studio 14 Win64" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
+
+    - For 64 bit Windows with Visual Studio 15:
+
+        cmake -G "Visual Studio 14 Win64" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp
 
     Remove the `Win64` part in these generators if your Vim architecture is
     32-bit.
@@ -723,7 +535,7 @@ process.
         cmake -G "<generator>" . ~/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/cregex
         cmake --build . --target _regex --config Release
 
-    where `<generator>` is the same generator used in the previous step.
+    where `<generator>` is the same generator used in the previous steps.
 
 6.  Set up support for additional languages, as desired:
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ environment variable.
 
 ###### macOS
 
-Install the latest version of [MacVim][]. Yes, MacVim. And yes, the _latest_.
+Either install MacVim with Homebrew using `brew install macvim
+--with-override-system-vim`. _If_ you have installed a Homebrew MacVim, see
+[this _FAQ_ entry](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
+for details.
 
 If you don't use the MacVim GUI, it is recommended to use the Vim binary that is
 inside the MacVim.app package (`MacVim.app/Contents/MacOS/Vim`). To ensure it
@@ -192,10 +195,6 @@ works correctly copy the `mvim` script from the [MacVim][] download to your
 local binary folder (for example `/usr/local/bin/mvim`) and then symlink it:
 
     ln -s /usr/local/bin/mvim vim
-
-_If_ you have installed a Homebrew MacVim, see this
-[_FAQ_](#i-have-a-homebrew-python-andor-macvim-cant-compilesigabrt-when-starting)
-for details.
 
 ###### Linux
 

--- a/README.md
+++ b/README.md
@@ -275,14 +275,14 @@ different distributions. Use the proper package manager for your distribution.
 - Fedora: `python-devel` `python3-devel`
 * Arch Linux: `python`
 
-##### C-family completion support requirements
-
-###### macOS
+##### C-family completion support requirements (macOS only)
 
 For all C languages, completion support on macOS requires the latest Xcode
 installed along with the latest Command Line Tools (they are installed
 automatically when you run `clang` for the first time, or manually by running
 `xcode-select --install`).
+
+##### C# completion support requirements
 
 ###### Linux
 

--- a/README.md
+++ b/README.md
@@ -305,22 +305,15 @@ your PATH][add-msbuild-to-path].
 Install YouCompleteMe with [Vundle][] or any other Vim plugin manager of your
 choice.
 
-Navigate to the YouCompleteMe directory: 
+Navigate to the YouCompleteMe directory:
 
 - on UNIX platforms, `cd ~/.vim/bundle/YouCompleteMe`
 - on Windows, `cd %USERPROFILE%/vimfiles/bundle/YouCompleteMe`
 
+When running `install.py`, follow these instructions for adding support for
+these languages:
 
-Compile YCM **with** semantic support for C-family languages:
-
-    python install.py --clang-completer
-
-Compile YCM **without** semantic support for C-family languages:
-
-    python install.py
-
-The following additional language support options are available:
-
+- C-family support: add `--clang-completer` when calling `install.py`.
 - C# support: add `--cs-completer` when calling `install.py`.
 - Go support: install [Go][go-install] and add `--go-completer` when calling
   `install.py`.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ different distributions. Use the proper package manager for your distribution.
 
 - Ubuntu: `build-essential` `cmake`
 - Older Ubuntu (e.g. Ubuntu 14.04): `build-essential` `cmake3`
-* Arch Linux: `cmake` `base-devel`
+* Arch Linux: `cmake` `base-devel` AUR: [ncurses5-compat-libs][aur-ncurses5-compat-libs] (see [#778][issue-778])
 * Fedora: `automake` `gcc` `gcc-c++` `kernel-devel` `cmake`
 
 ###### Windows
@@ -3275,6 +3275,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [issue-303]: https://github.com/Valloric/YouCompleteMe/issues/303
 [issue-593]: https://github.com/Valloric/YouCompleteMe/issues/593
 [issue-669]: https://github.com/Valloric/YouCompleteMe/issues/669
+[issue-778]: https://github.com/Valloric/YouCompleteMe/issues/778
 [status-mes]: https://groups.google.com/forum/#!topic/vim_dev/WeBBjkXE8H8
 [python-re]: https://docs.python.org/2/library/re.html#regular-expression-syntax
 [Bear]: https://github.com/rizsotto/Bear
@@ -3324,3 +3325,4 @@ This software is licensed under the [GPL v3 license][gpl].
 [jdtls-release]: http://download.eclipse.org/jdtls/milestones
 [diacritic]: https://www.unicode.org/glossary/#diacritic
 [regex]: https://pypi.org/project/regex/
+[aur-ncurses5-compat-libs]: https://aur.archlinux.org/packages/ncurses5-compat-libs/


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Continuing from #3042 and #3043, I've started refactoring the `README.md`. Most importantly, I've merged all the non-full installation guides at the beginning to a single guide with different instructions for every OS only when needed. I've marked this PR as a `[WIP]` since I'm not sure what to do with the full installation guide which stayed roughly the same.

Should I leave only one fully detailed installation guide? Or perhaps it'll be better to have a short and quick installation guide along with a fully detailed guide like the original? That's how I've done it in the version I'm suggesting here.

I've haven't stepped into documenting `EXTRA_CMAKE_ARGS` as explained in `third_party/ycmd/build.py` as pointed out by @bstaletic here: https://github.com/Valloric/YouCompleteMe/issues/3043#issuecomment-392961283, but I've documented the _real_ fix to #778 for Arch Linux users.

I'll need your opinions before I'll move on. Thanks.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3055)
<!-- Reviewable:end -->
