### PR TITLE
[READY] Make vimsupport.BuildRange construct a half-open range

### DIFF
--- a/python/ycm/tests/command_test.py
+++ b/python/ycm/tests/command_test.py
@@ -99,7 +99,7 @@ class CommandTest( TestCase ):
               },
               'end': {
                 'line_num': 2,
-                'column_num': 12
+                'column_num': 13
               }
             }
           },
@@ -132,7 +132,7 @@ class CommandTest( TestCase ):
               },
               'end': {
                 'line_num': 2,
-                'column_num': 9
+                'column_num': 10
               }
             }
           },

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1400,7 +1400,7 @@ def BuildRange( start_line, end_line ):
         # Vim returns the maximum 32-bit integer value when a whole line is
         # selected. Use the end of line instead.
         'column_num': min( end[ 1 ],
-                           len( vim.current.buffer[ end[ 0 ] - 1 ] ) ) + 1
+                           len( vim.current.buffer[ end[ 0 ] - 1 ] ) ) + 2
       }
     }
   }


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The rest of YCM is already dealing with half-open ranges and so does LSP.
In fact, ycmd assumes this is a half-open range, so YCM had a bug.

Though I have to look at what non-LSP completers are doing.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4266)
<!-- Reviewable:end -->
