### PR TITLE
[READY] Make diagnostic highlighting in buffers without filepath work

### DIFF
--- a/python/ycm/tests/test_utils.py
+++ b/python/ycm/tests/test_utils.py
@@ -34,7 +34,8 @@ from unittest import skipIf
 from ycmd.utils import GetCurrentDirectory, OnMac, OnWindows, ToUnicode
 
 
-BUFNR_REGEX = re.compile( '^bufnr\\(\'(?P<buffer_filename>.+)\', ([01])\\)$' )
+BUFNR_REGEX = re.compile(
+  '^bufnr\\(\'(?P<buffer_filename>.+)\'(, ([01]))?\\)$' )
 BUFWINNR_REGEX = re.compile( '^bufwinnr\\((?P<buffer_number>[0-9]+)\\)$' )
 BWIPEOUT_REGEX = re.compile(
   '^(?:silent! )bwipeout!? (?P<buffer_number>[0-9]+)$' )

--- a/test/diagnostics.test.vim
+++ b/test/diagnostics.test.vim
@@ -148,3 +148,39 @@ function! Test_MessagePoll_Multiple_Filetypes()
       \ { 'group': 'ycm_signs' } )[ 0 ][ 'signs' ]
   call assert_false( java_signs == cpp_signs )
 endfunction
+
+function! Test_BufferWithoutAssociatedFile_HighlightingWorks()
+  enew
+  call setbufline( '%', 1, 'iiii' )
+  setf c
+  call WaitForAssert( {->
+    \ assert_true( len( sign_getplaced(
+                        \ '%',
+                        \ { 'group': 'ycm_signs' } )[ 0 ][ 'signs' ] ) ) } )
+  let expected_properties = [
+    \ { 'id': 3,
+    \   'col': 1,
+    \   'end': 1,
+    \   'type': 'YcmErrorProperty',
+    \   'length': 0,
+    \   'start': 1 },
+    \ { 'id': 2,
+    \   'col': 1,
+    \   'end': 1,
+    \   'type': 'YcmErrorProperty',
+    \   'length': 0,
+    \   'start': 1 },
+    \ { 'id': 1,
+    \    'col': 1,
+    \    'end': 1,
+    \    'type': 'YcmErrorProperty',
+    \    'length': 4,
+    \    'start': 1 },
+    \ { 'id': 0,
+    \    'col': 1,
+    \    'end': 1,
+    \    'type': 'YcmErrorProperty',
+    \    'length': 4,
+    \    'start': 1 } ]
+  call assert_equal( expected_properties, prop_list( 1 ) )
+endfunction


### PR DESCRIPTION
Currently this is the only thing that doesn't work for this kind of
files.

Because we don't have a file path, we use `$PWD/$BUFNR` as file path in
requests. This mostly works, but for diagnostics it means we can't find
the file corresponding to the diagnostics we have received. See
vimsupport.py line 187 for reference.

This PR introduces some heuristics to make those work in most cases:

1. If the filepath we get from diags has a corresponding buffer number
   already, just use that. This covers already open files.
2. If the filepath doesn't exist on the local storage, and the tail of
   the path is a numeric string, we assume the weird path came from
   `$PWD/$BUFNR` magic.
3. Else we fall back to the current behaviour - either the path is an
   actual file path, or is not numeric. Either way, creating a new
   buffer seems reasonable.

Note that this fails under the following circumstances:

1. User has a file called `1` in the working directory.
2. User opens vim without any arguments.
3. YCM sends `OnBufferVisit` with `$PWD/1`.
4. ycmd responds with some diagnostics.
5. YCM mistakes `$PWD/1` (the buffer's fake path) with the actual file
   in the project.

A more robust solution could be something like a global mapping from
random strings to buffer numbers and using those generated strings as
file paths. I just didn't think it would be worth the effort.

Honestly, not sure if even this is worth the effort, but hey... there
was clearly an intention to keep this category of files working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3952)
<!-- Reviewable:end -->
