### PR TITLE
[READY] Ensure positive position for diagnostic matches

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -1373,6 +1373,24 @@ def AddDiagnosticSyntaxMatch_UnicodeAtEndOfLine_test():
     )
 
 
+def AddDiagnosticSyntaxMatch_NonPositivePosition_test():
+  current_buffer = VimBuffer(
+    'some_file',
+    contents = [ 'Some contents' ]
+  )
+
+  with patch( 'vim.current.buffer', current_buffer ):
+    assert_that(
+      vimsupport.GetDiagnosticMatchPattern( 0, 0, 0, 0 ),
+      equal_to( '\\%1l\\%1c\\_.\\{-}\\%1l\\%1c' )
+    )
+
+    assert_that(
+      vimsupport.GetDiagnosticMatchPattern( -1, -2, -3, -4 ),
+      equal_to( '\\%1l\\%1c\\_.\\{-}\\%1l\\%1c' )
+    )
+
+
 @patch( 'vim.command', new_callable=ExtendedMock )
 @patch( 'vim.current', new_callable=ExtendedMock )
 def WriteToPreviewWindow_test( vim_current, vim_command ):


### PR DESCRIPTION
Creating a diagnostic match with a non-positive line or column number raises an exception.

Fixes #3373.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3380)
<!-- Reviewable:end -->
