### PR TITLE
[READY] Ignore BufEnter and BufLeave when switching window

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1236,7 +1236,10 @@ def CurrentWindow():
   without triggering autocommands related to window movement. Use the
   SwitchWindow function to move to other windows while under the context."""
   current_window = vim.current.window
-  with AutocommandEventsIgnored( [ 'WinEnter', 'Winleave' ] ):
+  with AutocommandEventsIgnored( [ 'BufEnter',
+                                   'BufLeave',
+                                   'WinEnter',
+                                   'Winleave' ] ):
     try:
       yield
     finally:


### PR DESCRIPTION
Switching to a different window also triggers the `BufEnter` and `BufLeave` events. Ignore them.

Fixes #3150.