### PR TITLE
[READY] Workaround "Invalid channel" errors when NeoVim exits immediately after started

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -509,6 +509,11 @@ endfunction
 
 
 function! s:OnVimLeave()
+  " Workaround a NeoVim issue - not shutting down timers correctly
+  " https://github.com/neovim/neovim/issues/6840
+  for poller in values( s:pollers )
+    call timer_stop( poller.id )
+  endfor
   exec s:python_command "ycm_state.OnVimLeave()"
 endfunction
 


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
   Dunno how to write a test for such an _intermittent_ issue, sorry
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The issue was originally reported at https://github.com/neovim/neovim/issues/6840.

If I exit neovim immediately after it starts, there are error messages like this:
```
Error detected while processing function <SNR>96_PollServerReady[1]..<SNR>96_Pyeval[2]..provider#python3#Call:
line   18:
Invalid channel: 3
Error detected while processing function <SNR>96_PollServerReady[7]..<SNR>96_Pyeval[2]..provider#python3#Call:
line   18:
Invalid channel: 3
```
The issue is not always reproducible. Usually I get once in 5 neovim runs. With this patch I don't get these message in 20 neovim runs.

In https://github.com/neovim/neovim/issues/6840#issuecomment-309960751, @micbou mentions that

> Stopping the timers on the `VimLeave` event seems to fix that issue

So, here's my attempt!

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3292)
<!-- Reviewable:end -->
