### PR TITLE
[READY] Reduce logging verbosity when a connection error occurs

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -83,11 +83,11 @@ class BaseRequest( object ):
         else:
           _IgnoreExtraConfFile( e.extra_conf_file )
         self._should_resend = True
-    except BaseRequest.Requests().exceptions.ConnectionError:
+    except BaseRequest.Requests().exceptions.ConnectionError as e:
       # We don't display this exception to the user since it is likely to happen
       # for each subsequent request (typically if the server crashed) and we
       # don't want to spam the user with it.
-      _logger.exception( 'Unable to connect to server' )
+      _logger.error( e )
     except Exception as e:
       _logger.exception( 'Error while handling server response' )
       if display_message:


### PR DESCRIPTION
Logging `ConnectionError` as an exception results in writing a Python traceback of 64 lines in the logs. Not only this messes up the logs, this also considerably increases their size for no good reason. Instead, we should log the exception as an error. This gives us something like
```
2018-09-24 11:19:27,487 - ERROR - HTTPConnectionPool(host='127.0.0.1', port=27810): Max retries exceeded with url: /ready (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.HTTPConnection object at 0x0000000005CC7B70>, 'Connection to 127.0.0.1 timed out. (connect timeout=0.01)'))
```
which is much more reasonable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3154)
<!-- Reviewable:end -->
