### PR TITLE
[READY] Remap GoTo* commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1594,7 +1594,10 @@ changes since the last parse that would lead to incorrect jumps. When you're
 just browsing around your codebase, this command can spare you quite a bit of
 latency.
 
-Supported in filetypes: `c, cpp, objc, objcpp, cuda`
+**NOTE:** this command is identical to `GoTo` for other languages.
+
+Supported in filetypes: `c, cpp, objc, objcpp, cuda, cs, go, java, javascript,
+python, rust, typescript`
 
 #### The `GoToReferences` subcommand
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1837,7 +1837,10 @@ made any changes since the last parse that would lead to incorrect jumps. When
 you're just browsing around your codebase, this command can spare you quite a
 bit of latency.
 
-Supported in filetypes: 'c, cpp, objc, objcpp, cuda'
+**NOTE:** this command is identical to |GoTo| for other languages.
+
+Supported in filetypes: 'c, cpp, objc, objcpp, cuda, cs, go, java, javascript,
+python, rust, typescript'
 
 -------------------------------------------------------------------------------
 The *GoToReferences* subcommand


### PR DESCRIPTION
Remap the `GoToDefinitionElseDeclaration` and `GoToImprecise` commands to `GoTo` if not defined by the completer (always the case for `GoToDefinitionElseDeclaration`) by using the `/defined_subcommands` endpoint. With this change, the `GoToImprecise` command can be removed from the LSP completer in ycmd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3321)
<!-- Reviewable:end -->
