### PR TITLE
[READY] Update diagnostic matches only in current window

### DIFF
--- a/python/ycm/diagnostic_interface.py
+++ b/python/ycm/diagnostic_interface.py
@@ -129,28 +129,29 @@ class DiagnosticInterface( object ):
     if not self._user_options[ 'enable_diagnostic_highlighting' ]:
       return
 
-    with vimsupport.CurrentWindow():
-      for window in vimsupport.GetWindowsForBufferNumber( self._bufnr ):
-        vimsupport.SwitchWindow( window )
+    # Vim doesn't provide a way to update the matches for a different window
+    # than the current one (which is a view of the current buffer).
+    if vimsupport.GetCurrentBufferNumber() != self._bufnr:
+      return
 
-        matches_to_remove = vimsupport.GetDiagnosticMatchesInCurrentWindow()
+    matches_to_remove = vimsupport.GetDiagnosticMatchesInCurrentWindow()
 
-        for diags in itervalues( self._line_to_diags ):
-          # Insert squiggles in reverse order so that errors overlap warnings.
-          for diag in reversed( diags ):
-            group = ( 'YcmErrorSection' if _DiagnosticIsError( diag ) else
-                      'YcmWarningSection' )
+    for diags in itervalues( self._line_to_diags ):
+      # Insert squiggles in reverse order so that errors overlap warnings.
+      for diag in reversed( diags ):
+        group = ( 'YcmErrorSection' if _DiagnosticIsError( diag ) else
+                  'YcmWarningSection' )
 
-            for pattern in _ConvertDiagnosticToMatchPatterns( diag ):
-              # The id doesn't matter for matches that we may add.
-              match = vimsupport.DiagnosticMatch( 0, group, pattern )
-              try:
-                matches_to_remove.remove( match )
-              except ValueError:
-                vimsupport.AddDiagnosticMatch( match )
+        for pattern in _ConvertDiagnosticToMatchPatterns( diag ):
+          # The id doesn't matter for matches that we may add.
+          match = vimsupport.DiagnosticMatch( 0, group, pattern )
+          try:
+            matches_to_remove.remove( match )
+          except ValueError:
+            vimsupport.AddDiagnosticMatch( match )
 
-        for match in matches_to_remove:
-          vimsupport.RemoveDiagnosticMatch( match )
+    for match in matches_to_remove:
+      vimsupport.RemoveDiagnosticMatch( match )
 
 
   def _UpdateSigns( self ):

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -1047,14 +1047,13 @@ def YouCompleteMe_AsyncDiagnosticUpdate_PerFile_test( ycm,
     ] )
   ] )
 
+  # FIXME: diagnostic matches in windows other than the current one are not
+  # updated.
   assert_that(
     test_utils.VIM_MATCHES_FOR_WINDOW,
     has_entries( {
       1: contains(
         VimMatch( 'YcmErrorSection', '\\%1l\\%1c\\_.\\{-}\\%1l\\%1c' )
-      ),
-      3: contains(
-        VimMatch( 'YcmErrorSection', '\\%3l\\%3c\\_.\\{-}\\%3l\\%3c' )
       )
     } )
   )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -23,7 +23,6 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from future.utils import iterkeys
-import contextlib
 import vim
 import os
 import json
@@ -1216,49 +1215,6 @@ def BuildRange( start_line, end_line ):
       }
     }
   }
-
-
-@contextlib.contextmanager
-def AutocommandEventsIgnored( events = [ 'all' ] ):
-  """Context manager to perform operations without triggering autocommand
-  events. |events| is a list of events to ignore. By default, all events are
-  ignored."""
-  old_eventignore = vim.options[ 'eventignore' ]
-  ignored_events = {
-    event for event in ToUnicode( old_eventignore ).split( ',' ) if event }
-  ignored_events.update( events )
-  vim.options[ 'eventignore' ] = ','.join( ignored_events )
-  try:
-    yield
-  finally:
-    vim.options[ 'eventignore' ] = old_eventignore
-
-
-def GetPreviousWindowNumber():
-  return GetIntValue( 'winnr("#")' ) - 1
-
-
-@contextlib.contextmanager
-def CurrentWindow():
-  """Context manager to perform operations on other windows than the current one
-  without triggering autocommands related to window movement. Use the
-  SwitchWindow function to move to other windows while under the context."""
-  previous_window = vim.windows[ GetPreviousWindowNumber() ]
-  current_window = vim.current.window
-  with AutocommandEventsIgnored( [ 'WinEnter', 'Winleave' ] ):
-    try:
-      yield
-    finally:
-      # Ensure <c-w>p still go to the previous window.
-      vim.current.window = previous_window
-      vim.current.window = current_window
-
-
-def SwitchWindow( window ):
-  """Move to the window object |window|. This function should be called under
-  the CurrentWindow context if you are going to switch back to the original
-  window."""
-  vim.current.window = window
 
 
 # Expects version_string in 'MAJOR.MINOR.PATCH' format, e.g. '8.1.278'


### PR DESCRIPTION
Unfortunately, switching windows when updating the diagnostic matches causes too many side-effects like issues #3228 and #3242. Revert PRs https://github.com/Valloric/YouCompleteMe/pull/3024 and https://github.com/Valloric/YouCompleteMe/pull/3229 and only update matches in the current window.

Fixes #3242.