### PR TITLE
[READY] Update ycmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,26 +699,27 @@ Quick Feature Summary
 * Semantic auto-completion with automatic fixes
 * Real-time diagnostic display
 * Go to include/declaration/definition (`GoTo`, etc.)
-* Semantic type information for identifiers (`GetType`)
-* Automatically fix certain errors (`FixIt`)
 * View documentation comments for identifiers (`GetDoc`)
+* Type information for identifiers (`GetType`)
+* Automatically fix certain errors (`FixIt`)
 
 ### C♯
 
 * Semantic auto-completion
 * Real-time diagnostic display
 * Go to declaration/definition (`GoTo`, etc.)
-* Semantic type information for identifiers (`GetType`)
+* View documentation comments for identifiers (`GetDoc`)
+* Type information for identifiers (`GetType`)
 * Automatically fix certain errors (`FixIt`)
 * Management of OmniSharp server instance
-* View documentation comments for identifiers (`GetDoc`)
 
 ### Python
 
-* Intelligent auto-completion
+* Semantic auto-completion
 * Go to definition (`GoTo`)
 * Reference finding (`GoToReferences`)
 * View documentation comments for identifiers (`GetDoc`)
+* Type information for identifiers (`GetType`)
 
 ### Go
 
@@ -729,15 +730,15 @@ Quick Feature Summary
 ### JavaScript and TypeScript
 
 * Semantic auto-completion with automatic import insertion
+* Real-time diagnostic display
 * Go to definition (`GoTo`, `GoToDefinition`, and `GoToDeclaration` are
   identical)
 * Go to type definition (`GoToType`)
 * Reference finding (`GoToReferences`)
-* Real-time diagnostic display
-* Renaming symbols (`RefactorRename <new name>`)
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
 * Automatically fix certain errors (`FixIt`)
+* Renaming symbols (`RefactorRename <new name>`)
 * Code formatting (`Format`)
 * Organize imports (`OrganizeImports`)
 * Management of `TSServer` server instance
@@ -747,8 +748,8 @@ Quick Feature Summary
 * Semantic auto-completion
 * Go to definition (`GoTo`, `GoToDefinition`, and `GoToDeclaration` are
   identical)
-* Management of `racer` server instance
 * View documentation comments for identifiers (`GetDoc`)
+* Management of `racer` server instance
 
 ### Java
 
@@ -756,14 +757,14 @@ Quick Feature Summary
 [feedback](#contact).
 
 * Semantic auto-completion with automatic import insertion
+* Real-time diagnostic display
 * Go to definition (`GoTo`, `GoToDefinition`, and `GoToDeclaration` are
   identical)
 * Reference finding (`GoToReferences`)
-* Real-time diagnostic display
-* Renaming symbols (`RefactorRename <new name>`)
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
-* Automatically fix certain errors including code generation  (`FixIt`)
+* Automatically fix certain errors including code generation (`FixIt`)
+* Renaming symbols (`RefactorRename <new name>`)
 * Code formatting (`Format`)
 * Organize imports (`OrganizeImports`)
 * Detection of java projects
@@ -1640,7 +1641,7 @@ Invoking this command on `s` returns `std::string => std::basic_string<char>`
 **NOTE:** Causes re-parsing of the current translation unit.
 
 Supported in filetypes: `c, cpp, objc, objcpp, cuda, java, javascript,
-typescript`
+python, typescript`
 
 #### The `GetTypeImprecise` subcommand
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -923,9 +923,9 @@ C-family languages (C, C++, Objective C, Objective C++, CUDA) ~
 - Semantic auto-completion with automatic fixes
 - Real-time diagnostic display
 - Go to include/declaration/definition (|GoTo|, etc.)
-- Semantic type information for identifiers (|GetType|)
-- Automatically fix certain errors (|FixIt|)
 - View documentation comments for identifiers (|GetDoc|)
+- Type information for identifiers (|GetType|)
+- Automatically fix certain errors (|FixIt|)
 
 -------------------------------------------------------------------------------
                                                               *youcompleteme-c*
@@ -934,19 +934,20 @@ C♯ ~
 - Semantic auto-completion
 - Real-time diagnostic display
 - Go to declaration/definition (|GoTo|, etc.)
-- Semantic type information for identifiers (|GetType|)
+- View documentation comments for identifiers (|GetDoc|)
+- Type information for identifiers (|GetType|)
 - Automatically fix certain errors (|FixIt|)
 - Management of OmniSharp server instance
-- View documentation comments for identifiers (|GetDoc|)
 
 -------------------------------------------------------------------------------
                                                          *youcompleteme-python*
 Python ~
 
-- Intelligent auto-completion
+- Semantic auto-completion
 - Go to definition (|GoTo|)
 - Reference finding (|GoToReferences|)
 - View documentation comments for identifiers (|GetDoc|)
+- Type information for identifiers (|GetType|)
 
 -------------------------------------------------------------------------------
                                                              *youcompleteme-go*
@@ -961,15 +962,15 @@ Go ~
 JavaScript and TypeScript ~
 
 - Semantic auto-completion with automatic import insertion
+- Real-time diagnostic display
 - Go to definition (|GoTo|, |GoToDefinition|, and |GoToDeclaration| are
   identical)
 - Go to type definition (|GoToType|)
 - Reference finding (|GoToReferences|)
-- Real-time diagnostic display
-- Renaming symbols ('RefactorRename <new name>')
 - View documentation comments for identifiers (|GetDoc|)
 - Type information for identifiers (|GetType|)
 - Automatically fix certain errors (|FixIt|)
+- Renaming symbols ('RefactorRename <new name>')
 - Code formatting (|Format|)
 - Organize imports (|OrganizeImports|)
 - Management of 'TSServer' server instance
@@ -981,8 +982,8 @@ Rust ~
 - Semantic auto-completion
 - Go to definition (|GoTo|, |GoToDefinition|, and |GoToDeclaration| are
   identical)
-- Management of 'racer' server instance
 - View documentation comments for identifiers (|GetDoc|)
+- Management of 'racer' server instance
 
 -------------------------------------------------------------------------------
                                                            *youcompleteme-java*
@@ -992,14 +993,14 @@ Java ~
 feedback.
 
 - Semantic auto-completion with automatic import insertion
+- Real-time diagnostic display
 - Go to definition (|GoTo|, |GoToDefinition|, and |GoToDeclaration| are
   identical)
 - Reference finding (|GoToReferences|)
-- Real-time diagnostic display
-- Renaming symbols ('RefactorRename <new name>')
 - View documentation comments for identifiers (|GetDoc|)
 - Type information for identifiers (|GetType|)
 - Automatically fix certain errors including code generation (|FixIt|)
+- Renaming symbols ('RefactorRename <new name>')
 - Code formatting (|Format|)
 - Organize imports (|OrganizeImports|)
 - Detection of java projects
@@ -1890,7 +1891,7 @@ Invoking this command on 's' returns 'std::string => std::basic_string<char>'
 
 **NOTE:** Causes re-parsing of the current translation unit.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, cuda, java, javascript,
+Supported in filetypes: 'c, cpp, objc, objcpp, cuda, java, javascript, python,
 typescript'
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Include the following changes:

 - PR Valloric/ycmd#1095: allow users to configure LSP servers through extra conf;
 - PR Valloric/ycmd#1118: add Clangd completer;
 - PR Valloric/ycmd#1130: do not default to 32-bit when downloading libclang;
 - PR Valloric/ycmd#1132: update requests;
 - PR Valloric/ycmd#1149: do not include Clangd with `--all`;
 - PR Valloric/ycmd#1151: add `GetType` command to Python completer;
 - PR Valloric/ycmd#1152: update Boost to 1.69;
 - PR Valloric/ycmd#1153: only detail filtered candidates in Python completer;
 - PR Valloric/ycmd#1154: include signature to Python candidates;
 - PR Valloric/ycmd#1155: only detail filtered candidates in TypeScript completer;
 - PR Valloric/ycmd#1156: update Jedi to 0.13.2;
 - PR Valloric/ycmd#1157: only detail filtered candidates in Go completer;
 - PR Valloric/ycmd#1161: only resolve filtered candidates in LSP completer;
 - PR Valloric/ycmd#1164: do not find CMake and Python if not needed;
 - PR Valloric/ycmd#1167: do not read LSP settings on every file parse;
 - PR Valloric/ycmd#1172: fix system headers search on macOS;
 - PR Valloric/ycmd#1174: report Java server startup status correctly;
 - PR Valloric/ycmd#1177: make LSP debug info consistent;
 - PR Valloric/ycmd#1178: improve LSP project directory detection;
 - PR Valloric/ycmd#1179: determine simple subcommands automatically in LSP completer;
 - PR Valloric/ycmd#1181: fix LSP server startup when UnknownExtraConf is thrown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3312)
<!-- Reviewable:end -->
