### PR TITLE
[READY] Include extra data when getting the logs

### DIFF
--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -593,7 +593,9 @@ class YouCompleteMe( object ):
                       self._server_stdout,
                       self._server_stderr ]
 
-    debug_info = SendDebugInfoRequest()
+    extra_data = {}
+    self._AddExtraConfDataIfNeeded( extra_data )
+    debug_info = SendDebugInfoRequest( extra_data )
     if debug_info:
       completer = debug_info[ 'completer' ]
       if completer:


### PR DESCRIPTION
Include the extra conf data to the debug info request when getting the logfiles.

Fixes https://github.com/Valloric/ycmd/issues/1106.