### PR TITLE
Reduced latency by using jobstart to dispatch request (optional)

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -709,6 +709,17 @@ endfunction
 
 
 function! s:OnTextChangedInsertMode()
+  if !g:ycm_async_completionrequest_dispatch
+    return s:OnTextChangedInsertModeCB()
+  endif
+  if has("nvim")
+    call jobstart(['true'], {'on_exit':function("s:OnTextChangedInsertModeCB")})
+  else
+    call job_start('true', {'exit_cb':function("s:OnTextChangedInsertModeCB")})
+  endif
+endfunction
+
+function! s:OnTextChangedInsertModeCB(...)
   if !s:AllowedToCompleteInCurrentBuffer()
     return
   endif

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -141,6 +141,7 @@ Contents ~
   47. The |g:ycm_use_ultisnips_completer| option
   48. The |g:ycm_goto_buffer_command| option
   49. The |g:ycm_disable_for_files_larger_than_kb| option
+  50. The |g:ycm_async_completionrequest_dispatch| option
  13. FAQ                                                    |youcompleteme-faq|
   1. I used to be able to 'import vim' in '.ycm_extra_conf.py', but now can't |youcompleteme-i-used-to-be-able-to-import-vim-in-.ycm_extra_conf.py-but-now-cant|
   2. I get 'ImportError' exceptions that mention 'PyInit_ycm_core' or 'initycm_core' |youcompleteme-i-get-importerror-exceptions-that-mention-pyinit_ycm_core-or-initycm_core|
@@ -3062,6 +3063,19 @@ opening.
 Default: 1000
 >
   let g:ycm_disable_for_files_larger_than_kb = 1000
+<
+-------------------------------------------------------------------------------
+The *g:ycm_async_completionrequest_dispatch* option
+
+If enabled, the dispatch of requests to the server is done asynchronous as
+well as the communication itself.
+Per default communication with the YouCompleteMe-server is asynchronous, but
+dispatching the request is not. As this is done on every keystroke, using an
+async dispatch does improve input latency in most cases.
+
+Default: 0
+>
+  let g:ycm_async_completionrequest_dispatch = 0
 <
 ===============================================================================
                                                             *youcompleteme-faq*

--- a/plugin/youcompleteme.vim
+++ b/plugin/youcompleteme.vim
@@ -195,6 +195,8 @@ let g:ycm_goto_buffer_command =
 let g:ycm_disable_for_files_larger_than_kb =
       \ get( g:, 'ycm_disable_for_files_larger_than_kb', 1000 )
 
+let g:ycm_async_completionrequest_dispatch =
+      \ get( g:, 'ycm_async_completionrequest_dispatch', 0 )
 "
 " List of ycmd options.
 "


### PR DESCRIPTION
First: Thanks for YCM! You really complete me!

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Lately I concerned myself with input latency (https://lwn.net/Articles/751763/, https://pavelfatin.com/typometer/) and found that in my setup YCM adds quite some latency onto the stack.
But a fix was easily found and I wanted to share this with you. I attached the benchmark results done with Fatin's tool. At least for neovim users this option does really help pushing down input latency. Classic vim is not that much influenced.

Handling of completions is already asynchronous but dispatching the
request is not. As this is done on every key stroke it does influence
input latency for most vim flavors. The option
g:ycm_async_completionrequest_dispatch enables an asynchronous
dispatching by using the jobstart (or job_start).
It uses "true" as there is no real job to be done in the shell, but we
only want to trigger the callback.

It is made optional as it might not be the right fix for everyone and I guess it won't work on windows.


[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
![benchmark](https://user-images.githubusercontent.com/7195718/54516533-74b12d00-495f-11e9-8246-94d88f55b4d7.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3346)
<!-- Reviewable:end -->
