### PR TITLE
[READY] Disable Vim filtering

### DIFF
--- a/python/ycm/client/completion_request.py
+++ b/python/ycm/client/completion_request.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013-2018 YouCompleteMe contributors
+# Copyright (C) 2013-2019 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -201,6 +201,8 @@ def _ConvertCompletionDataToVimData( completion_identifier, completion_data ):
     'menu'     : completion_data.get( 'extra_menu_info', '' ),
     'info'     : _GetCompletionInfoField( completion_data ),
     'kind'     : ToUnicode( completion_data.get( 'kind', '' ) )[ :1 ].lower(),
+    # Disable Vim filtering.
+    'equal'    : 1,
     'dup'      : 1,
     'empty'    : 1,
     # We store the completion item index as a string in the completion

--- a/python/ycm/omni_completer.py
+++ b/python/ycm/omni_completer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011, 2012, 2013  Google Inc.
+# Copyright (C) 2011-2019 ycmd contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -127,8 +127,14 @@ class OmniCompleter( Completer ):
       # but ycmd only supports lists where items are all strings or all
       # dictionaries. Convert all strings into dictionaries.
       for index, item in enumerate( items ):
+        # Set the 'equal' field to 1 to disable Vim filtering.
         if not isinstance( item, dict ):
-          items[ index ] = { 'word': item }
+          items[ index ] = {
+            'word': item,
+            'equal': 1
+          }
+        else:
+          item[ 'equal' ] = 1
 
       return items
 

--- a/python/ycm/tests/client/completion_request_test.py
+++ b/python/ycm/tests/client/completion_request_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 YouCompleteMe Contributors
+# Copyright (C) 2015-2019 YouCompleteMe Contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -41,7 +41,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
     try:
       eq_( expected_vim_data, vim_data )
     except Exception:
-      print( "Expected:\n'{0}'\nwhen parsing:\n'{1}'\nBut found:\n'{2}'".format(
+      print( "Expected:\n'{}'\nwhen parsing:\n'{}'\nBut found:\n'{}'".format(
           expected_vim_data,
           completion_data,
           vim_data ) )
@@ -64,6 +64,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : 'EXTRA MENU INFO',
       'kind'     : 'k',
       'info'     : 'DETAILED INFO\nDOC STRING',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': '0',
@@ -79,6 +80,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : '',
       'kind'     : '',
       'info'     : '',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': '17',
@@ -98,6 +100,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : 'EXTRA MENU INFO',
       'kind'     : 'k',
       'info'     : 'DETAILED INFO',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': '9999999999',
@@ -119,6 +122,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : 'EXTRA MENU INFO',
       'kind'     : 'k',
       'info'     : 'DOC STRING',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': 'not_an_int',
@@ -139,6 +143,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : 'EXTRA MENU INFO',
       'kind'     : 'k',
       'info'     : '',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': '0',
@@ -161,6 +166,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : 'EXTRA MENU INFO',
       'kind'     : 'k',
       'info'     : 'DETAILEDINFO\nDOCSTRING',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': '0',
@@ -182,6 +188,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : 'EXTRA MENU INFO',
       'kind'     : 'k',
       'info'     : 'DETAILED INFO',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': '0',
@@ -204,6 +211,7 @@ class ConvertCompletionResponseToVimDatas_test( object ):
       'menu'     : 'EXTRA MENU INFO',
       'kind'     : 'k',
       'info'     : 'DETAILED INFO\nDOC STRING',
+      'equal'    : 1,
       'dup'      : 1,
       'empty'    : 1,
       'user_data': '0',

--- a/python/ycm/tests/omni_completer_test.py
+++ b/python/ycm/tests/omni_completer_test.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright (C) 2016-2018 YouCompleteMe contributors
+# Copyright (C) 2016-2019 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -58,9 +58,9 @@ def OmniCompleter_GetCompletions_Cache_List_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': 'a' },
-          { 'word': 'b' },
-          { 'word': 'cdef' }
+          { 'word': 'a',    'equal': 1 },
+          { 'word': 'b',    'equal': 1 },
+          { 'word': 'cdef', 'equal': 1 }
         ] ),
         'completion_start_column': 6
       } )
@@ -110,9 +110,9 @@ def OmniCompleter_GetCompletions_NoCache_List_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': 'a' },
-          { 'word': 'b' },
-          { 'word': 'cdef' }
+          { 'word': 'a',    'equal': 1 },
+          { 'word': 'b',    'equal': 1 },
+          { 'word': 'cdef', 'equal': 1 }
         ] ),
         'completion_start_column': 6
       } )
@@ -140,9 +140,9 @@ def OmniCompleter_GetCompletions_NoCache_ListFilter_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': 'a' },
-          { 'word': 'b' },
-          { 'word': 'cdef' }
+          { 'word': 'a',    'equal': 1 },
+          { 'word': 'b',    'equal': 1 },
+          { 'word': 'cdef', 'equal': 1 }
         ] ),
         'completion_start_column': 6
       } )
@@ -170,9 +170,9 @@ def OmniCompleter_GetCompletions_NoCache_UseFindStart_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': 'a' },
-          { 'word': 'b' },
-          { 'word': 'cdef' }
+          { 'word': 'a',    'equal': 1 },
+          { 'word': 'b',    'equal': 1 },
+          { 'word': 'cdef', 'equal': 1 }
         ] ),
         'completion_start_column': 1
       } )
@@ -223,7 +223,7 @@ def OmniCompleter_GetCompletions_Cache_Object_test( ycm ):
     assert_that(
       ycm.GetCompletionResponse(),
       has_entries( {
-        'completions': [ { 'word': 'CDtEF' } ],
+        'completions': [ { 'word': 'CDtEF', 'equal': 1 } ],
         'completion_start_column': 6
       } )
     )
@@ -263,11 +263,12 @@ def OmniCompleter_GetCompletions_Cache_ObjectList_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': contains( {
-          'word': 'test',
-          'abbr': 'ABBRTEST',
-          'menu': 'MENUTEST',
-          'info': 'INFOTEST',
-          'kind': 'T'
+          'word' : 'test',
+          'abbr' : 'ABBRTEST',
+          'menu' : 'MENUTEST',
+          'info' : 'INFOTEST',
+          'kind' : 'T',
+          'equal': 1
         } ),
         'completion_start_column': 6
       } )
@@ -310,17 +311,19 @@ def OmniCompleter_GetCompletions_NoCache_ObjectList_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [ {
-          'word': 'a',
-          'abbr': 'ABBR',
-          'menu': 'MENU',
-          'info': 'INFO',
-          'kind': 'K'
+          'word' : 'a',
+          'abbr' : 'ABBR',
+          'menu' : 'MENU',
+          'info' : 'INFO',
+          'kind' : 'K',
+          'equal': 1
         }, {
-          'word': 'test',
-          'abbr': 'ABBRTEST',
-          'menu': 'MENUTEST',
-          'info': 'INFOTEST',
-          'kind': 'T'
+          'word' : 'test',
+          'abbr' : 'ABBRTEST',
+          'menu' : 'MENUTEST',
+          'info' : 'INFOTEST',
+          'kind' : 'T',
+          'equal': 1
         } ] ),
         'completion_start_column': 6
       } )
@@ -361,11 +364,12 @@ def OmniCompleter_GetCompletions_Cache_ObjectListObject_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [ {
-          'word': 'test',
-          'abbr': 'ABBRTEST',
-          'menu': 'MENUTEST',
-          'info': 'INFOTEST',
-          'kind': 'T'
+          'word' : 'test',
+          'abbr' : 'ABBRTEST',
+          'menu' : 'MENUTEST',
+          'info' : 'INFOTEST',
+          'kind' : 'T',
+          'equal': 1
         } ] ),
         'completion_start_column': 6
       } )
@@ -408,17 +412,19 @@ def OmniCompleter_GetCompletions_NoCache_ObjectListObject_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [ {
-          'word': 'a',
-          'abbr': 'ABBR',
-          'menu': 'MENU',
-          'info': 'INFO',
-          'kind': 'K'
+          'word' : 'a',
+          'abbr' : 'ABBR',
+          'menu' : 'MENU',
+          'info' : 'INFO',
+          'kind' : 'K',
+          'equal': 1
         }, {
-          'word': 'test',
-          'abbr': 'ABBRTEST',
-          'menu': 'MENUTEST',
-          'info': 'INFOTEST',
-          'kind': 'T'
+          'word' : 'test',
+          'abbr' : 'ABBRTEST',
+          'menu' : 'MENUTEST',
+          'info' : 'INFOTEST',
+          'kind' : 'T',
+          'equal': 1
         } ] ),
         'completion_start_column': 6
       } )
@@ -444,9 +450,9 @@ def OmniCompleter_GetCompletions_Cache_List_Unicode_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': [
-          { 'word': 'å_unicode_identifier' },
-          { 'word': 'πππππππ yummy πie' },
-          { 'word': '†est' }
+          { 'word': 'å_unicode_identifier', 'equal': 1 },
+          { 'word': 'πππππππ yummy πie',    'equal': 1 },
+          { 'word': '†est',                 'equal': 1 }
         ],
         'completion_start_column': 13
       } )
@@ -472,9 +478,9 @@ def OmniCompleter_GetCompletions_NoCache_List_Unicode_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': '†est' },
-          { 'word': 'å_unicode_identifier' },
-          { 'word': 'πππππππ yummy πie' }
+          { 'word': '†est',                 'equal': 1 },
+          { 'word': 'å_unicode_identifier', 'equal': 1 },
+          { 'word': 'πππππππ yummy πie',    'equal': 1 }
         ] ),
         'completion_start_column': 13
       } )
@@ -499,7 +505,7 @@ def OmniCompleter_GetCompletions_Cache_List_Filter_Unicode_test( ycm ):
     assert_that(
       ycm.GetCompletionResponse(),
       has_entries( {
-        'completions': [ { 'word': 'πππππππ yummy πie' } ],
+        'completions': [ { 'word': 'πππππππ yummy πie', 'equal': 1 } ],
         'completion_start_column': 13
       } )
     )
@@ -523,7 +529,9 @@ def OmniCompleter_GetCompletions_NoCache_List_Filter_Unicode_test( ycm ):
     assert_that(
       ycm.GetCompletionResponse(),
       has_entries( {
-        'completions': ToBytesOnPY2( [ { 'word': 'πππππππ yummy πie' } ] ),
+        'completions': ToBytesOnPY2(
+          [ { 'word': 'πππππππ yummy πie', 'equal': 1 } ]
+        ),
         'completion_start_column': 13
       } )
     )
@@ -563,11 +571,12 @@ def OmniCompleter_GetCompletions_Cache_ObjectList_Unicode_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': [ {
-          'word': 'π†´ß†π',
-          'abbr': 'ÅııÂÊ‰ÍÊ',
-          'menu': '˜‰ˆËÊ‰ÍÊ',
-          'info': 'ÈˆÏØÊ‰ÍÊ',
-          'kind': 'Ê'
+          'word' : 'π†´ß†π',
+          'abbr' : 'ÅııÂÊ‰ÍÊ',
+          'menu' : '˜‰ˆËÊ‰ÍÊ',
+          'info' : 'ÈˆÏØÊ‰ÍÊ',
+          'kind' : 'Ê',
+          'equal': 1
         } ],
         'completion_start_column': 13
       } )
@@ -617,17 +626,19 @@ def OmniCompleter_GetCompletions_Cache_ObjectListObject_Unicode_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': contains( {
-          'word': 'test',
-          'abbr': 'ÅııÂÊ‰ÍÊ',
-          'menu': '˜‰ˆËÊ‰ÍÊ',
-          'info': 'ÈˆÏØÊ‰ÍÊ',
-          'kind': 'Ê'
+          'word' : 'test',
+          'abbr' : 'ÅııÂÊ‰ÍÊ',
+          'menu' : '˜‰ˆËÊ‰ÍÊ',
+          'info' : 'ÈˆÏØÊ‰ÍÊ',
+          'kind' : 'Ê',
+          'equal': 1
         }, {
-          'word': 'ålpha∫et',
-          'abbr': 'å∫∫®',
-          'menu': 'µ´~¨á',
-          'info': '^~fo',
-          'kind': '˚'
+          'word' : 'ålpha∫et',
+          'abbr' : 'å∫∫®',
+          'menu' : 'µ´~¨á',
+          'info' : '^~fo',
+          'kind' : '˚',
+          'equal': 1
         } ),
         'completion_start_column': 13
       } )
@@ -663,7 +674,7 @@ def OmniCompleter_GetCompletions_RestoreCursorPositionAfterOmnifuncCall_test(
     assert_that(
       ycm.GetCompletionResponse(),
       has_entries( {
-        'completions': ToBytesOnPY2( [ { 'word': 'length' } ] ),
+        'completions': ToBytesOnPY2( [ { 'word': 'length', 'equal': 1 } ] ),
         'completion_start_column': 6
       } )
     )
@@ -698,7 +709,7 @@ def OmniCompleter_GetCompletions_MoveCursorPositionAtStartColumn_test( ycm ):
     assert_that(
       ycm.GetCompletionResponse(),
       has_entries( {
-        'completions': ToBytesOnPY2( [ { 'word': 'length' } ] ),
+        'completions': ToBytesOnPY2( [ { 'word': 'length', 'equal': 1 } ] ),
         'completion_start_column': 6
       } )
     )
@@ -731,14 +742,14 @@ def StartColumnCompliance( ycm,
 
 
 def OmniCompleter_GetCompletions_StartColumnCompliance_test():
-  yield StartColumnCompliance, -4, [ { 'word': 'foo' } ], 3
-  yield StartColumnCompliance, -3, [],        1
-  yield StartColumnCompliance, -2, [],        1
-  yield StartColumnCompliance, -1, [ { 'word': 'foo' } ], 3
-  yield StartColumnCompliance,  0, [ { 'word': 'foo' } ], 1
-  yield StartColumnCompliance,  1, [ { 'word': 'foo' } ], 2
-  yield StartColumnCompliance,  2, [ { 'word': 'foo' } ], 3
-  yield StartColumnCompliance,  3, [ { 'word': 'foo' } ], 3
+  yield StartColumnCompliance, -4, [ { 'word': 'foo', 'equal': 1 } ], 3
+  yield StartColumnCompliance, -3, [],                                1
+  yield StartColumnCompliance, -2, [],                                1
+  yield StartColumnCompliance, -1, [ { 'word': 'foo', 'equal': 1 } ], 3
+  yield StartColumnCompliance,  0, [ { 'word': 'foo', 'equal': 1 } ], 1
+  yield StartColumnCompliance,  1, [ { 'word': 'foo', 'equal': 1 } ], 2
+  yield StartColumnCompliance,  2, [ { 'word': 'foo', 'equal': 1 } ], 3
+  yield StartColumnCompliance,  3, [ { 'word': 'foo', 'equal': 1 } ], 3
 
 
 @YouCompleteMeInstance( { 'g:ycm_cache_omnifunc': 0,
@@ -783,7 +794,7 @@ def OmniCompleter_GetCompletions_NoCache_ForceSemantic_test( ycm ):
     assert_that(
       ycm.GetCompletionResponse(),
       has_entries( {
-        'completions': ToBytesOnPY2( [ { 'word': 'test' } ] ),
+        'completions': ToBytesOnPY2( [ { 'word': 'test', 'equal': 1 } ] ),
         'completion_start_column': 1
       } )
     )
@@ -811,8 +822,8 @@ def OmniCompleter_GetCompletions_ConvertStringsToDictionaries_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': 'a' },
-          { 'word': 'b' }
+          { 'word': 'a', 'equal': 1 },
+          { 'word': 'b', 'equal': 1 }
         ] ),
         'completion_start_column': 6
       } )
@@ -894,9 +905,9 @@ def OmniCompleter_GetCompletions_FiletypeDisabled_ForceSemantic_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': 'a' },
-          { 'word': 'b' },
-          { 'word': 'cdef' }
+          { 'word': 'a',    'equal': 1 },
+          { 'word': 'b',    'equal': 1 },
+          { 'word': 'cdef', 'equal': 1 }
         ] ),
         'completion_start_column': 6
       } )
@@ -924,9 +935,9 @@ def OmniCompleter_GetCompletions_AllFiletypesDisabled_ForceSemantic_test( ycm ):
       ycm.GetCompletionResponse(),
       has_entries( {
         'completions': ToBytesOnPY2( [
-          { 'word': 'a' },
-          { 'word': 'b' },
-          { 'word': 'cdef' }
+          { 'word': 'a',    'equal': 1 },
+          { 'word': 'b',    'equal': 1 },
+          { 'word': 'cdef', 'equal': 1 }
         ] ),
         'completion_start_column': 6
       } )

--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2018 YouCompleteMe contributors
+# Copyright (C) 2011-2019 YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.
 #
@@ -707,6 +707,8 @@ def ToBytesOnPY2( data ):
   if not PY2:
     return data
 
+  if isinstance( data, int ):
+    return data
   if isinstance( data, list ):
     return [ ToBytesOnPY2( item ) for item in data ]
   if isinstance( data, dict ):


### PR DESCRIPTION
[Patch 8.1.1123](https://github.com/vim/vim/commit/73655cf0ca37a9aa8f56fc51bb853a8b1f7b43d4) added a new field `equal` to completion items that disable Vim filtering. Since we are using our own filtering, we should always set that field to `1`. This should in theory speed up completion and reduce flickering but I couldn't really notice a difference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3364)
<!-- Reviewable:end -->
