### PR TITLE
[READY] Ignore ft= argument from YcmCompleter command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1507,18 +1507,13 @@ This command gives access to a number of additional [IDE-like
 features](#quick-feature-summary) in YCM, for things like semantic GoTo, type
 information, FixIt and refactoring.
 
-Technically the command invokes completer-specific commands.  If the first
-argument is of the form `ft=...` the completer for that file type will be used
-(for example `ft=cpp`), else the native completer of the current buffer will be
-used.
+This command accepts a range that can either be specified through a selection in
+one of Vim's visual modes (see `:h visual-use`) or on the command line. For
+instance, `:2,5YcmCompleter` will apply the command from line 2 to line 5. This
+is useful for [the `Format` subcommand](#the-format-subcommand).
 
-This command also accepts a range that can either be specified through a
-selection in one of Vim's visual modes (see `:h visual-use`) or on the command
-line. For instance, `:2,5YcmCompleter` will apply the command from line 2 to
-line 5. This is useful for [the `Format` subcommand](#the-format-subcommand).
-
-Call `YcmCompleter` without further arguments for a list of the
-commands you can call for the current completer.
+Call `YcmCompleter` without further arguments for a list of the commands you can
+call for the current completer.
 
 See the [file type feature summary](#quick-feature-summary) for an overview of
 the features available for each file type. See the _YcmCompleter subcommands_

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -900,26 +900,8 @@ endfunction
 
 
 function! s:CompleterCommand( mods, count, line1, line2, ... )
-  " CompleterCommand will call the OnUserCommand function of a completer. If
-  " the first arguments is of the form "ft=..." it can be used to specify the
-  " completer to use (for example "ft=cpp"). Else the native filetype completer
-  " of the current buffer is used. If no native filetype completer is found and
-  " no completer was specified this throws an error. You can use "ft=ycm:ident"
-  " to select the identifier completer. The remaining arguments will be passed
-  " to the completer.
-  let arguments = copy(a:000)
-  let completer = ''
-
-  if a:0 > 0 && strpart(a:1, 0, 3) == 'ft='
-    if a:1 == 'ft=ycm:ident'
-      let completer = 'identifier'
-    endif
-    let arguments = arguments[1:]
-  endif
-
   exec s:python_command "ycm_state.SendCommandRequest(" .
-        \ "vim.eval( 'l:arguments' )," .
-        \ "vim.eval( 'l:completer' )," .
+        \ "vim.eval( 'a:000' )," .
         \ "vim.eval( 'a:mods' )," .
         \ "vimsupport.GetBoolValue( 'a:count != -1' )," .
         \ "vimsupport.GetIntValue( 'a:line1' )," .

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1746,15 +1746,10 @@ The *:YcmCompleter* command
 This command gives access to a number of additional IDE-like features in YCM,
 for things like semantic GoTo, type information, FixIt and refactoring.
 
-Technically the command invokes completer-specific commands. If the first
-argument is of the form 'ft=...' the completer for that file type will be used
-(for example 'ft=cpp'), else the native completer of the current buffer will be
-used.
-
-This command also accepts a range that can either be specified through a
-selection in one of Vim's visual modes (see ':h visual-use') or on the command
-line. For instance, ':2,5YcmCompleter' will apply the command from line 2 to
-line 5. This is useful for the |Format| subcommand.
+This command accepts a range that can either be specified through a selection
+in one of Vim's visual modes (see ':h visual-use') or on the command line. For
+instance, ':2,5YcmCompleter' will apply the command from line 2 to line 5. This
+is useful for the |Format| subcommand.
 
 Call 'YcmCompleter' without further arguments for a list of the commands you
 can call for the current completer.

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -34,12 +34,10 @@ def _EnsureBackwardsCompatibility( arguments ):
 
 
 class CommandRequest( BaseRequest ):
-  def __init__( self, arguments, completer_target = None, extra_data = None ):
+  def __init__( self, arguments, extra_data = None ):
     super( CommandRequest, self ).__init__()
     self._arguments = _EnsureBackwardsCompatibility( arguments )
     self._command = arguments and arguments[ 0 ]
-    self._completer_target = ( completer_target if completer_target
-                               else 'filetype_default' )
     self._extra_data = extra_data
     self._response = None
 
@@ -49,7 +47,6 @@ class CommandRequest( BaseRequest ):
     if self._extra_data:
       request_data.update( self._extra_data )
     request_data.update( {
-      'completer_target': self._completer_target,
       'command_arguments': self._arguments
     } )
     self._response = self.PostDataToHandler( request_data,
@@ -132,8 +129,8 @@ class CommandRequest( BaseRequest ):
     vimsupport.WriteToPreviewWindow( self._response[ 'detailed_info' ] )
 
 
-def SendCommandRequest( arguments, completer, modifiers, extra_data = None ):
-  request = CommandRequest( arguments, completer, extra_data )
+def SendCommandRequest( arguments, modifiers, extra_data = None ):
+  request = CommandRequest( arguments, extra_data )
   # This is a blocking call.
   request.Start()
   request.RunPostCommandActionsIfNeeded( modifiers )

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -36,13 +36,12 @@ def SendCommandRequest_ExtraConfVimData_Works_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', 'aboveleft', False, 1, 1 )
+      ycm.SendCommandRequest( [ 'GoTo' ], 'aboveleft', False, 1, 1 )
       assert_that(
         # Positional arguments passed to SendCommandRequest.
         send_request.call_args[ 0 ],
         contains(
           contains( 'GoTo' ),
-          'python',
           'aboveleft',
           has_entries( {
             'options': has_entries( {
@@ -62,13 +61,12 @@ def SendCommandRequest_ExtraConfData_UndefinedValue_test( ycm ):
   current_buffer = VimBuffer( 'buffer' )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', 'belowright', False, 1, 1 )
+      ycm.SendCommandRequest( [ 'GoTo' ], 'belowright', False, 1, 1 )
       assert_that(
         # Positional arguments passed to SendCommandRequest.
         send_request.call_args[ 0 ],
         contains(
           contains( 'GoTo' ),
-          'python',
           'belowright',
           has_entries( {
             'options': has_entries( {
@@ -86,10 +84,9 @@ def SendCommandRequest_BuildRange_NoVisualMarks_test( ycm, *args ):
                                                      'second line' ] )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', '', True, 1, 2 )
+      ycm.SendCommandRequest( [ 'GoTo' ], '', True, 1, 2 )
       send_request.assert_called_once_with(
         [ 'GoTo' ],
-        'python',
         '',
         {
           'options': {
@@ -119,10 +116,9 @@ def SendCommandRequest_BuildRange_VisualMarks_test( ycm, *args ):
                               visual_end = [ 2, 8 ] )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
-      ycm.SendCommandRequest( [ 'GoTo' ], 'python', 'tab', True, 1, 2 )
+      ycm.SendCommandRequest( [ 'GoTo' ], 'tab', True, 1, 2 )
       send_request.assert_called_once_with(
         [ 'GoTo' ],
-        'python',
         'tab',
         {
           'options': {
@@ -141,3 +137,27 @@ def SendCommandRequest_BuildRange_VisualMarks_test( ycm, *args ):
           }
         }
       )
+
+
+@YouCompleteMeInstance()
+def SendCommandRequest_IgnoreFileTypeOption_test( ycm, *args ):
+  current_buffer = VimBuffer( 'buffer' )
+  with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
+    expected_args = (
+      [ 'GoTo' ],
+      '',
+      {
+        'options': {
+          'tab_size': 2,
+          'insert_spaces': True
+        },
+      }
+    )
+
+    with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
+      ycm.SendCommandRequest( [ 'ft=ycm:ident', 'GoTo' ], '', False, 1, 1 )
+      send_request.assert_called_once_with( *expected_args )
+
+    with patch( 'ycm.youcompleteme.SendCommandRequest' ) as send_request:
+      ycm.SendCommandRequest( [ 'GoTo', 'ft=python' ], '', False, 1, 1 )
+      send_request.assert_called_once_with( *expected_args )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -321,11 +321,19 @@ class YouCompleteMe( object ):
 
   def SendCommandRequest( self,
                           arguments,
-                          completer,
                           modifiers,
                           has_range,
                           start_line,
                           end_line ):
+    final_arguments = []
+    for argument in arguments:
+      # The ft= option which specifies the completer when running a command is
+      # ignored because it has not been working for a long time. The option is
+      # still parsed to not break users that rely on it.
+      if argument.startswith( 'ft=' ):
+        continue
+      final_arguments.append( argument )
+
     extra_data = {
       'options': {
         'tab_size': vimsupport.GetIntValue( 'shiftwidth()' ),
@@ -335,7 +343,8 @@ class YouCompleteMe( object ):
     if has_range:
       extra_data.update( vimsupport.BuildRange( start_line, end_line ) )
     self._AddExtraConfDataIfNeeded( extra_data )
-    return SendCommandRequest( arguments, completer, modifiers, extra_data )
+
+    return SendCommandRequest( final_arguments, modifiers, extra_data )
 
 
   def GetDefinedSubcommands( self ):


### PR DESCRIPTION
The `ft=` argument of the `YcmCompleter` command is supposed to allow users to specify a completer when running a command. However, this was broken a long time ago in commit https://github.com/Valloric/YouCompleteMe/commit/29bb90a6b434ec6b462398268fbe871924cbe8ed. Only the `ycm:ident` value is still supported but it serves no purpose because the identifier completer doesn't define commands. Ignore completely the `ft=` argument and move the logic to the Python layer. Remove the argument from the documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3161)
<!-- Reviewable:end -->
