### PR TITLE
Expose shutdown command with `:YcmShutdownServer`

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -841,6 +841,7 @@ endfunction
 
 function! s:SetUpCommands()
   command! YcmRestartServer call s:RestartServer()
+  command! YcmShutdownServer call s:ShutdownServer()
   command! YcmDebugInfo call s:DebugInfo()
   command! -nargs=* -complete=custom,youcompleteme#LogsComplete
         \ YcmToggleLogs call s:ToggleLogs(<f-args>)
@@ -879,6 +880,11 @@ function! s:RestartServer()
         \ function( 's:PollServerReady' ) )
 endfunction
 
+function! s:ShutdownServer()
+  call s:SetUpOptions()
+
+  exec s:python_command "ycm_state.ShutdownServer()"
+endfunction
 
 function! s:DebugInfo()
   echom "Printing YouCompleteMe debug information..."

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -52,12 +52,13 @@ Contents ~
    1. Diagnostic Highlighting Groups |youcompleteme-diagnostic-highlighting-groups|
  8. Commands                                           |youcompleteme-commands|
   1. The |:YcmRestartServer| command
-  2. The |:YcmForceCompileAndDiagnostics| command
-  3. The |:YcmDiags| command
-  4. The |:YcmShowDetailedDiagnostic| command
-  5. The |:YcmDebugInfo| command
-  6. The |:YcmToggleLogs| command
-  7. The |:YcmCompleter| command
+  2. The |:YcmShutdownServer| command
+  3. The |:YcmForceCompileAndDiagnostics| command
+  4. The |:YcmDiags| command
+  5. The |:YcmShowDetailedDiagnostic| command
+  6. The |:YcmDebugInfo| command
+  7. The |:YcmToggleLogs| command
+  8. The |:YcmCompleter| command
  9. YcmCompleter Subcommands           |youcompleteme-ycmcompleter-subcommands|
   1. GoTo Commands                                |youcompleteme-goto-commands|
    1. The |GoToInclude| subcommand
@@ -1685,6 +1686,13 @@ The *:YcmRestartServer* command
 
 If the ycmd completion server [46] suddenly stops for some reason, you can
 restart it with this command.
+
+-------------------------------------------------------------------------------
+The *:YcmShutdownServer* command
+
+Usefull when you would like to shutdown the ycmd completion server so it's
+process won't stay when you know you'll might kill vim through a parent
+process group - like a terminal emulator.
 
 -------------------------------------------------------------------------------
 The *:YcmForceCompileAndDiagnostics* command

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -281,13 +281,13 @@ class YouCompleteMe( object ):
     return self._server_popen.pid
 
 
-  def _ShutdownServer( self ):
+  def ShutdownServer( self ):
     SendShutdownRequest()
 
 
   def RestartServer( self ):
     vimsupport.PostVimMessage( 'Restarting ycmd server...' )
-    self._ShutdownServer()
+    self.ShutdownServer()
     self._SetUpServer()
 
 
@@ -485,7 +485,7 @@ class YouCompleteMe( object ):
 
 
   def OnVimLeave( self ):
-    self._ShutdownServer()
+    self.ShutdownServer()
     self._CleanLogfile()
 
 


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

I use `$EDITOR -c 'set ft=man' -` as my `$MANPAGER`. Usually I open a terminal emulator for every man page I'd like to view and when I finish reading those, I close the terminal emulator it self without quitting vim first. From some reason, a `ycmd` process is still running after vim is closed that way, even though a man page viewed in vim has a `&buftype` of `nofile` .

https://github.com/Valloric/YouCompleteMe/blob/43967bd71dc3dca218bff0f8541b0c9e6c680e8f/autoload/youcompleteme.vim#L396-L400

Anyway, with this patch, putting this in `after/autoload/youcompleteme.vim` fixed my problem:
```vim
autocmd FileType man YcmShutdownServer
```

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3153)
<!-- Reviewable:end -->
