### PR TITLE
[docs] Include make, ncurses-compat-libs in list of Fedora dependencies

### DIFF
--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -549,7 +549,7 @@ will notify you to recompile it. You should then rerun the install process.
 
 Install development tools and CMake:
 >
-  sudo dnf install automake gcc gcc-c++ kernel-devel cmake
+  sudo dnf install automake gcc gcc-c++ kernel-devel make cmake
 <
 Make sure you have Python headers installed:
 >

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -549,7 +549,7 @@ will notify you to recompile it. You should then rerun the install process.
 
 Install development tools and CMake:
 >
-  sudo dnf install automake gcc gcc-c++ kernel-devel make cmake
+  sudo dnf install automake gcc gcc-c++ kernel-devel make cmake ncurses-compat-libs
 <
 Make sure you have Python headers installed:
 >


### PR DESCRIPTION
# PR Prelude
- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
I just performed a fresh install on Fedora 28 server, and found that `make` needs to be explicitly installed as well.

Without make:
```
❯ ./install.py --clang-completer --go-completer --rust-completer
Searching Python 2.7 libraries...
Found Python library: /usr/lib64/python2.7/config/libpython2.7.so
Found Python headers folder: /usr/include/python2.7
CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
See also "/tmp/ycm_build_t8zIpC/CMakeFiles/CMakeOutput.log".
ERROR: the build failed.

NOTE: it is *highly* unlikely that this is a bug but rather
that this is a problem with the configuration of your system
or a missing dependency. Please carefully read CONTRIBUTING.md
and if you're sure that it is a bug, please raise an issue on the
issue tracker, including the entire output of this script
and the invocation line used to run it.
```

With make, the build succeeds.

Additionally, after the make succeeded, I received the following failures:
```
❯ cat /tmp/ycmd_39433_stderr_9NjDDL.log
2018-07-06 23:25:44,352 - ERROR - libtinfo.so.5: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/home/bunn/stuff/dotfiles/.vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/server_utils.py", line 96, in CompatibleWithCurrentCore
    ycm_core = ImportCore()
  File "/home/bunn/stuff/dotfiles/.vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/server_utils.py", line 88, in ImportCore
    import ycm_core as ycm_core
ImportError: libtinfo.so.5: cannot open shared object file: No such file or directory
```

The installation of `ncurses-compat-libs` resolves this.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3069)
<!-- Reviewable:end -->
