### PR TITLE
allow to set semantic highlight groups based on filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,20 +938,21 @@ per buffer, by setting `b:ycm_enable_semantic_highlighting`.
 YCM uses text properties (see `:help text-prop-intro`) for semantic
 highlighting. In order to customise the coloring, you should set
 `g:ycm_semantic_highlight_groups` list. Each item in that list must be
-dictionary with next fields:
-- `filetypes` - list of filetypes that should use this settings for semantic
-  highlighting. If not defined, then this settings will be used as default for
-  any not defined filetype
+dictionary with the following keys:
+- `filetypes` - list of filetypes that should use these settings for semantic
+  highlighting. If not defined, then these settings will be used as default for
+  any filetype without explicit configuration
 - `highlight` - dictionary, where key is [token type](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens)
-  and value is highlighting group. If not defined, then semantic highlighting
-  will be disabled for that filetypes. If group is empty string or `v:null`,
-  then semantic highlighing for that group will be disabled
+  and value is highlighting group. If this key is not present, then semantic
+  highlighting will be disabled for that filetypes. If group is empty string or
+  `v:null`, then semantic highlighing for that group will be disabled
 
 Some servers also use custom values. In this case, YCM prints a warning
 including the token type name that you can customise.
 
-For example (set custom highlight for go, disable highlight for rust and define
-default highlight for other filetypes):
+In the following example, we set a custom set of highlights for go, disable
+semantic highlighting for rust, and define default highlighting groups for all
+other languages:
 
 ```viml
 let g:ycm_enable_semantic_highlighting=1

--- a/README.md
+++ b/README.md
@@ -947,6 +947,9 @@ dictionary with the following keys:
   highlighting will be disabled for that filetypes. If group is empty string or
   `v:null`, then semantic highlighing for that group will be disabled
 
+For compatibility reasons we also support defining text properties named
+`YCM_HL_<token_type>`, but this may be removed in future.
+
 Some servers also use custom values. In this case, YCM prints a warning
 including the token type name that you can customise.
 

--- a/README.md
+++ b/README.md
@@ -994,7 +994,6 @@ let g:ycm_semantic_highlight_groups = [
       \},
       \{
       \ 'filetypes': ['rust']
-      \ }
       \},
       \{
       \ 'highlight': {

--- a/README.md
+++ b/README.md
@@ -936,43 +936,92 @@ per buffer, by setting `b:ycm_enable_semantic_highlighting`.
 #### Customising the highlight groups
 
 YCM uses text properties (see `:help text-prop-intro`) for semantic
-highlighting. In order to customise the coloring, you can define the text
-properties that are used.
-
-If you define a text property named `YCM_HL_<token type>`, then it will be used
-in place of the defaults. The `<token type>` is defined as the Language Server
-Protocol semantic token type, defined in the [LSP Spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens).
+highlighting. In order to customise the coloring, you should set
+`g:ycm_semantic_highlight_groups` list. Each item in that list must be
+dictionary with next fields:
+- `filetypes` - list of filetypes that should use this settings for semantic
+  highlighting. If not defined, then this settings will be used as default for
+  any not defined filetype
+- `highlight` - dictionary, where key is [token type](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens)
+  and value is highlighting group. If not defined, then semantic highlighting
+  will be disabled for that filetypes. If group is empty string or `v:null`,
+  then semantic highlighing for that group will be disabled
 
 Some servers also use custom values. In this case, YCM prints a warning
 including the token type name that you can customise.
 
-For example, to render `parameter` tokens using the `Normal` highlight group,
-you can do this:
+For example (set custom highlight for go, disable highlight for rust and define
+default highlight for other filetypes):
 
 ```viml
-call prop_type_add( 'YCM_HL_parameter', { 'highlight': 'Normal' } )
-```
+let g:ycm_enable_semantic_highlighting=1
 
-More generally, this pattern can be useful for customising the groups:
-
-```viml
-let MY_YCM_HIGHLIGHT_GROUP = {
-      \   'typeParameter': 'PreProc',
-      \   'parameter': 'Normal',
-      \   'variable': 'Normal',
-      \   'property': 'Normal',
-      \   'enumMember': 'Normal',
-      \   'event': 'Special',
-      \   'member': 'Normal',
-      \   'method': 'Normal',
-      \   'class': 'Special',
-      \   'namespace': 'Special',
+let g:ycm_semantic_highlight_groups = [
+      \{
+      \ 'filetypes': ['go'],
+      \ 'highlight': {
+      \   'namespace':      'Namespace',
+      \   'type':           'goType',
+      \   'class':          'goType',
+      \   'struct':         'goType',
+      \   'interface':      'goType',
+      \   'concept':        v:null,
+      \   'typeParameter':  v:null,
+      \   'enum':           'EnumConstant',
+      \   'enumMember':     'EnumConstant',
+      \   'function':       'goFunction',
+      \   'method':         'goFunction',
+      \   'member':         'goFunction',
+      \   'property':       'goFunction',
+      \   'macro':          v:null,
+      \   'variable':       v:null,
+      \   'parameter':      v:null,
+      \   'comment':        v:null,
+      \   'operator':       v:null,
+      \   'keyword':        v:null,
+      \   'modifier':       v:null,
+      \   'event':          v:null,
+      \   'number':         v:null,
+      \   'string':         v:null,
+      \   'regexp':         v:null,
+      \   'unknown':        v:null,
+      \   'bracket':        v:null,
       \ }
-
-for tokenType in keys( MY_YCM_HIGHLIGHT_GROUP )
-  call prop_type_add( 'YCM_HL_' . tokenType,
-                    \ { 'highlight': MY_YCM_HIGHLIGHT_GROUP[ tokenType ] } )
-endfor
+      \},
+      \{
+      \ 'filetypes': ['rust']
+      \ }
+      \},
+      \{
+      \ 'highlight': {
+      \   'namespace': 'Type',
+      \   'type': 'Type',
+      \   'class': 'Structure',
+      \   'enum': 'Structure',
+      \   'interface': 'Structure',
+      \   'struct': 'Structure',
+      \   'typeParameter': 'Identifier',
+      \   'parameter': 'Identifier',
+      \   'variable': 'Identifier',
+      \   'property': 'Identifier',
+      \   'enumMember': 'Identifier',
+      \   'enumConstant': 'Constant',
+      \   'event': 'Identifier',
+      \   'function': 'Function',
+      \   'member': 'Identifier',
+      \   'macro': 'Macro',
+      \   'method': 'Function',
+      \   'keyword': 'Keyword',
+      \   'modifier': 'Keyword',
+      \   'comment': 'Comment',
+      \   'string': 'String',
+      \   'number': 'Number',
+      \   'regexp': 'String',
+      \   'operator': 'Operator',
+      \   'unknown': 'Normal',
+      \ }
+      \}
+      \]
 ```
 
 ## Inlay hints

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -16,6 +16,7 @@
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from ycm.client.base_request import BaseRequest
 from ycm.client.semantic_tokens_request import SemanticTokensRequest
 from ycm.client.base_request import BuildRequestData
 from ycm import vimsupport
@@ -185,6 +186,9 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
 
 
   def _NewRequest( self, request_range ):
+    if self._do_highlight == False:
+      return BaseRequest()
+
     request: dict = BuildRequestData( self._bufnr )
     request[ 'range' ] = request_range
     return SemanticTokensRequest( request )

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -194,7 +194,7 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
           if token[ 'type' ] not in REPORTED_MISSING_TYPES:
             REPORTED_MISSING_TYPES.add( token[ 'type' ] )
             vimsupport.PostVimMessage(
-              f"Token type { token[ 'type' ] } not supported for { self._filetypes }. "
+              f"Token type { token[ 'type' ] } is not defined for { self._filetypes }. "
               f"See :help youcompleteme-customising-highlight-groups"
               )
         else:

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -90,9 +90,12 @@ def AddHiForTokenType( bufnr, token_type, group ):
                               priority = 0,
                               combine = combine,
                               bufnr = bufnr )
-    except vim.error:
-      # at YcmRestart we can get error about redefining properties, just ignore them
-      pass
+    except vim.error as e:
+      if 'E969:' in str( e ):
+        # at YcmRestart we can get error about redefining properties, just ignore them
+        pass
+      else:
+        raise e
 
 
 

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -107,8 +107,16 @@ def Initialise():
   default_hi = None
   for groups in HIGHLIGHT_GROUPS:
     if 'filetypes' not in groups:
-      default_hi = groups
-      break
+      if 'highlight' not in groups:
+        continue
+
+      if default_hi is None:
+        default_hi = groups
+      else:
+        # merge all defaults
+        for token_type, group in groups[ 'highlight' ].items():
+          if token_type not in default_hi[ 'highlight' ]:
+            default_hi[ 'highlight' ][ token_type ] = group
 
   if default_hi is None or 'highlight' not in default_hi:
     return

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -84,11 +84,16 @@ def AddHiForTokenType( bufnr, token_type, group ):
                               priority = 0,
                               combine = combine )
   else:
-    tp.AddTextPropertyType( prop,
-                            highlight = hi,
-                            priority = 0,
-                            combine = combine,
-                            bufnr = bufnr )
+    try:
+      tp.AddTextPropertyType( prop,
+                              highlight = hi,
+                              priority = 0,
+                              combine = combine,
+                              bufnr = bufnr )
+    except vim.error:
+      # at YcmRestart we can get error about redefining properties, just ignore them
+      pass
+
 
 
 def Initialise():

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -61,6 +61,9 @@ def AddHiForTokenType( bufnr, token_type, group ):
   prop = f'YCM_HL_{ token_type }'
   hi = group
   combine = 0
+  filetypes = "(default)"
+  if bufnr is not None:
+    filetypes = vimsupport.GetBufferFiletypes(bufnr)
 
   if group is None or len( group ) == 0:
     hi = 'Normal'
@@ -69,8 +72,8 @@ def AddHiForTokenType( bufnr, token_type, group ):
   if not vimsupport.GetIntValue(
       f"hlexists( '{ vimsupport.EscapeForVim( hi ) }' )" ):
     vimsupport.PostVimMessage(
-        f"Higlight group { hi } is not difined"
-        )
+        f"Higlight group { hi } is not difined for { filetypes }. "
+        f"See :help youcompleteme-customising-highlight-groups" )
     return
 
   if bufnr is None:
@@ -96,8 +99,7 @@ def Initialise():
 
   if "ycm_semantic_highlight_groups" in vimsupport.GetVimGlobalsKeys():
     hi_groups: list[dict] = vimsupport.VimExpressionToPythonType(
-        "g:ycm_semantic_highlight_groups"
-        )
+        "g:ycm_semantic_highlight_groups" )
     hi_groups.extend( HIGHLIGHT_GROUPS[:] )
     HIGHLIGHT_GROUPS = hi_groups
 
@@ -137,7 +139,7 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
     self._prop_id = NextPropID()
     super().__init__( bufnr )
 
-    self._filetypes = vimsupport.CurrentFiletypes()
+    self._filetypes = vimsupport.GetBufferFiletypes( bufnr )
 
     default_hi = None
     target_groups = None
@@ -195,8 +197,7 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
             REPORTED_MISSING_TYPES.add( token[ 'type' ] )
             vimsupport.PostVimMessage(
               f"Token type { token[ 'type' ] } is not defined for { self._filetypes }. "
-              f"See :help youcompleteme-customising-highlight-groups"
-              )
+              f"See :help youcompleteme-customising-highlight-groups" )
         else:
           raise e
 

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -126,8 +126,8 @@ def Initialise():
   if default_hi is None or 'highlight' not in default_hi:
     return
 
-  # XXX define default settings globally for make it compatible with older
-  # settings
+  # define default settings globally for make it compatible with older settings,
+  # that used global highlight groups, instead of groups per buffer
   for token_type, group in default_hi[ 'highlight' ].items():
     AddHiForTokenType( None, token_type, group )
 

--- a/python/ycm/semantic_highlighting.py
+++ b/python/ycm/semantic_highlighting.py
@@ -95,8 +95,10 @@ def Initialise():
   global HIGHLIGHT_GROUPS
 
   if "ycm_semantic_highlight_groups" in vimsupport.GetVimGlobalsKeys():
-    hi_groups: list[dict] = vimsupport.VimExpressionToPythonType("g:ycm_semantic_highlight_groups")
-    hi_groups.extend(HIGHLIGHT_GROUPS[:])
+    hi_groups: list[dict] = vimsupport.VimExpressionToPythonType(
+        "g:ycm_semantic_highlight_groups"
+        )
+    hi_groups.extend( HIGHLIGHT_GROUPS[:] )
     HIGHLIGHT_GROUPS = hi_groups
 
   # init default highlight
@@ -147,7 +149,7 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
       elif default_hi is None:
         default_hi = ft_groups
 
-    if target_groups is None and (default_hi is None or 'highlight' not in default_hi):
+    if target_groups is None and ( default_hi is None or 'highlight' not in default_hi ):
       self._do_highlight = False
       return
     elif target_groups is None:
@@ -162,8 +164,6 @@ class SemanticHighlighting( sr.ScrollingBufferRange ):
       AddHiForTokenType( bufnr, token_type, group )
 
     self._do_highlight = True
-
-
 
 
   def _NewRequest( self, request_range ):


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Currently there are no way for set highlighting groups for different file types, so I added such possibility. Also now it is possible to use default vim highlighting groups that defined for specific filetype

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4167)
<!-- Reviewable:end -->
