### PR TITLE
[READY] Set window height according to the wrap option

### DIFF
--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -466,6 +466,7 @@ class VimWindow( object ):
     self.number = number
     self.buffer = buffer_object
     self.cursor = cursor
+    self.options = {}
 
 
 class VimWindows( object ):

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -173,13 +173,26 @@ def OpenLocationList_test( vim_command, fitting_height, variable_exists ):
   variable_exists.assert_called_once_with( '#User#YcmLocationOpened' )
 
 
-@patch( 'ycm.vimsupport.GetIntValue', return_value = 120 )
 @patch( 'vim.command' )
-def SetFittingHeightForCurrentWindow_test( vim_command, *args ):
-  # Create a buffer with one line that is longer than the window width.
+def SetFittingHeightForCurrentWindow_LineWrapOn_test( vim_command, *args ):
+  # Create a two lines buffer whose first line is longer than the window width.
   current_buffer = VimBuffer( 'buffer',
-                              contents = [ 'a' * 140 ] )
-  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
+                              contents = [ 'a' * 140, 'b' * 80 ] )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+    vim.current.window.width = 120
+    vim.current.window.options[ 'wrap' ] = True
+    vimsupport.SetFittingHeightForCurrentWindow()
+  vim_command.assert_called_once_with( '3wincmd _' )
+
+
+@patch( 'vim.command' )
+def SetFittingHeightForCurrentWindow_LineWrapOff_test( vim_command, *args ):
+  # Create a two lines buffer whose first line is longer than the window width.
+  current_buffer = VimBuffer( 'buffer',
+                              contents = [ 'a' * 140, 'b' * 80 ] )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
+    vim.current.window.width = 120
+    vim.current.window.options[ 'wrap' ] = False
     vimsupport.SetFittingHeightForCurrentWindow()
   vim_command.assert_called_once_with( '2wincmd _' )
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -364,12 +364,20 @@ def OpenQuickFixList( focus = False, autoclose = False ):
     JumpToPreviousWindow()
 
 
-def SetFittingHeightForCurrentWindow():
-  window_width = GetIntValue( 'winwidth( 0 )' )
+def ComputeFittingHeightForCurrentWindow():
+  current_window = vim.current.window
+  if not current_window.options[ 'wrap' ]:
+    return len( vim.current.buffer )
+
+  window_width = current_window.width
   fitting_height = 0
   for line in vim.current.buffer:
     fitting_height += len( line ) // window_width + 1
-  vim.command( '{0}wincmd _'.format( fitting_height ) )
+  return fitting_height
+
+
+def SetFittingHeightForCurrentWindow():
+  vim.command( '{0}wincmd _'.format( ComputeFittingHeightForCurrentWindow() ) )
 
 
 def ConvertDiagnosticsToQfList( diagnostics ):


### PR DESCRIPTION
The height of the quickfix and location list windows is set to fit all entries by assuming that the lines of the entries are always wrapped if they are longer than the window width. This assumption is wrong if `nowrap` is set. In that case, the height should be set to the number of entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3134)
<!-- Reviewable:end -->
