### PR TITLE
[READY] Ensure only loclist or quickfix windows are closed

### DIFF
--- a/python/ycm/tests/client/command_request_test.py
+++ b/python/ycm/tests/client/command_request_test.py
@@ -107,7 +107,11 @@ class GoToResponse_QuickFix_test( object ):
     ] )
     vim_command.assert_has_exact_calls( [
       call( 'botright copen' ),
-      call( 'au WinLeave <buffer> q' ),
+      call( 'augroup ycmquickfix' ),
+      call( 'autocmd! * <buffer>' ),
+      call( 'autocmd WinLeave <buffer> '
+            'if bufnr( "%" ) == expand( "<abuf>" ) | q | endif' ),
+      call( 'augroup END' ),
       call( 'doautocmd User YcmQuickFixOpened' )
     ] )
     set_fitting_height.assert_called_once_with()

--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -165,7 +165,11 @@ def OpenLocationList_test( vim_command, fitting_height, variable_exists ):
   vimsupport.OpenLocationList( focus = False, autoclose = True )
   vim_command.assert_has_exact_calls( [
     call( 'lopen' ),
-    call( 'au WinLeave <buffer> q' ),
+    call( 'augroup ycmlocation' ),
+    call( 'autocmd! * <buffer>' ),
+    call( 'autocmd WinLeave <buffer> '
+          'if bufnr( "%" ) == expand( "<abuf>" ) | q | endif' ),
+    call( 'augroup END' ),
     call( 'doautocmd User YcmLocationOpened' ),
     call( 'silent! wincmd p' )
   ] )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -341,9 +341,7 @@ def OpenLocationList( focus = False, autoclose = False ):
   SetFittingHeightForCurrentWindow()
 
   if autoclose:
-    # This autocommand is automatically removed when the location list window is
-    # closed.
-    vim.command( 'au WinLeave <buffer> q' )
+    AutoCloseOnCurrentBuffer( 'ycmlocation' )
 
   if VariableExists( '#User#YcmLocationOpened' ):
     vim.command( 'doautocmd User YcmLocationOpened' )
@@ -368,9 +366,7 @@ def OpenQuickFixList( focus = False, autoclose = False ):
   SetFittingHeightForCurrentWindow()
 
   if autoclose:
-    # This autocommand is automatically removed when the quickfix window is
-    # closed.
-    vim.command( 'au WinLeave <buffer> q' )
+    AutoCloseOnCurrentBuffer( 'ycmquickfix' )
 
   if VariableExists( '#User#YcmQuickFixOpened' ):
     vim.command( 'doautocmd User YcmQuickFixOpened' )
@@ -1238,3 +1234,13 @@ def VimVersionAtLeast( version_string ):
     return actual_major_and_minor > matching_major_and_minor
 
   return GetBoolValue( "has( 'patch{0}' )".format( patch ) )
+
+
+def AutoCloseOnCurrentBuffer( name ):
+  """Create an autocommand group with name |name| on the current buffer that
+  automatically closes it when leaving its window."""
+  vim.command( 'augroup {}'.format( name ) )
+  vim.command( 'autocmd! * <buffer>' )
+  vim.command( 'autocmd WinLeave <buffer> '
+               'if bufnr( "%" ) == expand( "<abuf>" ) | q | endif' )
+  vim.command( 'augroup END' )


### PR DESCRIPTION
Fixes #3334.

Note that `autocmd! * <buffer>` is required for location lists because we don't want to remove the autocommand in other location lists. It doesn't matter for the quickfix window since there is only one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3335)
<!-- Reviewable:end -->
