### PR TITLE
jdt.ls: properly handle URI by showing contents

### DIFF
--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1497,3 +1497,44 @@ def BuildQfListItem( goto_data_item ):
     qf_item[ 'col' ] = goto_data_item[ 'column_num' ]
 
   return qf_item
+
+
+def CreateTemporaryReadonlyBuffer( contents=None,
+                                   buffer_name='[YCM-Temp-Readonly]',
+                                   syntax=None,
+                                   line=None,
+                                   column=None ):
+  """
+  Create a new temporary readonly buffer in Vim, optionally filled
+  with contents.  The buffer will not be associated with a file and
+  will be readonly and unmodifiable.
+  """
+  vim.command( 'enew' )
+  buf = vim.current.buffer
+
+  vim.command( f"file { buffer_name }" )
+
+  if contents:
+    buf.options[ 'modifiable' ] = True
+    buf[ : ] = contents.splitlines()
+    buf.options[ 'modifiable' ] = False
+
+  buf.options[ 'readonly' ] = True
+  buf.options[ 'modifiable' ] = False
+  buf.options[ 'bufhidden' ] = 'wipe'
+  buf.options[ 'buftype' ] = 'nofile'
+  buf.options[ 'buflisted' ] = False
+
+  vim.command( 'setlocal noswapfile' )
+  vim.command( 'setlocal nobuflisted' )
+  vim.command( 'setlocal nobuflisted' )
+
+  if syntax:
+    vim.command( f'set syntax={ syntax }' )
+
+  if line is not None and column is not None:
+    vim.current.window.cursor = ( line + 1, column )
+
+  vim.command( 'normal! zz' )
+
+  return buf


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This pull request introduces proper handling of `jdt://` URIs in YCM when using GoTo commands (e.g., `:YcmCompleter GoTo`) with the Java Development Tools Language Server (jdt.ls). Previously, these URIs, which are commonly returned by jdt.ls for navigation to class files or members, were not fully supported in YCM, leading to incomplete or incorrect buffer handling.

Building on the recent changes that I have made in the ycmd repository (specifically commit `ad64e63b` from 2025-07-07, which added support for jumping to `jdt://` URIs with `GoTo`), this change ensures YCM can display the contents of these URIs directly in a temporary Vim buffer without creating or relying on temporary files.

<b>Note!</b> This PR should be merged alongside [#1788](https://github.com/ycm-core/ycmd/pull/1788) on the [ycmd](https://github.com/ycm-core/ycmd) repository.

# Original Behavior

https://github.com/user-attachments/assets/e3365d18-4522-4cf4-b03c-36b4d3b23787

https://github.com/user-attachments/assets/d2d54db8-e60f-4f5c-a900-788082393dfe


[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4302)
<!-- Reviewable:end -->
