### PR TITLE
[READY] Preserve previous window when updating matches

### DIFF
--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -178,6 +178,14 @@ def _MockVimBufferEval( value ):
   return None
 
 
+def _MockVimWindowEval( value ):
+  if value == 'winnr("#")':
+    # For simplicity, we always assume there is no previous window.
+    return 0
+
+  return None
+
+
 def _MockVimOptionsEval( value ):
   result = VIM_OPTIONS.get( value )
   if result is not None:
@@ -263,6 +271,10 @@ def _MockVimEval( value ):
     return result
 
   result = _MockVimBufferEval( value )
+  if result is not None:
+    return result
+
+  result = _MockVimWindowEval( value )
   if result is not None:
     return result
 
@@ -485,10 +497,10 @@ class VimWindows( object ):
 
   def __getitem__( self, number ):
     """Emulates vim.windows[ number ]"""
-    for window in self._windows:
-      if number == window.number:
-        return window
-    raise KeyError( number )
+    try:
+      return self._windows[ number ]
+    except IndexError:
+      raise IndexError( 'no such window' )
 
 
   def __iter__( self ):
@@ -581,7 +593,7 @@ def MockVimBuffers( buffers, window_buffers, cursor_position = ( 1, 1 ) ):
   with patch( 'vim.buffers', VimBuffers( buffers ) ):
     with patch( 'vim.windows', VimWindows( window_buffers,
                                            cursor_position ) ) as windows:
-      with patch( 'vim.current', VimCurrent( windows[ 1 ] ) ):
+      with patch( 'vim.current', VimCurrent( windows[ 0 ] ) ):
         yield VIM_MOCK
 
 

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1230,16 +1230,23 @@ def AutocommandEventsIgnored( events = [ 'all' ] ):
     vim.options[ 'eventignore' ] = old_eventignore
 
 
+def GetPreviousWindowNumber():
+  return GetIntValue( 'winnr("#")' ) - 1
+
+
 @contextlib.contextmanager
 def CurrentWindow():
   """Context manager to perform operations on other windows than the current one
   without triggering autocommands related to window movement. Use the
   SwitchWindow function to move to other windows while under the context."""
+  previous_window = vim.windows[ GetPreviousWindowNumber() ]
   current_window = vim.current.window
   with AutocommandEventsIgnored( [ 'WinEnter', 'Winleave' ] ):
     try:
       yield
     finally:
+      # Ensure <c-w>p still go to the previous window.
+      vim.current.window = previous_window
       vim.current.window = current_window
 
 


### PR DESCRIPTION
Ensure `<c-w>p` still go to the previous window after updating matches for the current buffer.

Fixes #3228.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3229)
<!-- Reviewable:end -->
