### PR TITLE
[READY] Allow completion in the command-line window

### DIFF
--- a/README.md
+++ b/README.md
@@ -2073,9 +2073,9 @@ Default: `[see next line]`
 ```viml
 let g:ycm_filetype_blacklist = {
       \ 'tagbar': 1,
-      \ 'qf': 1,
       \ 'notes': 1,
       \ 'markdown': 1,
+      \ 'netrw': 1,
       \ 'unite': 1,
       \ 'text': 1,
       \ 'vimwiki': 1,
@@ -3345,6 +3345,18 @@ more details.
 
 This is a Vim bug fixed in version 8.1.0256. Update your Vim to this version or
 later.
+
+### `TAB` is already mapped to trigger completion in the command-line window
+
+Vim automatically maps the key set by the `wildchar` option, which is `TAB` by
+default, to complete commands in the command-line window. If you would prefer
+using this key to cycle through YCM's suggestions without changing the value of
+`wildchar`, add the following to your vimrc:
+
+```viml
+autocmd CmdwinEnter * inoremap <expr><buffer> <TAB>
+      \ pumvisible() ? "\<C-n>" : "\<TAB>"
+```
 
 Contributor Code of Conduct
 ---------------------------

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -181,6 +181,7 @@ module could not be loaded" |youcompleteme-on-windows-i-get-e887-sorry-this-comm
   35. YCM does not shut down when I quit Vim |youcompleteme-ycm-does-not-shut-down-when-i-quit-vim|
   36. YCM does not work with my Anaconda Python setup |youcompleteme-ycm-does-not-work-with-my-anaconda-python-setup|
   37. Automatic import insertion after selecting a completion breaks undo |youcompleteme-automatic-import-insertion-after-selecting-completion-breaks-undo|
+  38. 'TAB' is already mapped to trigger completion in the command-line window |youcompleteme-tab-is-already-mapped-to-trigger-completion-in-command-line-window|
  14. Contributor Code of Conduct    |youcompleteme-contributor-code-of-conduct|
  15. Contact                                            |youcompleteme-contact|
  16. License                                            |youcompleteme-license|
@@ -2331,9 +2332,9 @@ Default: '[see next line]'
 >
   let g:ycm_filetype_blacklist = {
         \ 'tagbar': 1,
-        \ 'qf': 1,
         \ 'notes': 1,
         \ 'markdown': 1,
+        \ 'netrw': 1,
         \ 'unite': 1,
         \ 'text': 1,
         \ 'vimwiki': 1,
@@ -3601,6 +3602,18 @@ Automatic import insertion after selecting a completion breaks undo ~
 This is a Vim bug fixed in version 8.1.0256. Update your Vim to this version or
 later.
 
+-------------------------------------------------------------------------------
+*youcompleteme-tab-is-already-mapped-to-trigger-completion-in-command-line-window*
+'TAB' is already mapped to trigger completion in the command-line window ~
+
+Vim automatically maps the key set by the 'wildchar' option, which is 'TAB' by
+default, to complete commands in the command-line window. If you would prefer
+using this key to cycle through YCM's suggestions without changing the value of
+'wildchar', add the following to your vimrc:
+>
+  autocmd CmdwinEnter * inoremap <expr><buffer> <TAB>
+        \ pumvisible() ? "\<C-n>" : "\<TAB>"
+<
 ===============================================================================
                                     *youcompleteme-contributor-code-of-conduct*
 Contributor Code of Conduct ~

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -91,7 +91,6 @@ let g:ycm_filetype_whitelist =
 let g:ycm_filetype_blacklist =
       \ get( g:, 'ycm_filetype_blacklist', {
       \   'tagbar': 1,
-      \   'qf': 1,
       \   'notes': 1,
       \   'markdown': 1,
       \   'netrw': 1,


### PR DESCRIPTION
This implements @puremourning's suggestion from https://github.com/Valloric/YouCompleteMe/pull/1415#issuecomment-460197058 and adds an entry in the FAQ on how to override the `TAB` mapping in the command-line window. Since the `CmdwinEnter` event is triggered instead of `BufEnter` in that window, the `s:OnBufferEnter` function is called for that event too. Also, the contents of that window are empty when the filetype is set the first time so we ignore the `FileType` event in that window. Finally, the `qf` filetype is removed from the `g:ycm_filetype_blacklist` option since the quickfix window is always ignored.

This needs testing as these changes may not work well with plugins that create special buffers. We may have to blacklist the filetype of these buffers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3316)
<!-- Reviewable:end -->
