### PR TITLE
[READY] Remove user_options_store dependency

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -200,7 +200,6 @@ ycmd_third_party_folder = p.join( third_party_folder, 'ycmd', 'third_party' )
 dependencies = [ p.join( root_folder, 'python' ),
                  p.join( third_party_folder, 'requests-futures' ),
                  p.join( third_party_folder, 'ycmd' ),
-                 p.join( ycmd_third_party_folder, 'frozendict' ),
                  p.join( ycmd_third_party_folder, 'requests' ) ]
 
 # The concurrent.futures module is part of the standard library on Python 3.

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -72,11 +72,26 @@ endif
 
 let g:loaded_youcompleteme = 1
 
-" NOTE: Most defaults are in third_party/ycmd/ycmd/default_settings.json. They
-" are loaded into Vim globals with the 'ycm_' prefix if such a key does not
-" already exist; thus, the user can override the defaults.
-" The only defaults that are here are the ones that are only relevant to the YCM
-" Vim client and not the ycmd server.
+"
+" List of YCM options.
+"
+let g:ycm_filetype_whitelist =
+      \ get( g:, 'ycm_filetype_whitelist', { "*": 1 } )
+
+let g:ycm_filetype_blacklist =
+      \ get( g:, 'ycm_filetype_blacklist', {
+      \   'tagbar': 1,
+      \   'qf': 1,
+      \   'notes': 1,
+      \   'markdown': 1,
+      \   'netrw': 1,
+      \   'unite': 1,
+      \   'text': 1,
+      \   'vimwiki': 1,
+      \   'pandoc': 1,
+      \   'infolog': 1,
+      \   'mail': 1
+      \ } )
 
 let g:ycm_open_loclist_on_ycm_diags =
       \ get( g:, 'ycm_open_loclist_on_ycm_diags', 1 )
@@ -150,11 +165,105 @@ let g:ycm_warning_symbol =
       \ get( g:, 'ycm_warning_symbol',
       \ get( g:, 'syntastic_warning_symbol', '>>' ) )
 
+let g:ycm_complete_in_comments =
+      \ get( g:, 'ycm_complete_in_comments', 0 )
+
+let g:ycm_complete_in_strings =
+      \ get( g:, 'ycm_complete_in_strings', 1 )
+
+let g:ycm_collect_identifiers_from_tags_files =
+      \ get( g:, 'ycm_collect_identifiers_from_tags_files', 0 )
+
+let g:ycm_seed_identifiers_with_syntax =
+      \ get( g:, 'ycm_seed_identifiers_with_syntax', 0 )
+
 let g:ycm_goto_buffer_command =
       \ get( g:, 'ycm_goto_buffer_command', 'same-buffer' )
 
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
+
+"
+" List of ycmd options.
+"
+let g:ycm_filepath_completion_use_working_dir =
+      \ get( g:, 'ycm_filepath_completion_use_working_dir', 0 )
+
+let g:ycm_auto_trigger =
+      \ get( g:, 'ycm_auto_trigger', 1 )
+
+let g:ycm_min_num_of_chars_for_completion =
+      \ get( g:, 'ycm_min_num_of_chars_for_completion', 2 )
+
+let g:ycm_min_identifier_candidate_chars =
+      \ get( g:, 'ycm_min_num_identifier_candidate_chars', 0 )
+
+let g:ycm_semantic_triggers =
+      \ get( g:, 'ycm_semantic_triggers', {} )
+
+let g:ycm_filetype_specific_completion_to_disable =
+      \ get( g:, 'ycm_filetype_specific_completion_to_disable',
+      \      { 'gitcommit': 1 } )
+
+let g:ycm_collect_identifiers_from_comments_and_strings =
+      \ get( g:, 'ycm_collect_identifiers_from_comments_and_strings', 0 )
+
+let g:ycm_max_num_identifier_candidates =
+      \ get( g:, 'ycm_max_num_identifier_candidates', 10 )
+
+let g:ycm_max_num_candidates =
+      \ get( g:, 'ycm_max_num_candidates', 50 )
+
+let g:ycm_extra_conf_globlist =
+      \ get( g:, 'ycm_extra_conf_globlist', [] )
+
+let g:ycm_global_ycm_extra_conf =
+      \ get( g:, 'ycm_global_ycm_extra_conf', '' )
+
+let g:ycm_confirm_extra_conf =
+      \ get( g:, 'ycm_confirm_extra_conf', 1 )
+
+let g:ycm_max_diagnostics_to_display =
+      \ get( g:, 'ycm_max_diagnostics_to_display', 30 )
+
+let g:ycm_filepath_blacklist =
+      \ get( g:, 'ycm_filepath_blacklist', {
+      \   'html': 1,
+      \   'jsx': 1,
+      \   'xml': 1
+      \ } )
+
+let g:ycm_auto_start_csharp_server =
+      \ get( g:, 'ycm_auto_start_csharp_server', 1 )
+
+let g:ycm_auto_stop_csharp_server =
+      \ get( g:, 'ycm_auto_stop_csharp_server', 1 )
+
+let g:ycm_use_ultisnips_completer =
+      \ get( g:, 'ycm_use_ultisnips_completer', 1 )
+
+let g:ycm_csharp_server_port =
+      \ get( g:, 'ycm_csharp_server_port', 0 )
+
+" These options are not documented.
+let g:ycm_gocode_binary_path =
+      \ get( g:, 'ycm_gocode_binary_path', '' )
+
+let g:ycm_godef_binary_path =
+      \ get( g:, 'ycm_godef_binary_path', '' )
+
+let g:ycm_rust_src_path =
+      \ get( g:, 'ycm_rust_src_path', '' )
+
+let g:ycm_racerd_binary_path =
+      \ get( g:, 'ycm_racerd_binary_path', '' )
+
+let g:ycm_java_jdtls_use_clean_workspace =
+      \ get( g:, 'ycm_java_jdtls_use_clean_workspace', 1 )
+
+" This option is deprecated.
+let g:ycm_python_binary_path =
+      \ get( g:, 'ycm_python_binary_path', '' )
 
 if has( 'vim_starting' ) " Loading at startup.
   " We defer loading until after VimEnter to allow the gui to fork (see

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -153,6 +153,9 @@ let g:ycm_echo_current_diagnostic =
       \ get( g:, 'ycm_echo_current_diagnostic',
       \ get( g:, 'syntastic_echo_current_error', 1 ) )
 
+let g:ycm_filter_diagnostics =
+      \ get( g:, 'ycm_filter_diagnostics', {} )
+
 let g:ycm_always_populate_location_list =
       \ get( g:, 'ycm_always_populate_location_list',
       \ get( g:, 'syntastic_always_populate_loc_list', 0 ) )

--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -22,38 +22,28 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from future.utils import iteritems
 from ycm import vimsupport
-from ycmd import user_options_store
 from ycmd import identifier_utils
 
 YCM_VAR_PREFIX = 'ycm_'
 
 
-def BuildServerConf():
+def GetUserOptions():
   """Builds a dictionary mapping YCM Vim user options to values. Option names
   don't have the 'ycm_' prefix."""
   # We only evaluate the keys of the vim globals and not the whole dictionary
   # to avoid unicode issues.
   # See https://github.com/Valloric/YouCompleteMe/pull/2151 for details.
   keys = vimsupport.GetVimGlobalsKeys()
-  server_conf = {}
+  user_options = {}
   for key in keys:
     if not key.startswith( YCM_VAR_PREFIX ):
       continue
     new_key = key[ len( YCM_VAR_PREFIX ): ]
     new_value = vimsupport.VimExpressionToPythonType( 'g:' + key )
-    server_conf[ new_key ] = new_value
+    user_options[ new_key ] = new_value
 
-  return server_conf
-
-
-def LoadJsonDefaultsIntoVim():
-  defaults = user_options_store.DefaultOptions()
-  for key, value in iteritems( defaults ):
-    new_key = 'g:ycm_' + key
-    if not vimsupport.VariableExists( new_key ):
-      vimsupport.SetVariableValue( new_key, value )
+  return user_options
 
 
 def CurrentIdentifierFinished():

--- a/python/ycm/client/command_request.py
+++ b/python/ycm/client/command_request.py
@@ -34,10 +34,14 @@ def _EnsureBackwardsCompatibility( arguments ):
 
 
 class CommandRequest( BaseRequest ):
-  def __init__( self, arguments, extra_data = None ):
+  def __init__( self,
+                arguments,
+                buffer_command = 'same-buffer',
+                extra_data = None ):
     super( CommandRequest, self ).__init__()
     self._arguments = _EnsureBackwardsCompatibility( arguments )
     self._command = arguments and arguments[ 0 ]
+    self._buffer_command = buffer_command
     self._extra_data = extra_data
     self._response = None
 
@@ -91,7 +95,8 @@ class CommandRequest( BaseRequest ):
       vimsupport.JumpToLocation( self._response[ 'filepath' ],
                                  self._response[ 'line_num' ],
                                  self._response[ 'column_num' ],
-                                 modifiers )
+                                 modifiers,
+                                 self._buffer_command )
 
 
   def _HandleFixitResponse( self ):
@@ -129,8 +134,11 @@ class CommandRequest( BaseRequest ):
     vimsupport.WriteToPreviewWindow( self._response[ 'detailed_info' ] )
 
 
-def SendCommandRequest( arguments, modifiers, extra_data = None ):
-  request = CommandRequest( arguments, extra_data )
+def SendCommandRequest( arguments,
+                        modifiers,
+                        buffer_command,
+                        extra_data = None ):
+  request = CommandRequest( arguments, buffer_command, extra_data )
   # This is a blocking call.
   request.Start()
   request.RunPostCommandActionsIfNeeded( modifiers )

--- a/python/ycm/diagnostic_filter.py
+++ b/python/ycm/diagnostic_filter.py
@@ -53,9 +53,9 @@ class DiagnosticFilter( object ):
 
   @staticmethod
   def CreateFromOptions( user_options ):
-    all_filters = dict( user_options.get( 'filter_diagnostics', {} ) )
+    all_filters = user_options[ 'filter_diagnostics' ]
     compiled_by_type = {}
-    for type_spec, filter_value in iteritems( dict( all_filters ) ):
+    for type_spec, filter_value in iteritems( all_filters ):
       filetypes = [ type_spec ]
       if type_spec.find( ',' ) != -1:
         filetypes = type_spec.split( ',' )

--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -37,19 +37,28 @@ from ycm.tests import test_utils
 from ycm.youcompleteme import YouCompleteMe
 from ycmd.utils import CloseStandardStreams, WaitUntilProcessIsTerminated
 
-# The default options which are only relevant to the client, not the server and
-# thus are not part of default_options.json, but are required for a working
-# YouCompleteMe object.
+# The default options which are required for a working YouCompleteMe object.
 DEFAULT_CLIENT_OPTIONS = {
-  'g:ycm_server_python_interpreter': '',
+  # YCM options
   'g:ycm_log_level': 'info',
   'g:ycm_keep_logfiles': 0,
   'g:ycm_extra_conf_vim_data': [],
+  'g:ycm_server_python_interpreter': '',
   'g:ycm_show_diagnostics_ui': 1,
-  'g:ycm_echo_current_diagnostic': 1,
   'g:ycm_enable_diagnostic_signs': 1,
   'g:ycm_enable_diagnostic_highlighting': 0,
+  'g:ycm_echo_current_diagnostic': 1,
   'g:ycm_always_populate_location_list': 0,
+  'g:ycm_collect_identifiers_from_tags_files': 0,
+  'g:ycm_seed_identifiers_with_syntax': 0,
+  'g:ycm_goto_buffer_command': 'same-buffer',
+  # ycmd options
+  'g:ycm_auto_trigger': 1,
+  'g:ycm_min_num_of_chars_for_completion': 2,
+  'g:ycm_semantic_triggers': {},
+  'g:ycm_filetype_specific_completion_to_disable': { 'gitcommit': 1 },
+  'g:ycm_max_num_candidates': 50,
+  'g:ycm_max_diagnostics_to_display': 30
 }
 
 

--- a/python/ycm/tests/__init__.py
+++ b/python/ycm/tests/__init__.py
@@ -48,6 +48,7 @@ DEFAULT_CLIENT_OPTIONS = {
   'g:ycm_enable_diagnostic_signs': 1,
   'g:ycm_enable_diagnostic_highlighting': 0,
   'g:ycm_echo_current_diagnostic': 1,
+  'g:ycm_filter_diagnostics': {},
   'g:ycm_always_populate_location_list': 0,
   'g:ycm_collect_identifiers_from_tags_files': 0,
   'g:ycm_seed_identifiers_with_syntax': 0,

--- a/python/ycm/tests/client/command_request_test.py
+++ b/python/ycm/tests/client/command_request_test.py
@@ -268,7 +268,8 @@ class Response_Detection_test( object ):
             response[ 'filepath' ],
             response[ 'line_num' ],
             response[ 'column_num' ],
-            'rightbelow' )
+            'rightbelow',
+            'same-buffer' )
 
     def GoToListTest( command, response ):
       # Note: the detail of these called are tested by

--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -43,6 +43,7 @@ def SendCommandRequest_ExtraConfVimData_Works_test( ycm ):
         contains(
           contains( 'GoTo' ),
           'aboveleft',
+          'same-buffer',
           has_entries( {
             'options': has_entries( {
               'tab_size': 2,
@@ -68,6 +69,7 @@ def SendCommandRequest_ExtraConfData_UndefinedValue_test( ycm ):
         contains(
           contains( 'GoTo' ),
           'belowright',
+          'same-buffer',
           has_entries( {
             'options': has_entries( {
               'tab_size': 2,
@@ -88,6 +90,7 @@ def SendCommandRequest_BuildRange_NoVisualMarks_test( ycm, *args ):
       send_request.assert_called_once_with(
         [ 'GoTo' ],
         '',
+        'same-buffer',
         {
           'options': {
             'tab_size': 2,
@@ -120,6 +123,7 @@ def SendCommandRequest_BuildRange_VisualMarks_test( ycm, *args ):
       send_request.assert_called_once_with(
         [ 'GoTo' ],
         'tab',
+        'same-buffer',
         {
           'options': {
             'tab_size': 2,
@@ -146,6 +150,7 @@ def SendCommandRequest_IgnoreFileTypeOption_test( ycm, *args ):
     expected_args = (
       [ 'GoTo' ],
       '',
+      'same-buffer',
       {
         'options': {
           'tab_size': 2,

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1680,8 +1680,6 @@ def InsertNamespace_append_test( vim_current, *args ):
   AssertBuffersAreEqualAsBytes( expected_buffer, vim_current.buffer )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_SameFile_SameBuffer_NoSwapFile_test( vim_command ):
   # No 'u' prefix for the current buffer name string to simulate Vim returning
@@ -1691,7 +1689,8 @@ def JumpToLocation_SameFile_SameBuffer_NoSwapFile_test( vim_command ):
     vimsupport.JumpToLocation( os.path.realpath( u'uni¢𐍈d€' ),
                                2,
                                5,
-                               'aboveleft' )
+                               'aboveleft',
+                               'same-buffer' )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1700,15 +1699,13 @@ def JumpToLocation_SameFile_SameBuffer_NoSwapFile_test( vim_command ):
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_SameBuffer_Unmodified_test( vim_command ):
   current_buffer = VimBuffer( 'uni¢𐍈d€' )
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'belowright' )
+    vimsupport.JumpToLocation( target_name, 2, 5, 'belowright', 'same-buffer' )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1718,8 +1715,6 @@ def JumpToLocation_DifferentFile_SameBuffer_Unmodified_test( vim_command ):
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_SameBuffer_Modified_CannotHide_test(
     vim_command ):
@@ -1728,7 +1723,7 @@ def JumpToLocation_DifferentFile_SameBuffer_Modified_CannotHide_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'botright' )
+    vimsupport.JumpToLocation( target_name, 2, 5, 'botright', 'same-buffer' )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1738,8 +1733,6 @@ def JumpToLocation_DifferentFile_SameBuffer_Modified_CannotHide_test(
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_SameBuffer_Modified_CanHide_test(
     vim_command ):
@@ -1748,7 +1741,7 @@ def JumpToLocation_DifferentFile_SameBuffer_Modified_CanHide_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ) as vim:
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'leftabove' )
+    vimsupport.JumpToLocation( target_name, 2, 5, 'leftabove', 'same-buffer' )
 
     assert_that( vim.current.window.cursor, equal_to( ( 2, 4 ) ) )
     vim_command.assert_has_exact_calls( [
@@ -1758,8 +1751,6 @@ def JumpToLocation_DifferentFile_SameBuffer_Modified_CanHide_test(
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command',
         side_effect = [ None, VimError( 'Unknown code' ), None ] )
 def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Unexpected_test(
@@ -1769,13 +1760,15 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Unexpected_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     assert_that(
       calling( vimsupport.JumpToLocation ).with_args(
-          os.path.realpath( u'different_uni¢𐍈d€' ), 2, 5, 'rightbelow' ),
+        os.path.realpath( u'different_uni¢𐍈d€' ),
+        2,
+        5,
+        'rightbelow',
+        'same-buffer' ),
       raises( VimError, 'Unknown code' )
     )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command',
         new_callable = ExtendedMock,
         side_effect = [ None, VimError( 'E325' ), None ] )
@@ -1784,7 +1777,7 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Quit_test( vim_command ):
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'topleft' )
+    vimsupport.JumpToLocation( target_name, 2, 5, 'topleft', 'same-buffer' )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1792,8 +1785,6 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Quit_test( vim_command ):
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'same-buffer' } )
 @patch( 'vim.command',
         new_callable = ExtendedMock,
         side_effect = [ None, KeyboardInterrupt, None ] )
@@ -1802,7 +1793,7 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Abort_test( vim_command ):
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'vertical' )
+    vimsupport.JumpToLocation( target_name, 2, 5, 'vertical', 'same-buffer' )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1810,8 +1801,6 @@ def JumpToLocation_DifferentFile_SameBuffer_SwapFile_Abort_test( vim_command ):
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'split-or-existing-window' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_Split_CurrentTab_NotAlreadyOpened_test(
     vim_command ):
@@ -1824,7 +1813,11 @@ def JumpToLocation_DifferentFile_Split_CurrentTab_NotAlreadyOpened_test(
 
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'aboveleft' )
+    vimsupport.JumpToLocation( target_name,
+                               2,
+                               5,
+                               'aboveleft',
+                               'split-or-existing-window' )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1833,8 +1826,6 @@ def JumpToLocation_DifferentFile_Split_CurrentTab_NotAlreadyOpened_test(
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'split-or-existing-window' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_Split_CurrentTab_AlreadyOpened_test(
     vim_command ):
@@ -1849,7 +1840,10 @@ def JumpToLocation_DifferentFile_Split_CurrentTab_AlreadyOpened_test(
     vim.current.tabpage = current_tab
 
     vimsupport.JumpToLocation( os.path.realpath( u'different_uni¢𐍈d€' ),
-                               2, 5, 'belowright' )
+                               2,
+                               5,
+                               'belowright',
+                               'split-or-existing-window' )
 
     assert_that( vim.current.tabpage, equal_to( current_tab ) )
     assert_that( vim.current.window, equal_to( different_window ) )
@@ -1860,8 +1854,6 @@ def JumpToLocation_DifferentFile_Split_CurrentTab_AlreadyOpened_test(
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'split-or-existing-window' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_Split_AllTabs_NotAlreadyOpened_test(
     vim_command ):
@@ -1870,7 +1862,11 @@ def JumpToLocation_DifferentFile_Split_AllTabs_NotAlreadyOpened_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'tab' )
+    vimsupport.JumpToLocation( target_name,
+                               2,
+                               5,
+                               'tab',
+                               'split-or-existing-window' )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1879,8 +1875,6 @@ def JumpToLocation_DifferentFile_Split_AllTabs_NotAlreadyOpened_test(
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'split-or-existing-window' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_Split_AllTabs_AlreadyOpened_test(
     vim_command ):
@@ -1894,7 +1888,10 @@ def JumpToLocation_DifferentFile_Split_AllTabs_AlreadyOpened_test(
     with MockVimBuffers( [ current_buffer, different_buffer ],
                          [ current_buffer ] ) as vim:
       vimsupport.JumpToLocation( os.path.realpath( u'different_uni¢𐍈d€' ),
-                                 2, 5, 'tab' )
+                                 2,
+                                 5,
+                                 'tab',
+                                 'split-or-existing-window' )
 
       assert_that( vim.current.tabpage, equal_to( current_tab ) )
       assert_that( vim.current.window, equal_to( different_window ) )
@@ -1905,8 +1902,6 @@ def JumpToLocation_DifferentFile_Split_AllTabs_AlreadyOpened_test(
       ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'new-or-existing-tab' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_NewOrExistingTab_NotAlreadyOpened_test(
     vim_command ):
@@ -1915,7 +1910,11 @@ def JumpToLocation_DifferentFile_NewOrExistingTab_NotAlreadyOpened_test(
   with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
     target_name = os.path.realpath( u'different_uni¢𐍈d€' )
 
-    vimsupport.JumpToLocation( target_name, 2, 5, 'aboveleft vertical' )
+    vimsupport.JumpToLocation( target_name,
+                               2,
+                               5,
+                               'aboveleft vertical',
+                               'new-or-existing-tab' )
 
     vim_command.assert_has_exact_calls( [
       call( 'normal! m\'' ),
@@ -1924,8 +1923,6 @@ def JumpToLocation_DifferentFile_NewOrExistingTab_NotAlreadyOpened_test(
     ] )
 
 
-@patch( 'ycmd.user_options_store._USER_OPTIONS',
-        { 'goto_buffer_command': 'new-or-existing-tab' } )
 @patch( 'vim.command', new_callable = ExtendedMock )
 def JumpToLocation_DifferentFile_NewOrExistingTab_AlreadyOpened_test(
     vim_command ):
@@ -1939,7 +1936,10 @@ def JumpToLocation_DifferentFile_NewOrExistingTab_AlreadyOpened_test(
     with MockVimBuffers( [ current_buffer, different_buffer ],
                          [ current_buffer ] ) as vim:
       vimsupport.JumpToLocation( os.path.realpath( u'different_uni¢𐍈d€' ),
-                                 2, 5, 'belowright tab' )
+                                 2,
+                                 5,
+                                 'belowright tab',
+                                 'new-or-existing-tab' )
 
       assert_that( vim.current.tabpage, equal_to( current_tab ) )
       assert_that( vim.current.window, equal_to( different_window ) )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -31,7 +31,6 @@ import re
 from collections import defaultdict, namedtuple
 from ycmd.utils import ( ByteOffsetToCodepointOffset, GetCurrentDirectory,
                          JoinLinesAsUnicode, ToBytes, ToUnicode )
-from ycmd import user_options_store
 
 BUFFER_COMMAND_MAP = { 'same-buffer'      : 'edit',
                        'split'            : 'split',
@@ -511,7 +510,7 @@ def JumpToFile( filename, command, modifiers ):
 
 
 # Both |line| and |column| need to be 1-based
-def JumpToLocation( filename, line, column, modifiers ):
+def JumpToLocation( filename, line, column, modifiers, command ):
   # Add an entry to the jumplist
   vim.command( "normal! m'" )
 
@@ -522,24 +521,22 @@ def JumpToLocation( filename, line, column, modifiers ):
     # location, not to the start of the newly opened file.
     # Sadly this fails on random occasions and the undesired jump remains in the
     # jumplist.
-    user_command = user_options_store.Value( 'goto_buffer_command' )
-
-    if user_command == 'split-or-existing-window':
+    if command == 'split-or-existing-window':
       if 'tab' in modifiers:
         if TryJumpLocationInTabs( filename, line, column ):
           return
       elif TryJumpLocationInTab( vim.current.tabpage, filename, line, column ):
         return
-      user_command = 'split'
+      command = 'split'
 
     # This command is kept for backward compatibility. :tab should be used with
     # the 'split-or-existing-window' command instead.
-    if user_command == 'new-or-existing-tab':
+    if command == 'new-or-existing-tab':
       if TryJumpLocationInTabs( filename, line, column ):
         return
-      user_command = 'new-tab'
+      command = 'new-tab'
 
-    if not JumpToFile( filename, user_command, modifiers ):
+    if not JumpToFile( filename, command, modifiers ):
       return
 
   vim.current.window.cursor = ( line, column - 1 )

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -35,7 +35,7 @@ from ycm import base, paths, vimsupport
 from ycm.buffer import ( BufferDict,
                          DIAGNOSTIC_UI_FILETYPES,
                          DIAGNOSTIC_UI_ASYNC_FILETYPES )
-from ycmd import server_utils, user_options_store, utils
+from ycmd import server_utils, utils
 from ycmd.request_wrap import RequestWrap
 from ycm.omni_completer import OmniCompleter
 from ycm import syntax_parse
@@ -133,9 +133,7 @@ class YouCompleteMe( object ):
     self._server_is_ready_with_cache = False
     self._message_poll_request = None
 
-    base.LoadJsonDefaultsIntoVim()
-    user_options_store.SetAll( base.BuildServerConf() )
-    self._user_options = user_options_store.GetAll()
+    self._user_options = base.GetUserOptions()
     self._omnicomp = OmniCompleter( self._user_options )
     self._buffers = BufferDict( self._user_options )
 
@@ -344,7 +342,10 @@ class YouCompleteMe( object ):
       extra_data.update( vimsupport.BuildRange( start_line, end_line ) )
     self._AddExtraConfDataIfNeeded( extra_data )
 
-    return SendCommandRequest( final_arguments, modifiers, extra_data )
+    return SendCommandRequest( final_arguments,
+                               modifiers,
+                               self._user_options[ 'goto_buffer_command' ],
+                               extra_data )
 
 
   def GetDefinedSubcommands( self ):


### PR DESCRIPTION
A small step in decoupling YCM and ycmd. Instead of loading the default settings from ycmd, define them directly in the `plugin/youcompleteme.vim` file along the other options. This removes the `frozendict` and `user_options_store` dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3243)
<!-- Reviewable:end -->
