### PR TITLE
[READY] Fix insertion adjustment for omnifunc candidates

### DIFF
--- a/python/ycm/base.py
+++ b/python/ycm/base.py
@@ -103,7 +103,7 @@ def AdjustCandidateInsertionText( candidates ):
   for candidate in candidates:
     new_candidate = candidate.copy()
 
-    if not new_candidate[ 'abbr' ]:
+    if not new_candidate.get( 'abbr' ):
       new_candidate[ 'abbr' ] = new_candidate[ 'word' ]
 
     new_candidate[ 'word' ] = NewCandidateInsertionText(

--- a/python/ycm/tests/base_test.py
+++ b/python/ycm/tests/base_test.py
@@ -130,6 +130,13 @@ def AdjustCandidateInsertionText_DontTouchAbbr_test():
            { 'word': 'foobar', 'abbr': '1234' } ] ) )
 
 
+def AdjustCandidateInsertionText_NoAbbr_test():
+  with MockTextAfterCursor( 'bar' ):
+    eq_( [ { 'word': 'foo', 'abbr': 'foobar' } ],
+         base.AdjustCandidateInsertionText( [
+           { 'word': 'foobar' } ] ) )
+
+
 def OverlapLength_Basic_test():
   eq_( 3, base.OverlapLength( 'foo bar', 'bar zoo' ) )
   eq_( 3, base.OverlapLength( 'foobar', 'barzoo' ) )


### PR DESCRIPTION
The assumption that the `abbr` field always exist does not hold when candidates are from Vim's omnifunc.

Fixes #3264.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3265)
<!-- Reviewable:end -->
