### PR TITLE
[READY] Update ycmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,7 @@ Install development tools, CMake, and Python headers:
 
 - Fedora 27 and later:
 
-      sudo dnf install cmake gcc-c++ make ncurses-compat-libs python3-devel
-
-  `ncurses-compat-libs` is only required for C-family languages support.
+      sudo dnf install cmake gcc-c++ make python3-devel
 
 - Ubuntu 14.04:
 

--- a/README.md
+++ b/README.md
@@ -2058,10 +2058,10 @@ semantic engine will operate in them.
 
 You can get the filetype of the current file in Vim with `:set ft?`.
 
-Default: `{'*' : 1}`
+Default: `{'*': 1}`
 
 ```viml
-let g:ycm_filetype_whitelist = { '*': 1 }
+let g:ycm_filetype_whitelist = {'*': 1}
 ```
 
 ### The `g:ycm_filetype_blacklist` option
@@ -2077,16 +2077,16 @@ Default: `[see next line]`
 
 ```viml
 let g:ycm_filetype_blacklist = {
-      \ 'tagbar' : 1,
-      \ 'qf' : 1,
-      \ 'notes' : 1,
-      \ 'markdown' : 1,
-      \ 'unite' : 1,
-      \ 'text' : 1,
-      \ 'vimwiki' : 1,
-      \ 'pandoc' : 1,
-      \ 'infolog' : 1,
-      \ 'mail' : 1
+      \ 'tagbar': 1,
+      \ 'qf': 1,
+      \ 'notes': 1,
+      \ 'markdown': 1,
+      \ 'unite': 1,
+      \ 'text': 1,
+      \ 'vimwiki': 1,
+      \ 'pandoc': 1,
+      \ 'infolog': 1,
+      \ 'mail': 1
       \}
 ```
 
@@ -2124,7 +2124,7 @@ being filetype strings (like `python`, `cpp`, etc.) and values being unimportant
 The `*` key is special and matches all filetypes. Use this key if you want to
 completely disable filepath completion:
 ```viml
-let g:ycm_filepath_blacklist = { '*': 1 }
+let g:ycm_filepath_blacklist = {'*': 1}
 ```
 
 You can get the filetype of the current file in Vim with `:set ft?`.
@@ -2133,9 +2133,9 @@ Default: `[see next line]`
 
 ```viml
 let g:ycm_filepath_blacklist = {
-      \ 'html' : 1,
-      \ 'jsx' : 1,
-      \ 'xml' : 1,
+      \ 'html': 1,
+      \ 'jsx': 1,
+      \ 'xml': 1,
       \}
 ```
 
@@ -2771,17 +2771,17 @@ Default: `[see next line]`
 
 ```viml
 let g:ycm_semantic_triggers =  {
-  \   'c' : ['->', '.'],
-  \   'objc' : ['->', '.', 're!\[[_a-zA-Z]+\w*\s', 're!^\s*[^\W\d]\w*\s',
-  \             're!\[.*\]\s'],
-  \   'ocaml' : ['.', '#'],
-  \   'cpp,cuda,objcpp' : ['->', '.', '::'],
-  \   'perl' : ['->'],
-  \   'php' : ['->', '::'],
-  \   'cs,java,javascript,typescript,d,python,perl6,scala,vb,elixir,go' : ['.'],
-  \   'ruby' : ['.', '::'],
-  \   'lua' : ['.', ':'],
-  \   'erlang' : [':'],
+  \   'c': ['->', '.'],
+  \   'objc': ['->', '.', 're!\[[_a-zA-Z]+\w*\s', 're!^\s*[^\W\d]\w*\s',
+  \            're!\[.*\]\s'],
+  \   'ocaml': ['.', '#'],
+  \   'cpp,cuda,objcpp': ['->', '.', '::'],
+  \   'perl': ['->'],
+  \   'php': ['->', '::'],
+  \   'cs,d,elixir,go,groovy,java,javascript,julia,perl6,python,scala,typescript,vb': ['.'],
+  \   'ruby,rust': ['.', '::'],
+  \   'lua': ['.', ':'],
+  \   'erlang': [':'],
   \ }
 ```
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2321,9 +2321,9 @@ the semantic engine will operate in them.
 
 You can get the filetype of the current file in Vim with ':set ft?'.
 
-Default: "{'*' : 1}"
+Default: "{'*': 1}"
 >
-  let g:ycm_filetype_whitelist = { '*': 1 }
+  let g:ycm_filetype_whitelist = {'*': 1}
 <
 -------------------------------------------------------------------------------
 The *g:ycm_filetype_blacklist* option
@@ -2338,16 +2338,16 @@ See the |g:ycm_filetype_whitelist| option for more details on how this works.
 Default: '[see next line]'
 >
   let g:ycm_filetype_blacklist = {
-        \ 'tagbar' : 1,
-        \ 'qf' : 1,
-        \ 'notes' : 1,
-        \ 'markdown' : 1,
-        \ 'unite' : 1,
-        \ 'text' : 1,
-        \ 'vimwiki' : 1,
-        \ 'pandoc' : 1,
-        \ 'infolog' : 1,
-        \ 'mail' : 1
+        \ 'tagbar': 1,
+        \ 'qf': 1,
+        \ 'notes': 1,
+        \ 'markdown': 1,
+        \ 'unite': 1,
+        \ 'text': 1,
+        \ 'vimwiki': 1,
+        \ 'pandoc': 1,
+        \ 'infolog': 1,
+        \ 'mail': 1
         \}
 <
 -------------------------------------------------------------------------------
@@ -2385,16 +2385,16 @@ matter).
 The '*' key is special and matches all filetypes. Use this key if you want to
 completely disable filepath completion:
 >
-  let g:ycm_filepath_blacklist = { '*': 1 }
+  let g:ycm_filepath_blacklist = {'*': 1}
 <
 You can get the filetype of the current file in Vim with ':set ft?'.
 
 Default: '[see next line]'
 >
   let g:ycm_filepath_blacklist = {
-        \ 'html' : 1,
-        \ 'jsx' : 1,
-        \ 'xml' : 1,
+        \ 'html': 1,
+        \ 'jsx': 1,
+        \ 'xml': 1,
         \}
 <
 -------------------------------------------------------------------------------
@@ -2988,17 +2988,17 @@ your trigger with 're!' to signify it's a regex trigger. For instance,
 Default: '[see next line]'
 >
   let g:ycm_semantic_triggers =  {
-    \   'c' : ['->', '.'],
-    \   'objc' : ['->', '.', 're!\[[_a-zA-Z]+\w*\s', 're!^\s*[^\W\d]\w*\s',
-    \             're!\[.*\]\s'],
-    \   'ocaml' : ['.', '#'],
-    \   'cpp,cuda,objcpp' : ['->', '.', '::'],
-    \   'perl' : ['->'],
-    \   'php' : ['->', '::'],
-    \   'cs,java,javascript,typescript,d,python,perl6,scala,vb,elixir,go' : ['.'],
-    \   'ruby' : ['.', '::'],
-    \   'lua' : ['.', ':'],
-    \   'erlang' : [':'],
+    \   'c': ['->', '.'],
+    \   'objc': ['->', '.', 're!\[[_a-zA-Z]+\w*\s', 're!^\s*[^\W\d]\w*\s',
+    \            're!\[.*\]\s'],
+    \   'ocaml': ['.', '#'],
+    \   'cpp,cuda,objcpp': ['->', '.', '::'],
+    \   'perl': ['->'],
+    \   'php': ['->', '::'],
+    \   'cs,d,elixir,go,groovy,java,javascript,julia,perl6,python,scala,typescript,vb': ['.'],
+    \   'ruby,rust': ['.', '::'],
+    \   'lua': ['.', ':'],
+    \   'erlang': [':'],
     \ }
 <
 -------------------------------------------------------------------------------

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -460,9 +460,7 @@ Install development tools, CMake, and Python headers:
 
 - Fedora 27 and later:
 
-  sudo dnf install cmake gcc-c++ make ncurses-compat-libs python3-devel
-
-'ncurses-compat-libs' is only required for C-family languages support.
+  sudo dnf install cmake gcc-c++ make python3-devel
 
 - Ubuntu 14.04:
 


### PR DESCRIPTION
Include the following changes:
 - PR Valloric/ycmd#1075: remove Node.js workaround for Debian-based distributions;
 - PR Valloric/ycmd#1077: update Boost to 1.68;
 - PR Valloric/ycmd#1078: add semantic trigger for Julia;
 - PR Valloric/ycmd#1081: improve type information on C++ member functions;
 - PR Valloric/ycmd#1086: check if Python headers are installed before building;
 - PR Valloric/ycmd#1088: raise proper exception for commands when file is still being parsed in C-family languages;
 - PR Valloric/ycmd#1098: update Go completer;
 - PR Valloric/ycmd#1099: update regex submodule;
 - PR Valloric/ycmd#1100: add Python path to debugging information;
 - PR Valloric/ycmd#1103: support framework headers completion and code navigation in C-family languages;
 - PR Valloric/ycmd#1107: update Clang to 7.0.0;
 - PR Valloric/ycmd#1109: update jdt.ls to 0.25.0;
 - PR Valloric/ycmd#1110: handle null hover response from language servers;
 - PR Valloric/ycmd#1111: update list of completion kinds defined by LSP;
 - PR Valloric/ycmd#1113: send completion item kinds capability to language servers;
 - PR Valloric/ycmd#1116: update Parso to 0.3.1 and Jedi to 0.13.1.

Closes https://github.com/Valloric/YouCompleteMe/issues/3138.
Closes https://github.com/Valloric/YouCompleteMe/issues/3145.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3175)
<!-- Reviewable:end -->
