### PR TITLE
[READY] Do not decrement end_col in neovim diagnostics twice

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -246,7 +246,6 @@ def AddTextProperty( buffer_number,
   else:
     extra_args[ 'hl_group' ] = prop_type
     # Neovim uses 0-based offsets
-    extra_args[ 'end_col' ] = extra_args[ 'end_col' ] - 1
     if 'end_lnum' in extra_args:
       extra_args[ 'end_line' ] = extra_args.pop( 'end_lnum' ) - 1
     if 'end_col' in extra_args:


### PR DESCRIPTION
Neovim uses 0-based line and column offsets, so we have to decrement our
"normal" offsets, but we shouldn't do it *twice*.

# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fixes #3954 

No tests, because we don't test with neovim. Unless you'd like me to mock `VimIsNeovim()`?

From #3920:

> do we think this is g2g now, or should we dogfood it a bit first?

Well, it still works fine in vim! I'm not sure we would have caught a neovim-only bug.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/youcompleteme/3955)
<!-- Reviewable:end -->
