### PR TITLE
[READY] Update g:ycm_max_diagnostics_to_display docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2560,8 +2560,10 @@ let g:ycm_autoclose_preview_window_after_insertion = 0
 ### The `g:ycm_max_diagnostics_to_display` option
 
 This option controls the maximum number of diagnostics shown to the user when
-errors or warnings are detected in the file. This option is only relevant if you
-are using the C-family semantic completion engine.
+errors or warnings are detected in the file. This option is only relevant for
+the C-family, C#, Java, JavaScript, and TypeScript languages.
+
+A special value of `0` means there is no limit.
 
 Default: `30`
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2787,8 +2787,10 @@ Default: '0'
 The *g:ycm_max_diagnostics_to_display* option
 
 This option controls the maximum number of diagnostics shown to the user when
-errors or warnings are detected in the file. This option is only relevant if
-you are using the C-family semantic completion engine.
+errors or warnings are detected in the file. This option is only relevant for
+the C-family, C#, Java, JavaScript, and TypeScript languages.
+
+A special value of '0' means there is no limit.
 
 Default: '30'
 >


### PR DESCRIPTION
Update the documentation with the complete list of languages affected by the `g:ycm_max_diagnostics_to_display` option and mention that the number of diagnostics is unlimited if the option is set to `0` .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3301)
<!-- Reviewable:end -->
