### PR TITLE
[READY] Decouple YCM and ycmd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "third_party/python-future"]
 	path = third_party/python-future
 	url = https://github.com/PythonCharmers/python-future
+[submodule "third_party/protoycmd"]
+	path = third_party/protoycmd
+	url = https://github.com/bstaletic/protoycmd

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -47,7 +47,7 @@ def PythonSysPath( **kwargs ):
 
   dependencies = [ p.join( DIR_OF_THIS_SCRIPT, 'python' ),
                    p.join( DIR_OF_THIRD_PARTY, 'requests-futures' ),
-                   p.join( DIR_OF_THIRD_PARTY, 'ycmd' ),
+                   p.join( DIR_OF_THIRD_PARTY, 'protoycmd' ),
                    p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'idna' ),
                    p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'chardet' ),
                    p.join( DIR_OF_THIRD_PARTY,

--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -198,7 +198,7 @@ third_party_folder = p.join( root_folder, 'third_party' )
 # Add dependencies to Python path.
 dependencies = [ p.join( root_folder, 'python' ),
                  p.join( third_party_folder, 'requests-futures' ),
-                 p.join( third_party_folder, 'ycmd' ),
+                 p.join( third_party_folder, 'protoycmd' ),
                  p.join( third_party_folder, 'requests_deps', 'idna' ),
                  p.join( third_party_folder, 'requests_deps', 'chardet' ),
                  p.join( third_party_folder,

--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from ycm import vimsupport
-from ycmd import identifier_utils
+from protoycmd import identifier_utils
 
 YCM_VAR_PREFIX = 'ycm_'
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -28,9 +28,11 @@ import vim
 from future.utils import native
 from base64 import b64decode, b64encode
 from ycm import vimsupport
-from ycmd.utils import ToBytes, urljoin, urlparse, GetCurrentDirectory
-from ycmd.hmac_utils import CreateRequestHmac, CreateHmac, SecureBytesEqual
-from ycmd.responses import ServerError, UnknownExtraConf
+from protoycmd.utils import ToBytes, urljoin, urlparse, GetCurrentDirectory
+from protoycmd.hmac_utils import ( CreateRequestHmac,
+                                   CreateHmac,
+                                   SecureBytesEqual )
+from protoycmd.responses import ServerError, UnknownExtraConf
 
 _HEADERS = { 'content-type': 'application/json' }
 _CONNECT_TIMEOUT_SEC = 0.01

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -24,7 +24,7 @@ from builtins import *  # noqa
 
 from ycm.client.base_request import BaseRequest, BuildRequestData
 from ycm import vimsupport
-from ycmd.utils import ToUnicode
+from protoycmd.utils import ToUnicode
 
 
 def _EnsureBackwardsCompatibility( arguments ):

--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 import logging
-from ycmd.utils import ToUnicode
+from protoycmd.utils import ToUnicode
 from ycm.client.base_request import ( BaseRequest, DisplayServerException,
                                       MakeServerException )
 from ycm import vimsupport

--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -24,8 +24,8 @@ from builtins import *  # noqa
 
 import vim
 from ycm import vimsupport
-from ycmd import utils
-from ycmd.completers.completer import Completer
+from protoycmd import utils
+from protoycmd.completers.completer import Completer
 from ycm.client.base_request import BaseRequest
 
 OMNIFUNC_RETURNED_BAD_VALUE = 'Omnifunc returned bad value to YCM!'

--- a/python/ycm/paths.py
+++ b/python/ycm/paths.py
@@ -42,7 +42,7 @@ PYTHON_BINARY_REGEX = re.compile(
 def PathToPythonInterpreter():
   # Not calling the Python interpreter to check its version as it significantly
   # impacts startup time.
-  from ycmd import utils
+  from protoycmd import utils
 
   python_interpreter = vim.eval( 'g:ycm_server_python_interpreter' )
   if python_interpreter:
@@ -83,7 +83,7 @@ def PathToPythonInterpreter():
 
 
 def _PathToPythonUsedDuringBuild():
-  from ycmd import utils
+  from protoycmd import utils
 
   try:
     filepath = os.path.join( DIR_OF_YCMD, 'PYTHON_USED_DURING_BUILDING' )

--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -35,7 +35,8 @@ import warnings
 from ycm.client.base_request import BaseRequest
 from ycm.tests import test_utils
 from ycm.youcompleteme import YouCompleteMe
-from ycmd.utils import CloseStandardStreams, WaitUntilProcessIsTerminated
+from protoycmd.utils import ( CloseStandardStreams,
+                              WaitUntilProcessIsTerminated )
 
 # The default options which are required for a working YouCompleteMe object.
 DEFAULT_CLIENT_OPTIONS = {

--- a/python/ycm/tests/completion_test.py
+++ b/python/ycm/tests/completion_test.py
@@ -34,7 +34,7 @@ from mock import call, MagicMock, patch
 from nose.tools import ok_
 
 from ycm.tests import PathToTestFile, YouCompleteMeInstance
-from ycmd.responses import ServerError
+from protoycmd.responses import ServerError
 
 
 @contextlib.contextmanager

--- a/python/ycm/tests/event_notification_test.py
+++ b/python/ycm/tests/event_notification_test.py
@@ -35,8 +35,12 @@ import os
 from ycm.tests import ( PathToTestFile, test_utils, YouCompleteMeInstance,
                         WaitUntilReady )
 from ycm.vimsupport import SIGN_BUFFER_ID_INITIAL_VALUE
-from ycmd.responses import ( BuildDiagnosticData, Diagnostic, Location, Range,
-                             UnknownExtraConf, ServerError )
+from protoycmd.responses import ( BuildDiagnosticData,
+                                  Diagnostic,
+                                  Location,
+                                  Range,
+                                  UnknownExtraConf,
+                                  ServerError )
 
 from hamcrest import ( assert_that, contains, empty, has_entries, has_entry,
                        has_item, has_items, has_key, is_not )

--- a/python/ycm/tests/postcomplete_test.py
+++ b/python/ycm/tests/postcomplete_test.py
@@ -32,7 +32,7 @@ from mock import MagicMock, DEFAULT, patch
 from nose.tools import eq_, ok_
 
 from ycm import vimsupport
-from ycmd.utils import ToBytes
+from protoycmd.utils import ToBytes
 from ycm.client.completion_request import ( CompletionRequest,
                                             _FilterToMatchingCompletions,
                                             _GetRequiredNamespaceImport )

--- a/python/ycm/tests/syntax_parse_test.py
+++ b/python/ycm/tests/syntax_parse_test.py
@@ -29,7 +29,7 @@ MockVimModule()
 import os
 from hamcrest import assert_that, contains_inanyorder, has_item, has_items
 from ycm import syntax_parse
-from ycmd.utils import ReadFile
+from protoycmd.utils import ReadFile
 
 
 def ContentsOfTestFile( test_file ):

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -34,7 +34,7 @@ import os
 import re
 import sys
 
-from ycmd.utils import GetCurrentDirectory, ToBytes, ToUnicode
+from protoycmd.utils import GetCurrentDirectory, ToBytes, ToUnicode
 
 
 BUFNR_REGEX = re.compile( '^bufnr\\(\'(?P<buffer_filename>.+)\', ([01])\\)$' )

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -35,7 +35,7 @@ from nose.tools import eq_
 from hamcrest import ( assert_that, calling, contains, empty, equal_to,
                        has_entry, raises )
 from mock import MagicMock, call, patch
-from ycmd.utils import ToBytes
+from protoycmd.utils import ToBytes
 import os
 import json
 

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -48,7 +48,7 @@ from ycm.tests import ( StopServer,
                         YouCompleteMeInstance )
 from ycm.client.base_request import _LoadExtraConfFile
 from ycm.youcompleteme import YouCompleteMe
-from ycmd.responses import ServerError
+from protoycmd.responses import ServerError
 from ycm.tests.mock_utils import ( MockAsyncServerResponseDone,
                                    MockAsyncServerResponseInProgress,
                                    MockAsyncServerResponseException )
@@ -89,13 +89,14 @@ def YouCompleteMe_InvalidPythonInterpreterPath_test( post_vim_message ):
       StopServer( ycm )
 
 
-@patch( 'ycmd.utils.PathToFirstExistingExecutable', return_value = None )
+@patch( 'protoycmd.utils.PathToFirstExistingExecutable',
+        return_value = None )
 @patch( 'ycm.paths._EndsWithPython', return_value = False )
 @patch( 'ycm.vimsupport.PostVimMessage' )
 def YouCompleteMe_NoPythonInterpreterFound_test( post_vim_message, *args ):
   with UserOptions( {} ):
     try:
-      with patch( 'ycmd.utils.ReadFile', side_effect = IOError ):
+      with patch( 'protoycmd.utils.ReadFile', side_effect = IOError ):
         ycm = YouCompleteMe()
 
       assert_that( ycm.IsServerAlive(), equal_to( False ) )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -28,8 +28,8 @@ import os
 import json
 import re
 from collections import defaultdict, namedtuple
-from ycmd.utils import ( ByteOffsetToCodepointOffset, GetCurrentDirectory,
-                         JoinLinesAsUnicode, ToBytes, ToUnicode )
+from protoycmd.utils import ( ByteOffsetToCodepointOffset, GetCurrentDirectory,
+                              JoinLinesAsUnicode, ToBytes, ToUnicode )
 
 BUFFER_COMMAND_MAP = { 'same-buffer'      : 'edit',
                        'split'            : 'split',
@@ -753,7 +753,7 @@ def GetIntValue( variable ):
 
 def _SortChunksByFile( chunks ):
   """Sort the members of the list |chunks| (which must be a list of dictionaries
-  conforming to ycmd.responses.FixItChunk) by their filepath. Returns a new
+  conforming to protoycmd.responses.FixItChunk) by their filepath. Returns a new
   list in arbitrary order."""
 
   chunks_by_file = defaultdict( list )
@@ -828,7 +828,7 @@ def _OpenFileInSplitIfNeeded( filepath ):
 
 def ReplaceChunks( chunks, silent=False ):
   """Apply the source file deltas supplied in |chunks| to arbitrary files.
-  |chunks| is a list of changes defined by ycmd.responses.FixItChunk,
+  |chunks| is a list of changes defined by protoycmd.responses.FixItChunk,
   which may apply arbitrary modifications to arbitrary files.
 
   If a file specified in a particular chunk is not currently open in a visible

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -35,8 +35,8 @@ from ycm import base, paths, vimsupport
 from ycm.buffer import ( BufferDict,
                          DIAGNOSTIC_UI_FILETYPES,
                          DIAGNOSTIC_UI_ASYNC_FILETYPES )
-from ycmd import utils
-from ycmd.request_wrap import RequestWrap
+from protoycmd import utils
+from protoycmd.request_wrap import RequestWrap
 from ycm.omni_completer import OmniCompleter
 from ycm import syntax_parse
 from ycm.client.ycmd_keepalive import YcmdKeepalive

--- a/run_tests.py
+++ b/run_tests.py
@@ -27,7 +27,7 @@ python_path = [ p.join( DIR_OF_THIRD_PARTY, 'pythonfutures' ),
                 p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'idna' ),
                 p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'requests' ),
                 p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'urllib3', 'src' ),
-                p.join( DIR_OF_THIRD_PARTY, 'ycmd' ) ]
+                p.join( DIR_OF_THIRD_PARTY, 'protoycmd' ) ]
 if os.environ.get( 'PYTHONPATH' ):
   python_path.append( os.environ[ 'PYTHONPATH' ] )
 os.environ[ 'PYTHONPATH' ] = os.pathsep.join( python_path )


### PR DESCRIPTION
Third times's the charm...

This allows YCM to not reach into ycmd's `third_party`, allowing us to completely separate thte client from the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3233)
<!-- Reviewable:end -->
