### PR TITLE
[READY] Restore cursor position after omnifunc calls

### DIFF
--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -622,9 +622,9 @@ def OmniCompleter_GetCompletions_RestoreCursorPositionAfterOmnifuncCall_test(
   # This omnifunc moves the cursor to the test definition like
   # ccomplete#Complete would.
   def Omnifunc( findstart, base ):
+    vimsupport.SetCurrentLineAndColumn( 0, 0 )
     if findstart:
       return 5
-    vimsupport.SetCurrentLineAndColumn( 0, 0 )
     return [ 'length' ]
 
   current_buffer = VimBuffer( 'buffer',


### PR DESCRIPTION
An omnifunc may move the cursor position even on the first call, e.g. [`completeR` from the `Nvim-R` plugin](https://github.com/jalvesaq/Nvim-R/blob/0db20893d34654aefe2ea1027d815159556330a7/R/common_global.vim#L3383). The cursor position is not restored between the two calls because it's unnecessary with the changes from PR #3112.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3117)
<!-- Reviewable:end -->
