### PR TITLE
[READY] Improve omnifunc compliance when start column is invalid

### DIFF
--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -88,10 +88,15 @@ class OmniCompleter( Completer ):
 
     try:
       start_column = vimsupport.GetIntValue( self._omnifunc + '(1,"")' )
-      if start_column < 0:
-        # FIXME: Technically, if the returned value is -1 we should raise an
-        # error.
+
+      # Vim only stops completion if the value returned by the omnifunc is -3 or
+      # -2. In other cases, if the value is negative or greater than the current
+      # column, the start column is set to the current column; otherwise, the
+      # value is used as the start column.
+      if start_column in ( -3, -2 ):
         return []
+      if start_column < 0 or start_column > column:
+        start_column = column
 
       # Use the start column calculated by the omnifunc, rather than our own
       # interpretation. This is important for certain languages where our

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -684,6 +684,43 @@ def OmniCompleter_GetCompletions_MoveCursorPositionAtStartColumn_test( ycm ):
     )
 
 
+@YouCompleteMeInstance( { 'g:ycm_cache_omnifunc': 1 } )
+def StartColumnCompliance( ycm,
+                           omnifunc_start_column,
+                           ycm_completions,
+                           ycm_start_column ):
+  def Omnifunc( findstart, base ):
+    if findstart:
+      return omnifunc_start_column
+    return [ 'foo' ]
+
+  current_buffer = VimBuffer( 'buffer',
+                              contents = [ 'fo' ],
+                              filetype = FILETYPE,
+                              omnifunc = Omnifunc )
+
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ], ( 1, 2 ) ):
+    ycm.SendCompletionRequest( force_semantic = True )
+    assert_that(
+      ycm.GetCompletionResponse(),
+      has_entries( {
+        'completions': ToBytesOnPY2( ycm_completions ),
+        'completion_start_column': ycm_start_column
+      } )
+    )
+
+
+def OmniCompleter_GetCompletions_StartColumnCompliance_test():
+  yield StartColumnCompliance, -4, [ 'foo' ], 3
+  yield StartColumnCompliance, -3, [],        1
+  yield StartColumnCompliance, -2, [],        1
+  yield StartColumnCompliance, -1, [ 'foo' ], 3
+  yield StartColumnCompliance,  0, [ 'foo' ], 1
+  yield StartColumnCompliance,  1, [ 'foo' ], 2
+  yield StartColumnCompliance,  2, [ 'foo' ], 3
+  yield StartColumnCompliance,  3, [ 'foo' ], 3
+
+
 @YouCompleteMeInstance( { 'g:ycm_cache_omnifunc': 0,
                           'g:ycm_semantic_triggers': TRIGGERS } )
 def OmniCompleter_GetCompletions_NoCache_NoSemanticTrigger_test( ycm ):


### PR DESCRIPTION
Contrarily to [what the docs say](https://github.com/vim/vim/blob/3f6a16f022c437eccaeb683640b25a972cb1b376/runtime/doc/insert.txt#L1057-L1058), [Vim only stops completion if the value returned by the omnifunc is `-3` or `-2`](https://github.com/vim/vim/blob/3f6a16f022c437eccaeb683640b25a972cb1b376/src/edit.c#L5585-L5621). In other cases, if the value is negative or greater than the current column, the start column is set to the current column; otherwise, the value is used as the start column.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3125)
<!-- Reviewable:end -->
