### PR TITLE
added type check for g:ycm_filetype_blacklist

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -403,9 +403,11 @@ function! s:AllowedToCompleteInBuffer( buffer )
     return 0
   endif
 
-  let whitelist_allows = has_key( g:ycm_filetype_whitelist, '*' ) ||
+  let whitelist_allows = type( g:ycm_filetype_whitelist ) != type( {} ) ||
+        \ has_key( g:ycm_filetype_whitelist, '*' ) ||
         \ has_key( g:ycm_filetype_whitelist, buffer_filetype )
-  let blacklist_allows = !has_key( g:ycm_filetype_blacklist, buffer_filetype )
+  let blacklist_allows = type( g:ycm_filetype_blacklist ) != type( {} ) ||
+        \ !has_key( g:ycm_filetype_blacklist, buffer_filetype )
 
   let allowed = whitelist_allows && blacklist_allows
   if allowed


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

I made a mistake while configuring ycm and used a list instead of a ditionary for the blacklist, like so:

```vim
let g:ycm_filetype_blacklist = ['python']
```

If the `CursorMoved` autocmd is installed while the configuration is not a dictionary, an error message is raised after every keystroke, this makes fixing the configuration error a bit painful. Error message:

```
Error detected while processing function <SNR>78_OnCursorMovedNormalMode[1]..<SNR>78_AllowedToCompleteInCurrentBuffer[1]..<SNR>78_AllowedToCompleteInBuffer:
line   15:
E715: Dictionary required
```

This PR just adds a check for the type of the variable `g:ycm_filetype_blacklist`, if it's  the wrong type a message is printed and the autocmd is not installed. The check was done inside `Enable` to ensure the init.vim had fully executed.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3124)
<!-- Reviewable:end -->
