### PR TITLE
Fix invalid syntax in Go Semantic Completion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1560,7 +1560,7 @@ def Settings( **kwargs ):
   if kwargs[ 'language' ] == 'go':
     return {
        'ls': {
-         'build.buildFlags': [ '-tags=debug' ] }
+         'build.buildFlags': [ '-tags=debug' ]
        }
     }
 ```


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The configuration example in README has too many brackets.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4328)
<!-- Reviewable:end -->
