### PR TITLE
[READY] Update docs about the default version of Python used for completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,9 +1146,9 @@ present so we'd love to hear your feedback! Please do remember to check
 ### Python Semantic Completion
 
 YCM relies on the [Jedi][] engine to provide completion and code navigation. By
-default, it will pick the latest version of Python available on your system and
-use its default `sys.path`. While this is fine for simple projects, this needs
-to be configurable when working with virtual environments or in a project with
+default, it will pick the version of Python running the [ycmd server][ycmd] and
+use its `sys.path`. While this is fine for simple projects, this needs to be
+configurable when working with virtual environments or in a project with
 third-party packages. The next sections explain how to do that.
 
 #### Working with virtual environments

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1375,10 +1375,10 @@ for the list of diagnostics we'll need.
 Python Semantic Completion ~
 
 YCM relies on the Jedi [12] engine to provide completion and code navigation.
-By default, it will pick the latest version of Python available on your system
-and use its default 'sys.path'. While this is fine for simple projects, this
-needs to be configurable when working with virtual environments or in a project
-with third-party packages. The next sections explain how to do that.
+By default, it will pick the version of Python running the ycmd server [46] and
+use its 'sys.path'. While this is fine for simple projects, this needs to be
+configurable when working with virtual environments or in a project with third-
+party packages. The next sections explain how to do that.
 
 -------------------------------------------------------------------------------
                               *youcompleteme-working-with-virtual-environments*


### PR DESCRIPTION
The behavior of `get_default_environment` has been changed in the latest version of Jedi. Instead of picking the latest version of Python available on the system, it now uses the one it's running on i.e. the one running ycmd in our case. See https://github.com/davidhalter/jedi/issues/1196. Update the docs accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3176)
<!-- Reviewable:end -->
