### PR TITLE
Fix #4305 by coping with replacement request with start == line after the last

### DIFF
--- a/python/ycm/tests/vimsupport_test.py
+++ b/python/ycm/tests/vimsupport_test.py
@@ -667,6 +667,16 @@ class VimsupportTest( TestCase ):
     AssertBuffersAreEqualAsBytes( [ 'first line' ], result_buffer )
 
 
+  @patch( 'vim.current.window.cursor', ( 1, 1 ) )
+  def test_ReplaceChunk_AtOneLinePastEndOfFile( self ):
+    result_buffer = VimBuffer( 'buffer', contents = [ 'first line' ] )
+    start, end = _BuildLocations( 2, 1, 2, 1 )
+    vimsupport.ReplaceChunk( start, end, 'second line', result_buffer )
+
+    AssertBuffersAreEqualAsBytes( [ 'first line', 'second line' ],
+                                result_buffer )
+
+
   @patch( 'vim.current.window.cursor', ( 1, 3 ) )
   def test_ReplaceChunk_CursorPosition( self ):
     result_buffer = VimBuffer( 'buffer', contents = [ 'bar' ] )

--- a/python/ycm/vimsupport.py
+++ b/python/ycm/vimsupport.py
@@ -1140,6 +1140,10 @@ def ReplaceChunk( start, end, replacement_text, vim_buffer ):
   # so we convert to bytes
   replacement_lines = SplitLines( ToBytes( replacement_text ) )
 
+  if start_line >= len( vim_buffer ):
+    start_line -= 1
+    replacement_lines = [ ToBytes( vim_buffer[ -1 ] ) ] + replacement_lines
+
   # NOTE: Vim buffers are a list of unicode objects on Python 3.
   start_existing_text = ToBytes( vim_buffer[ start_line ] )[ : start_column ]
   end_line_text = ToBytes( vim_buffer[ end_line ] )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

My understanding, from what reported in #4305 and what I've experienced, is that the existing code was not written with the idea that a `ReplaceChunk` could be fed with a `start` that is the line _after_ the last line of the buffer, i.e. when it is `== len( vim_buffer )` (I don't think a request can be made with a number higher than that, e.g. "insert from line 9 in a 7-lines file").

This change copes with that case by setting `start_line` back to the last line index (I've done `start_line -= 1`, but maybe `start_line = len( vim_buffer )` would be better?), and prepending the last line to the `replacement_lines` as originally computed.

The test I've written passes, and the usecase I've described and screencasted in #4305 is fixed.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4311)
<!-- Reviewable:end -->
