### PR TITLE
[READY] Add CUDA to C-family languages in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ First carefully read the [installation instructions](#installation) for your OS.
 We recommend you use the supplied `install.py`.
 
 Next check the [User Guide](#user-guide) section on the semantic completer that
-you are using. For C/C++/Objective C, you  _must_ read
-[this section](#c-family-semantic-completion).
+you are using. For C/C++/Objective-C/Objective-C++/CUDA, you  _must_ read [this
+section](#c-family-semantic-completion).
 
 Finally, check the [FAQ](#faq).
 
@@ -77,8 +77,8 @@ YouCompleteMe is a fast, as-you-type, fuzzy-search code completion engine for
 
 - an identifier-based engine that works with every programming language,
 - a [Clang][]-based engine that provides native semantic code
-  completion for C/C++/Objective-C/Objective-C++ (from now on referred to as
-  "the C-family languages"),
+  completion for C/C++/Objective-C/Objective-C++/CUDA (from now on referred to
+  as "the C-family languages"),
 - a [Jedi][]-based completion engine for Python 2 and 3,
 - an [OmniSharp][]-based completion engine for C#,
 - a combination of [Gocode][] and [Godef][] semantic engines for Go,
@@ -590,10 +590,9 @@ process.
     C-family languages. Otherwise it's not necessary.*
 
     **Download the latest version of `libclang`**. Clang is an open-source
-    compiler that can compile C/C++/Objective-C/Objective-C++. The `libclang`
-    library it provides is used to power the YCM semantic completion engine for
-    those languages. YCM is designed to work with libclang version 3.9 or
-    higher.
+    compiler that can compile C-family languages. The `libclang` library it
+    provides is used to power the YCM semantic completion engine for those
+    languages. YCM is designed to work with libclang version 3.9 or higher.
 
     You can use the system libclang _only if you are sure it is version 3.9 or
     higher_, otherwise don't. Even if it is, we recommend using the [official
@@ -762,7 +761,7 @@ Quick Feature Summary
 * Suggestions from Vim's OmniFunc
 * UltiSnips snippet suggestions
 
-### C-family languages (C, C++, Objective C, Objective C++)
+### C-family languages (C, C++, Objective C, Objective C++, CUDA)
 
 * Semantic auto-completion
 * Real-time diagnostic display
@@ -1599,8 +1598,8 @@ section.
 The invoked subcommand is automatically routed to the currently active semantic
 completer, so `:YcmCompleter GoToDefinition` will invoke the `GoToDefinition`
 subcommand on the Python semantic completer if the currently active file is a
-Python one and on the Clang completer if the currently active file is a
-C/C++/Objective-C one.
+Python one and on the Clang completer if the currently active file is a C-family
+language one.
 
 You may also want to map the subcommands to something less verbose; for
 instance, `nnoremap <leader>jd :YcmCompleter GoTo<CR>`
@@ -1648,7 +1647,7 @@ This command tries to perform the "most sensible" GoTo operation it can.
 Currently, this means that it tries to look up the symbol under the cursor and
 jumps to its definition if possible; if the definition is not accessible from
 the current translation unit, jumps to the symbol's declaration. For
-C/C++/Objective-C, it first tries to look up the current line for a header and
+C-family languages, it first tries to look up the current line for a header and
 jump to it. For C#, implementations are also considered and preferred.
 
 Supported in filetypes: `c, cpp, objc, objcpp, cuda, cs, go, java, javascript,

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -16,7 +16,7 @@ Contents ~
   6. Full Installation Guide            |youcompleteme-full-installation-guide|
  6. Quick Feature Summary                 |youcompleteme-quick-feature-summary|
   1. General (all languages)                            |youcompleteme-general|
-  2. C-family languages (C, C++, Objective C, Objective C++) |youcompleteme-c-family-languages|
+  2. C-family languages (C, C++, Objective C, Objective C++, CUDA) |youcompleteme-c-family-languages|
   3. C♯                                                       |youcompleteme-c|
   4. Python                                              |youcompleteme-python|
   5. Go                                                      |youcompleteme-go|
@@ -204,7 +204,7 @@ First carefully read the installation instructions for your OS. We recommend
 you use the supplied 'install.py'.
 
 Next check the User Guide section on the semantic completer that you are using.
-For C/C++/Objective C, you _must_ read this section.
+For C/C++/Objective-C/Objective-C++/CUDA, you _must_ read this section.
 
 Finally, check the FAQ.
 
@@ -273,8 +273,8 @@ Vim. It has several completion engines:
 
 - an identifier-based engine that works with every programming language,
 - a Clang [11]-based engine that provides native semantic code completion for
-  C/C++/Objective-C/Objective-C++ (from now on referred to as "the C-family
-  languages"),
+  C/C++/Objective-C/Objective-C++/CUDA (from now on referred to as "the
+  C-family languages"),
 - a Jedi [12]-based completion engine for Python 2 and 3,
 - an OmniSharp [13]-based completion engine for C#,
 - a combination of Gocode [14] and Godef [15] semantic engines for Go,
@@ -810,10 +810,9 @@ will notify you to recompile it. You should then rerun the install process.
    for C-family languages. Otherwise it's not necessary._
 
    **Download the latest version of 'libclang'**. Clang is an open-source
-   compiler that can compile C/C++/Objective-C/Objective-C++. The 'libclang'
-   library it provides is used to power the YCM semantic completion engine
-   for those languages. YCM is designed to work with libclang version 3.9 or
-   higher.
+   compiler that can compile C-family languages. The 'libclang' library it
+   provides is used to power the YCM semantic completion engine for those
+   languages. YCM is designed to work with libclang version 3.9 or higher.
 
    You can use the system libclang _only if you are sure it is version 3.9
    or higher_, otherwise don't. Even if it is, we recommend using the
@@ -990,7 +989,7 @@ General (all languages) ~
 
 -------------------------------------------------------------------------------
                                              *youcompleteme-c-family-languages*
-C-family languages (C, C++, Objective C, Objective C++) ~
+C-family languages (C, C++, Objective C, Objective C++, CUDA) ~
 
 - Semantic auto-completion
 - Real-time diagnostic display
@@ -1844,7 +1843,7 @@ The invoked subcommand is automatically routed to the currently active semantic
 completer, so ':YcmCompleter GoToDefinition' will invoke the |GoToDefinition|
 subcommand on the Python semantic completer if the currently active file is a
 Python one and on the Clang completer if the currently active file is a
-C/C++/Objective-C one.
+C-family language one.
 
 You may also want to map the subcommands to something less verbose; for
 instance, 'nnoremap <leader>jd :YcmCompleter GoTo<CR>' maps the '<leader>jd'
@@ -1896,9 +1895,9 @@ The *GoTo* subcommand
 This command tries to perform the "most sensible" GoTo operation it can.
 Currently, this means that it tries to look up the symbol under the cursor and
 jumps to its definition if possible; if the definition is not accessible from
-the current translation unit, jumps to the symbol's declaration. For
-C/C++/Objective-C, it first tries to look up the current line for a header and
-jump to it. For C#, implementations are also considered and preferred.
+the current translation unit, jumps to the symbol's declaration. For C-family
+languages, it first tries to look up the current line for a header and jump to
+it. For C#, implementations are also considered and preferred.
 
 Supported in filetypes: 'c, cpp, objc, objcpp, cuda, cs, go, java, javascript,
 python, rust, typescript'


### PR DESCRIPTION
Add CUDA to the list of C-family languages in the docs and use the "C-family languages" expression when appropriate (instead of enumerating each language).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3123)
<!-- Reviewable:end -->
