### PR TITLE
[READY] Add minimal dependencies to Python path

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -29,6 +29,7 @@
 # For more information, please refer to <http://unlicense.org/>
 
 import os
+import subprocess
 
 DIR_OF_THIS_SCRIPT = os.path.abspath( os.path.dirname( __file__ ) )
 DIR_OF_THIRD_PARTY = os.path.join( DIR_OF_THIS_SCRIPT, 'third_party' )
@@ -46,19 +47,23 @@ def GetStandardLibraryIndexInSysPath( sys_path ):
 def PythonSysPath( **kwargs ):
   sys_path = kwargs[ 'sys_path' ]
 
-  for folder in os.listdir( DIR_OF_THIRD_PARTY ):
-    sys_path.insert( 0, os.path.realpath( os.path.join( DIR_OF_THIRD_PARTY,
-                                                        folder ) ) )
+  dependencies = [ os.path.join( DIR_OF_THIS_SCRIPT, 'python' ),
+                   os.path.join( DIR_OF_THIRD_PARTY, 'requests-futures' ),
+                   os.path.join( DIR_OF_THIRD_PARTY, 'ycmd' ),
+                   os.path.join( DIR_OF_YCMD_THIRD_PARTY, 'frozendict' ),
+                   os.path.join( DIR_OF_YCMD_THIRD_PARTY, 'requests' ) ]
 
-  for folder in os.listdir( DIR_OF_YCMD_THIRD_PARTY ):
-    if folder == 'python-future':
-      folder = os.path.join( folder, 'src' )
-      sys_path.insert( GetStandardLibraryIndexInSysPath( sys_path ) + 1,
-                       os.path.realpath( os.path.join( DIR_OF_YCMD_THIRD_PARTY,
-                                                       folder ) ) )
-      continue
+  # The concurrent.futures module is part of the standard library on Python 3.
+  interpreter_path = kwargs[ 'interpreter_path' ]
+  major_version = int( subprocess.check_output( [
+    interpreter_path, '-c', 'import sys; print( sys.version_info[ 0 ] )' ]
+  ).rstrip().decode( 'utf8' ) )
+  if major_version == 2:
+    dependencies.append( os.path.join( DIR_OF_THIRD_PARTY, 'pythonfutures' ) )
 
-    sys_path.insert( 0, os.path.realpath( os.path.join( DIR_OF_YCMD_THIRD_PARTY,
-                                                        folder ) ) )
+  sys_path[ 0:0 ] = dependencies
+  sys_path.insert( GetStandardLibraryIndexInSysPath( sys_path ) + 1,
+                   os.path.join( DIR_OF_YCMD_THIRD_PARTY, 'python-future',
+                                 'src' ) )
 
   return sys_path

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -186,23 +186,34 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-import os
+import os.path as p
 import sys
 import traceback
 import vim
 
-# Add python sources folder to the system path.
-script_folder = vim.eval( 's:script_folder_path' )
-sys.path.insert( 0, os.path.join( script_folder, '..', 'python' ) )
-sys.path.insert( 0, os.path.join( script_folder, '..', 'third_party', 'ycmd' ) )
+root_folder = p.normpath( p.join( vim.eval( 's:script_folder_path' ), '..' ) )
+third_party_folder = p.join( root_folder, 'third_party' )
+ycmd_third_party_folder = p.join( third_party_folder, 'ycmd', 'third_party' )
+
+# Add dependencies to Python path.
+dependencies = [ p.join( root_folder, 'python' ),
+                 p.join( third_party_folder, 'requests-futures' ),
+                 p.join( third_party_folder, 'ycmd' ),
+                 p.join( ycmd_third_party_folder, 'frozendict' ),
+                 p.join( ycmd_third_party_folder, 'requests' ) ]
+
+# The concurrent.futures module is part of the standard library on Python 3.
+if sys.version_info[ 0 ] == 2:
+  dependencies.append( p.join( third_party_folder, 'pythonfutures' ) )
+
+sys.path[ 0:0 ] = dependencies
 
 # We enclose this code in a try/except block to avoid backtraces in Vim.
 try:
-  from ycmd import server_utils as su
-  su.AddNearestThirdPartyFoldersToSysPath( script_folder )
-  # We need to import ycmd's third_party folders as well since we import and
-  # use ycmd code in the client.
-  su.AddNearestThirdPartyFoldersToSysPath( su.__file__ )
+  # The python-future module must be inserted after the standard library path.
+  from ycmd.server_utils import GetStandardLibraryIndexInSysPath
+  sys.path.insert( GetStandardLibraryIndexInSysPath() + 1,
+                   p.join( ycmd_third_party_folder, 'python-future', 'src' ) )
 
   # Import the modules used in this file.
   from ycm import base, vimsupport, youcompleteme


### PR DESCRIPTION
Ideally, we shouldn't add anything to the Python path because it can break other plugins written in Python but since the alternative is to tell users to manually install our dependencies, we don't really have a choice (the last thing we want are reports about pip failing to install packages). Still, we can at least only add the dependencies we need:
 - [requests](https://github.com/requests/requests);
 - [pythonfutures](https://github.com/agronholm/pythonfutures) in Python 2;
 - [requests-futures](https://github.com/ross/requests-futures);
 - [frozendict](https://github.com/slezica/python-frozendict);
 - [python-future](https://github.com/PythonCharmers/python-future). 

Fixes #3162.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3163)
<!-- Reviewable:end -->
