### PR TITLE
[READY] Fix run_tests.py dependencies

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,39 +1,36 @@
 #!/usr/bin/env python
 
-import os
-import subprocess
-import os.path as p
+import argparse
 import glob
+import os
+import os.path as p
+import subprocess
 import sys
 
 DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )
 DIR_OF_THIRD_PARTY = p.join( DIR_OF_THIS_SCRIPT, 'third_party' )
-DIR_OF_YCMD_THIRD_PARTY = p.join( DIR_OF_THIRD_PARTY, 'ycmd', 'third_party' )
 
-python_path = []
-for folder in os.listdir( DIR_OF_THIRD_PARTY ):
-  python_path.append( p.abspath( p.join( DIR_OF_THIRD_PARTY, folder ) ) )
-for folder in os.listdir( DIR_OF_YCMD_THIRD_PARTY ):
-  # We skip python-future because it needs to be inserted in sys.path AFTER
-  # the standard library imports but we can't do that with PYTHONPATH because
-  # the std lib paths are always appended to PYTHONPATH. We do it correctly in
-  # prod in ycmd/utils.py because we have access to the right sys.path.
-  # So for dev, we rely on python-future being installed correctly with
-  #   pip install -r test_requirements.txt
-  #
-  # Pip knows how to install this correctly so that it doesn't matter where in
-  # sys.path the path is.
-  if folder == 'python-future':
-    continue
-  python_path.append( p.abspath( p.join( DIR_OF_YCMD_THIRD_PARTY, folder ) ) )
+# We don't include python-future (not to be confused with pythonfutures) because
+# it needs to be inserted in sys.path AFTER the standard library imports but we
+# can't do that with PYTHONPATH because the std lib paths are always appended to
+# PYTHONPATH. We do it correctly inside Vim because we have access to the right
+# sys.path. So for dev, we rely on python-future being installed correctly with
+#
+#   pip install -r python/test_requirements.txt
+#
+# Pip knows how to install this correctly so that it doesn't matter where in
+# sys.path the path is.
+python_path = [ p.join( DIR_OF_THIRD_PARTY, 'pythonfutures' ),
+                p.join( DIR_OF_THIRD_PARTY, 'requests-futures' ),
+                p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'chardet' ),
+                p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'certifi' ),
+                p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'idna' ),
+                p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'requests' ),
+                p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'urllib3', 'src' ),
+                p.join( DIR_OF_THIRD_PARTY, 'ycmd' ) ]
 if os.environ.get( 'PYTHONPATH' ):
   python_path.append( os.environ[ 'PYTHONPATH' ] )
 os.environ[ 'PYTHONPATH' ] = os.pathsep.join( python_path )
-
-sys.path.insert( 1, p.abspath( p.join( DIR_OF_YCMD_THIRD_PARTY,
-                                       'argparse' ) ) )
-
-import argparse
 
 
 def RunFlake8():


### PR DESCRIPTION
The dependencies are now explicitly added to `PYTHONPATH` in the `run_tests.py` script. Adding the `argparse` module to `sys.path` is not needed anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3266)
<!-- Reviewable:end -->
