### PR TITLE
[READY] Improve error message when unable to load Python

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -54,10 +54,19 @@ elseif !has( 'timers' )
         \ echohl None
   call s:restore_cpo()
   finish
-elseif !has( 'python' ) && !has( 'python3' )
+elseif !has( 'python_compiled' ) && !has( 'python3_compiled' )
   echohl WarningMsg |
         \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .
         \ "Python (2.7.1+ or 3.4+) support." |
+        \ echohl None
+  call s:restore_cpo()
+  finish
+" These calls try to load the Python 2 and Python 3 libraries when Vim is
+" compiled dynamically against them. Since only one can be loaded at a time on
+" some platforms, we first check if Python 3 is available.
+elseif !has( 'python3' ) && !has( 'python' )
+  echohl WarningMsg |
+        \ echomsg "YouCompleteMe unavailable: unable to load Python." |
         \ echohl None
   call s:restore_cpo()
   finish


### PR DESCRIPTION
The current error when Python cannot be loaded
> YouCompleteMe unavailable: requires Vim compiled Python (2.7.1+ or 3.4+) support.

is misleading if Vim has been dynamically compiled against Python but is unable to find the library. See issue https://github.com/Valloric/YouCompleteMe/issues/3300 for instance. We should only return that error if `has( 'python_compiled' )` and `has( 'python3_compiled' )` are both false. Furthermore, we should check if Python 3 is available before Python 2 because on some platforms, only one Python library can be loaded at a time so if Python 2 is loaded first, Python 3 cannot be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3303)
<!-- Reviewable:end -->
