### PR TITLE
fix user defined key map options

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -288,13 +288,13 @@ function! s:SetUpKeyMappings()
     " With this command, when the completion window is visible, the tab key
     " (default) will select the next candidate in the window. In vim, this also
     " changes the typed-in text to that of the candidate completion.
-    exe 'inoremap <expr>' . key .
+    exe 'imap <expr>' . key .
           \ ' pumvisible() ? "\<C-n>" : "\' . key .'"'
   endfor
 
   for key in g:ycm_key_list_previous_completion
     " This selects the previous candidate for shift-tab (default)
-    exe 'inoremap <expr>' . key .
+    exe 'imap <expr>' . key .
           \ ' pumvisible() ? "\<C-p>" : "\' . key .'"'
   endfor
 
@@ -302,7 +302,7 @@ function! s:SetUpKeyMappings()
     " When selecting a candidate and closing the completion menu with the <C-y>
     " key, the menu will automatically be reopened because of the TextChangedI
     " event. We define a command to prevent that.
-    exe 'inoremap <expr>' . key . ' <SID>StopCompletion( "\' . key . '" )'
+    exe 'imap <expr>' . key . ' <SID>StopCompletion( "\' . key . '" )'
   endfor
 
   if !empty( g:ycm_key_invoke_completion )
@@ -313,12 +313,12 @@ function! s:SetUpKeyMappings()
       imap <Nul> <C-Space>
     endif
 
-    silent! exe 'inoremap <unique> <silent> ' . invoke_key .
+    silent! exe 'imap <unique> <silent> ' . invoke_key .
           \ ' <C-R>=<SID>InvokeSemanticCompletion()<CR>'
   endif
 
   if !empty( g:ycm_key_detailed_diagnostics )
-    silent! exe 'nnoremap <unique> ' . g:ycm_key_detailed_diagnostics .
+    silent! exe 'nmap <unique> ' . g:ycm_key_detailed_diagnostics .
           \ ' :YcmShowDetailedDiagnostic<CR>'
   endif
 
@@ -326,7 +326,7 @@ function! s:SetUpKeyMappings()
   " completion menu is open. We handle this by closing the completion menu on
   " the keys that delete a character in insert mode.
   for key in [ "<BS>", "<C-h>" ]
-    silent! exe 'inoremap <unique> <expr> ' . key .
+    silent! exe 'imap <unique> <expr> ' . key .
           \ ' <SID>OnDeleteChar( "\' . key . '" )'
   endfor
 endfunction


### PR DESCRIPTION
# commit message:
-don't use [nore]map mapping flavours otherwise any recursive mappings
employed by the user won't work

# more detail
-this change is useful as it allows working key maps for anyone using
the (fairly fundamental) recursive mapping nature of vim 
-with my (rather limited) understanding, i believe that plugin devs are
only supposed to 'protect' (via [nore]map) *internal* mappings. e.g.
when exposing a public command via \<Plug>ycm..., 'noremap'ping of
that to an internal script function is all good. however, when taking a
user's key input, it's not really their place to provide 'protection' of that.
as with the above issue, it might be an intermediate map/name that
doesn't represent a valid/working key symbol

# testing
-this is a trivial vimscript change, touching nothing of this plugin's core
functionality, thus i see it as an 'either author agrees with above point'
and it gets merged, else it gets rejected - the use of noremap might
very well be intentional and i've no interest in debating that :smile: 

Thank you for this plugin.

# PR Prelude
Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ x ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3351)
<!-- Reviewable:end -->
