### PR TITLE
[READY] Update ycmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,8 @@ Quick Feature Summary
 * Real-time diagnostic display
 * Go to definition (`GoTo`, `GoToDefinition`, and `GoToDeclaration` are
   identical)
+* Go to type definition (`GoToType`)
+* Go to implementation (`GoToImplementation`)
 * Reference finding (`GoToReferences`)
 * View documentation comments for identifiers (`GetDoc`)
 * Type information for identifiers (`GetType`)
@@ -1751,7 +1753,7 @@ Looks up the symbol under the cursor and jumps to its implementation (i.e.
 non-interface). If there are multiple implementations, instead provides a list
 of implementations to choose from.
 
-Supported in filetypes: `cs`
+Supported in filetypes: `cs, java`
 
 #### The `GoToImplementationElseDeclaration` subcommand
 
@@ -1766,7 +1768,7 @@ Supported in filetypes: `cs`
 Looks up the symbol under the cursor and jumps to the definition of its type
 e.g. if the symbol is an object, go to the definition of its class.
 
-Supported in filetypes: `javascript, typescript`
+Supported in filetypes: `java, javascript, typescript`
 
 ### Semantic Information Commands
 

--- a/README.md
+++ b/README.md
@@ -593,16 +593,16 @@ process.
     **Download the latest version of `libclang`**. Clang is an open-source
     compiler that can compile C-family languages. The `libclang` library it
     provides is used to power the YCM semantic completion engine for those
-    languages. YCM is designed to work with libclang version 7.0.0 or higher.
+    languages. YCM is designed to work with libclang version 8.0.0 or higher.
 
     In addition to `libclang`, YCM also supports an **experimental**
     [clangd][]-based completer. You can download the latest version of
     [clangd][] from [llvm.org releases][clang-download]. Follow Step 4 to learn
     how to tell YCM where to find clangd binary. Please note that YCM is
-    designed to work with [clangd][] version 7.0.0 or higher.
+    designed to work with [clangd][] version 8.0.0 or higher.
 
     You can use the system libclang or clangd _only if you are sure it is
-    version 7.0.0 or higher_, otherwise don't. Even if it is, we recommend using
+    version 8.0.0 or higher_, otherwise don't. Even if it is, we recommend using
     the [official binaries from llvm.org][clang-download] if at all possible.
     Make sure you download the correct archive file for your OS.
 
@@ -3237,7 +3237,7 @@ to go through the full installation guide by hand.
 ### I see `undefined symbol: clang_getCompletionFixIt` in the server logs.
 
 This means that the server is trying to load a version of libclang that is too
-old. You need at least libclang 7.0.0. We recommend running the `install.py`
+old. You need at least libclang 8.0.0. We recommend running the `install.py`
 script without `--system-libclang` or downloading the [latest prebuilt binaries
 from llvm.org][clang-download] when going through the [full installation
 guide](#full-installation-guide).

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -807,16 +807,16 @@ will notify you to recompile it. You should then rerun the install process.
    **Download the latest version of 'libclang'**. Clang is an open-source
    compiler that can compile C-family languages. The 'libclang' library it
    provides is used to power the YCM semantic completion engine for those
-   languages. YCM is designed to work with libclang version 7.0.0 or higher.
+   languages. YCM is designed to work with libclang version 8.0.0 or higher.
 
    In addition to 'libclang', YCM also supports an **experimental** clangd
    [12]-based completer. You can download the latest version of clangd [12]
    from llvm.org releases [41]. Follow Step 4 to learn how to tell YCM where
    to find clangd binary. Please note that YCM is designed to work with
-   clangd [12] version 7.0.0 or higher.
+   clangd [12] version 8.0.0 or higher.
 
    You can use the system libclang or clangd _only if you are sure it is
-   version 7.0.0 or higher_, otherwise don't. Even if it is, we recommend
+   version 8.0.0 or higher_, otherwise don't. Even if it is, we recommend
    using the official binaries from llvm.org [41] if at all possible. Make
    sure you download the correct archive file for your OS.
 
@@ -3467,7 +3467,7 @@ to go through the full installation guide by hand.
 I see 'undefined symbol: clang_getCompletionFixIt' in the server logs. ~
 
 This means that the server is trying to load a version of libclang that is too
-old. You need at least libclang 7.0.0. We recommend running the 'install.py'
+old. You need at least libclang 8.0.0. We recommend running the 'install.py'
 script without '--system-libclang' or downloading the latest prebuilt binaries
 from llvm.org [41] when going through the full installation guide.
 

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -1086,6 +1086,8 @@ feedback.
 - Real-time diagnostic display
 - Go to definition (|GoTo|, |GoToDefinition|, and |GoToDeclaration| are
   identical)
+- Go to type definition (|GoToType|)
+- Go to implementation (|GoToImplementation|)
 - Reference finding (|GoToReferences|)
 - View documentation comments for identifiers (|GetDoc|)
 - Type information for identifiers (|GetType|)
@@ -2004,7 +2006,7 @@ Looks up the symbol under the cursor and jumps to its implementation (i.e.
 non-interface). If there are multiple implementations, instead provides a list
 of implementations to choose from.
 
-Supported in filetypes: 'cs'
+Supported in filetypes: 'cs, java'
 
 -------------------------------------------------------------------------------
 The *GoToImplementationElseDeclaration* subcommand
@@ -2021,7 +2023,7 @@ The *GoToType* subcommand
 Looks up the symbol under the cursor and jumps to the definition of its type
 e.g. if the symbol is an object, go to the definition of its class.
 
-Supported in filetypes: 'javascript, typescript'
+Supported in filetypes: 'java, javascript, typescript'
 
 -------------------------------------------------------------------------------
                                   *youcompleteme-semantic-information-commands*


### PR DESCRIPTION
Include the following changes:

 - PR Valloric/ycmd#1201: add `RestartServer` command to Clangd completer;
 - PR Valloric/ycmd#1203: reject any server to client requests in LSP completer;
 - PR Valloric/ycmd#1204: ignore any null or empty values and use our defaults in LSP completer;
 - PR Valloric/ycmd#1205: improve cache in LSP completer;
 - PR Valloric/ycmd#1207: drop Python 3.4 support;
 - PR Valloric/ycmd#1210: search custom Clangd in PATH;
 - PR Valloric/ycmd#1213: improve Clangd completer logging;
 - PR Valloric/ycmd#1214: fix off-by-one error in LSP Initialize request;
 - PR Valloric/ycmd#1215: update Clang to 8.0.0;
 - PR Valloric/ycmd#1216: support LSP declaration, typeDefinition, and implementation;
 - PR Valloric/ycmd#1219: update Unicode Standard to 12.0.0;
 - PR Valloric/ycmd#1220: do not reset state at server start in Clangd completer;
 - PR Valloric/ycmd#1222: simplify creation of LSP clients;
 - PR Valloric/ycmd#1223: include settings in debug info for LSP;
 - PR Valloric/ycmd#1228: add numpydoc to Jedi dependencies;
 - PR Valloric/ycmd#1232: fix Clangd `GetType` response;
 - PR Valloric/ycmd#1233: update to Boost 1.70;
 - PR Valloric/ycmd#1235: use move semantics in C++ code.

Add the `GoToType` and `GoToImplementation` commands for Java and increase the Clang requirement to 8.0.0 in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/youcompleteme/3384)
<!-- Reviewable:end -->
