### PR TITLE
Fix NeoVim Compatibility

### DIFF
--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -54,7 +54,7 @@ elseif !has( 'timers' )
         \ echohl None
   call s:restore_cpo()
   finish
-elseif !has( 'python_compiled' ) && !has( 'python3_compiled' )
+elseif !has( 'python_compiled' ) && !has( 'python3_compiled' ) && !has( 'nvim' )
   echohl WarningMsg |
         \ echomsg "YouCompleteMe unavailable: requires Vim compiled with " .
         \ "Python (2.7.1+ or 3.4+) support." |


### PR DESCRIPTION
> NeoVim doesn't have compiled support for Python/Python3 -- rather, it comes as a plugin. Without the added check, this change makes YCM incompatible with neovim.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ X ] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ X ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ X ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ X ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

As stated in the commit message, the recent addition of the check against `has("python3_compiled")` and `has("python_compiled")` has broken compatibility with neovim. I simply made it skip the check if the editor is neovim, making it compatible again.

No tests have been included because it's a very small change written in VimScript. I did test it on my machine and it appears to have worked.

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3310)
<!-- Reviewable:end -->
