### PR TITLE
[READY] Support modifiers for GoTo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2868,13 +2868,30 @@ let g:ycm_use_ultisnips_completer = 1
 
 ### The `g:ycm_goto_buffer_command` option
 
-Defines where `GoTo*` commands result should be opened.
-Can take one of the following values:
-`[ 'same-buffer', 'horizontal-split', 'vertical-split', 'new-tab',
-  'new-or-existing-tab' ]`
+Defines where `GoTo*` commands result should be opened. Can take one of the
+following values:
+`[ 'same-buffer', 'split', 'split-or-existing-window' ]`
 If this option is set to the `'same-buffer'` but current buffer can not
 be switched (when buffer is modified and `nohidden` option is set),
-then result will be opened in horizontal split.
+then result will be opened in a split. When the option is set to
+`'split-or-existing-window'`, if the result is already open in a window of the
+current tab page (or any tab pages with the `:tab` modifier; see below), it
+will jump to that window. Otherwise, the result will be opened in a split as if
+the option was set to `'split'`.
+
+To customize the way a new window is split, prefix the `GoTo*` command with one
+of the following modifiers: `:aboveleft`, `:belowright`, `:botright`,
+`:leftabove`, `:rightbelow`, `:topleft`, and `:vertical`. For instance, to
+split vertically to the right of the current window, run the command:
+```viml
+:rightbelow vertical YcmCompleter GoTo
+```
+
+To open in a new tab page, use the `:tab` modifier with the `'split'` or
+`'split-or-existing-window'` options e.g.:
+```viml
+:tab YcmCompleter GoTo
+```
 
 Default: `'same-buffer'`
 

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -845,7 +845,8 @@ function! s:SetUpCommands()
   command! -nargs=* -complete=custom,youcompleteme#LogsComplete
         \ YcmToggleLogs call s:ToggleLogs(<f-args>)
   command! -nargs=* -complete=custom,youcompleteme#SubCommandsComplete -range
-        \ YcmCompleter call s:CompleterCommand(<count>,
+        \ YcmCompleter call s:CompleterCommand(<q-mods>,
+        \                                      <count>,
         \                                      <line1>,
         \                                      <line2>,
         \                                      <f-args>)
@@ -889,7 +890,7 @@ function! youcompleteme#LogsComplete( arglead, cmdline, cursorpos )
 endfunction
 
 
-function! s:CompleterCommand( count, line1, line2, ... )
+function! s:CompleterCommand( mods, count, line1, line2, ... )
   " CompleterCommand will call the OnUserCommand function of a completer. If
   " the first arguments is of the form "ft=..." it can be used to specify the
   " completer to use (for example "ft=cpp"). Else the native filetype completer
@@ -910,6 +911,7 @@ function! s:CompleterCommand( count, line1, line2, ... )
   exec s:python_command "ycm_state.SendCommandRequest(" .
         \ "vim.eval( 'l:arguments' )," .
         \ "vim.eval( 'l:completer' )," .
+        \ "vim.eval( 'a:mods' )," .
         \ "vimsupport.GetBoolValue( 'a:count != -1' )," .
         \ "vimsupport.GetIntValue( 'a:line1' )," .
         \ "vimsupport.GetIntValue( 'a:line2' ) )"

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -3107,11 +3107,27 @@ Default: '1'
 The *g:ycm_goto_buffer_command* option
 
 Defines where 'GoTo*' commands result should be opened. Can take one of the
-following values: "[ 'same-buffer', 'horizontal-split', 'vertical-split', 'new-
-tab', 'new-or-existing-tab' ]" If this option is set to the "'same-buffer'" but
-current buffer can not be switched (when buffer is modified and 'nohidden'
-option is set), then result will be opened in horizontal split.
+following values: "[ 'same-buffer', 'split', 'split-or-existing-window' ]" If
+this option is set to the "'same-buffer'" but current buffer can not be
+switched (when buffer is modified and 'nohidden' option is set), then result
+will be opened in a split. When the option is set to "'split-or-existing-
+window'", if the result is already open in a window of the current tab page (or
+any tab pages with the ':tab' modifier; see below), it will jump to that
+window. Otherwise, the result will be opened in a split as if the option was
+set to "'split'".
 
+To customize the way a new window is split, prefix the 'GoTo*' command with one
+of the following modifiers: ':aboveleft', ':belowright', ':botright',
+':leftabove', ':rightbelow', ':topleft', and ':vertical'. For instance, to
+split vertically to the right of the current window, run the command:
+>
+  :rightbelow vertical YcmCompleter GoTo
+<
+To open in a new tab page, use the ':tab' modifier with the "'split'" or
+"'split-or-existing-window'" options e.g.:
+>
+  :tab YcmCompleter GoTo
+<
 Default: "'same-buffer'"
 >
   let g:ycm_goto_buffer_command = 'same-buffer'

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -60,7 +60,7 @@ class CommandRequest( BaseRequest ):
     return self._response
 
 
-  def RunPostCommandActionsIfNeeded( self ):
+  def RunPostCommandActionsIfNeeded( self, modifiers ):
     if not self.Done() or self._response is None:
       return
 
@@ -82,10 +82,10 @@ class CommandRequest( BaseRequest ):
     # The only other type of response we understand is GoTo, and that is the
     # only one that we can't detect just by inspecting the response (it should
     # either be a single location or a list)
-    return self._HandleGotoResponse()
+    return self._HandleGotoResponse( modifiers )
 
 
-  def _HandleGotoResponse( self ):
+  def _HandleGotoResponse( self, modifiers ):
     if isinstance( self._response, list ):
       vimsupport.SetQuickFixList(
         [ _BuildQfListItem( x ) for x in self._response ] )
@@ -93,7 +93,8 @@ class CommandRequest( BaseRequest ):
     else:
       vimsupport.JumpToLocation( self._response[ 'filepath' ],
                                  self._response[ 'line_num' ],
-                                 self._response[ 'column_num' ] )
+                                 self._response[ 'column_num' ],
+                                 modifiers )
 
 
   def _HandleFixitResponse( self ):
@@ -131,11 +132,11 @@ class CommandRequest( BaseRequest ):
     vimsupport.WriteToPreviewWindow( self._response[ 'detailed_info' ] )
 
 
-def SendCommandRequest( arguments, completer, extra_data = None ):
+def SendCommandRequest( arguments, completer, modifiers, extra_data = None ):
   request = CommandRequest( arguments, completer, extra_data )
   # This is a blocking call.
   request.Start()
-  request.RunPostCommandActionsIfNeeded()
+  request.RunPostCommandActionsIfNeeded( modifiers )
   return request.Response()
 
 

--- a/python/ycm/tests/client/command_request_test.py
+++ b/python/ycm/tests/client/command_request_test.py
@@ -100,7 +100,7 @@ class GoToResponse_QuickFix_test( object ):
                       variable_exists ):
     self._request._response = completer_response
 
-    self._request.RunPostCommandActionsIfNeeded()
+    self._request.RunPostCommandActionsIfNeeded( 'aboveleft' )
 
     vim_eval.assert_has_exact_calls( [
       call( 'setqflist( {0} )'.format( json.dumps( expected_qf_list ) ) )
@@ -120,7 +120,7 @@ class Response_Detection_test( object ):
       with patch( 'vim.command' ) as vim_command:
         request = CommandRequest( [ command ] )
         request._response = response
-        request.RunPostCommandActionsIfNeeded()
+        request.RunPostCommandActionsIfNeeded( 'belowright' )
         vim_command.assert_called_with( "echo '{0}'".format( response ) )
 
     tests = [
@@ -144,7 +144,7 @@ class Response_Detection_test( object ):
           request._response = {
             'fixits': []
           }
-          request.RunPostCommandActionsIfNeeded()
+          request.RunPostCommandActionsIfNeeded( 'botright' )
 
           post_vim_message.assert_called_with(
             'No fixits found for current line', warning = False )
@@ -163,7 +163,7 @@ class Response_Detection_test( object ):
                       return_value = selection ):
             request = CommandRequest( [ command ] )
             request._response = response
-            request.RunPostCommandActionsIfNeeded()
+            request.RunPostCommandActionsIfNeeded( 'leftabove' )
 
             replace_chunks.assert_called_with( chunks, silent = silent )
             post_vim_message.assert_not_called()
@@ -222,7 +222,7 @@ class Response_Detection_test( object ):
       with patch( 'ycm.vimsupport.PostVimMessage' ) as post_vim_message:
         request = CommandRequest( [ command ] )
         request._response = { 'message': message }
-        request.RunPostCommandActionsIfNeeded()
+        request.RunPostCommandActionsIfNeeded( 'rightbelow' )
         post_vim_message.assert_called_with( message, warning = False )
 
     tests = [
@@ -243,7 +243,7 @@ class Response_Detection_test( object ):
       with patch( 'ycm.vimsupport.WriteToPreviewWindow' ) as write_to_preview:
         request = CommandRequest( [ command ] )
         request._response = { 'detailed_info': info }
-        request.RunPostCommandActionsIfNeeded()
+        request.RunPostCommandActionsIfNeeded( 'topleft' )
         write_to_preview.assert_called_with( info )
 
     tests = [
@@ -263,11 +263,12 @@ class Response_Detection_test( object ):
       with patch( 'ycm.vimsupport.JumpToLocation' ) as jump_to_location:
         request = CommandRequest( [ command ] )
         request._response = response
-        request.RunPostCommandActionsIfNeeded()
+        request.RunPostCommandActionsIfNeeded( 'rightbelow' )
         jump_to_location.assert_called_with(
             response[ 'filepath' ],
             response[ 'line_num' ],
-            response[ 'column_num' ] )
+            response[ 'column_num' ],
+            'rightbelow' )
 
     def GoToListTest( command, response ):
       # Note: the detail of these called are tested by
@@ -277,7 +278,7 @@ class Response_Detection_test( object ):
         with patch( 'ycm.vimsupport.OpenQuickFixList' ) as open_qf_list:
           request = CommandRequest( [ command ] )
           request._response = response
-          request.RunPostCommandActionsIfNeeded()
+          request.RunPostCommandActionsIfNeeded( 'tab' )
           ok_( set_qf_list.called )
           ok_( open_qf_list.called )
 

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -36,13 +36,14 @@ def SendCommandRequest_ExtraConfVimData_Works_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', False, 1, 1 )
+      ycm.SendCommandRequest( [ 'GoTo' ], 'python', 'aboveleft', False, 1, 1 )
       assert_that(
         # Positional arguments passed to SendCommandRequest.
         send_request.call_args[ 0 ],
         contains(
           contains( 'GoTo' ),
           'python',
+          'aboveleft',
           has_entries( {
             'options': has_entries( {
               'tab_size': 2,
@@ -61,13 +62,14 @@ def SendCommandRequest_ExtraConfData_UndefinedValue_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', False, 1, 1 )
+      ycm.SendCommandRequest( [ 'GoTo' ], 'python', 'belowright', False, 1, 1 )
       assert_that(
         # Positional arguments passed to SendCommandRequest.
         send_request.call_args[ 0 ],
         contains(
           contains( 'GoTo' ),
           'python',
+          'belowright',
           has_entries( {
             'options': has_entries( {
               'tab_size': 2,
@@ -84,10 +86,11 @@ def SendCommandRequest_BuildRange_NoVisualMarks_test( ycm, *args ):
                                                      'second line' ] )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', True, 1, 2 )
+      ycm.SendCommandRequest( [ 'GoTo' ], 'python', '', True, 1, 2 )
       send_request.assert_called_once_with(
         [ 'GoTo' ],
         'python',
+        '',
         {
           'options': {
             'tab_size': 2,
@@ -116,10 +119,11 @@ def SendCommandRequest_BuildRange_VisualMarks_test( ycm, *args ):
                               visual_end = [ 2, 8 ] )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', True, 1, 2 )
+      ycm.SendCommandRequest( [ 'GoTo' ], 'python', 'tab', True, 1, 2 )
       send_request.assert_called_once_with(
         [ 'GoTo' ],
         'python',
+        'tab',
         {
           'options': {
             'tab_size': 2,

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -322,6 +322,7 @@ class YouCompleteMe( object ):
   def SendCommandRequest( self,
                           arguments,
                           completer,
+                          modifiers,
                           has_range,
                           start_line,
                           end_line ):
@@ -334,7 +335,7 @@ class YouCompleteMe( object ):
     if has_range:
       extra_data.update( vimsupport.BuildRange( start_line, end_line ) )
     self._AddExtraConfDataIfNeeded( extra_data )
-    return SendCommandRequest( arguments, completer, extra_data )
+    return SendCommandRequest( arguments, completer, modifiers, extra_data )
 
 
   def GetDefinedSubcommands( self ):


### PR DESCRIPTION
This PR allows users to customize how a window is split when running the `GoTo*` commands by prefixing them with the modifiers `:aboveleft`, `:belowright`, `:botright`, etc. (see `:h mods` for the complete list). For instance, to split a window vertically at the right of the screen, one could do:
```viml
:botright vertical YcmCompleter GoTo
```
The `'horizontal-split'` and `'vertical-split'` values of the `g:ycm_goto_buffer_command` option are replaced by `'split'` since a vertical split can be obtained by prefixing the `:vertical` modifier. Those values are still kept for backward compatibility.

A new value is added `'split-or-existing-window'` that is equivalent to `new-or-existing-tab` when the `:tab` modifier is used. Without the `:tab` modifier, the `GoTo*` commands only jump to an existing window if that window is in the current tab page.

Closes https://github.com/Valloric/YouCompleteMe/pull/3090.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3091)
<!-- Reviewable:end -->
