### PR TITLE
[READY] Ignore tests in codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,10 @@ coverage:
     patch: true
     changes: true
 
+  # We don't want statistics for the tests themselves.
+  ignore:
+  - .*/tests/.*
+
 comment:
   layout: "header, diff, changes, uncovered"
   behavior: default  # update if exists else create new


### PR DESCRIPTION
I don't know why but codecov includes the `tests` folder in its coverage report since [we migrated to Python 3.7 on AppVeyor](https://github.com/Valloric/YouCompleteMe/commit/2d213e7ed2d0230a6090d11157f33d134a52cc26). Ignoring the folder in codecov configuration file like [we already do in the ycmd repository](https://github.com/Valloric/ycmd/blob/ea58cfcf502dad92258102a5dd1911d43e39bcda/codecov.yml#L16-L25) fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3108)
<!-- Reviewable:end -->
