### PR TITLE
Update Go's part in full installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,14 @@ process.
       PATH][add-msbuild-to-path].
 
     - Go support: install [Go][go-install] and add it to your path. Navigate to
-      `YouCompleteMe/third_party/ycmd/third_party/gocode` and run `go build`.
+      `YouCompleteMe/third_party/ycmd/third_party/go` and in **both**
+      `src/github.com/mdempsky/gocode` and `src/github.com/rogpeppe/godef` run
+
+          GOPATH=$(realpath ../../../..) go build
+
+      On Windows, first set `GOPATH` to the absolute path of
+      `YouCompleteMe/third_party/ycmd/third_party/go` then run `go build` in the two
+      directories above.
 
     - JavaScript and TypeScript support: install [Node.js and npm][npm-install],
       navigate to `YouCompleteMe/third_party/ycmd` and run


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

- The original installation guide missed `go build` in `godef`'s directory, relating issue [here](https://github.com/Valloric/YouCompleteMe/issues/3071#issuecomment-403213723).
- The path of `gocode` and `godef` has been changed, update them in the doc.

I have tested this guide on my Manjaro laptop and it works fine, my go version is `1.11.4`.

(Since the path is too long, the vim help doc looks kind of ugly, maybe the formatting or the
path's presenting way should be changed so that it looks better. I used the `gq` command
in vim and it gave me this.)

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3315)
<!-- Reviewable:end -->
