### PR TITLE
client: validate URI scheme in BaseRequest

### DIFF
--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -324,7 +324,10 @@ def _ValidateResponseObject( response, response_text ):
 
 
 def _BuildUri( handler ):
-  return ToBytes( urljoin( BaseRequest.server_location, handler ) )
+  request_uri = urljoin( BaseRequest.server_location, handler )
+  if urlparse( request_uri ).scheme not in ( 'http', 'https' ):
+    raise RuntimeError( 'Invalid URI scheme. Only http and https are allowed.' )
+  return ToBytes( request_uri )
 
 
 def MakeServerException( data ):

--- a/python/ycm/tests/client/base_request_test.py
+++ b/python/ycm/tests/client/base_request_test.py
@@ -18,10 +18,10 @@
 from ycm.tests.test_utils import MockVimBuffers, MockVimModule, VimBuffer
 MockVimModule()
 
-from hamcrest import assert_that, has_entry
+from hamcrest import assert_that, has_entry, equal_to
 from unittest import TestCase
 from unittest.mock import patch
-from ycm.client.base_request import BuildRequestData
+from ycm.client.base_request import BuildRequestData, _BuildUri, BaseRequest
 
 
 class BaseRequestTest( TestCase ):
@@ -40,3 +40,15 @@ class BaseRequestTest( TestCase ):
     with MockVimBuffers( [ current_buffer ], [ current_buffer ] ):
       assert_that( BuildRequestData( current_buffer.number ),
                    has_entry( 'working_dir', '/some/dir' ) )
+
+
+  def test_BuildUri_ValidScheme( self ):
+    BaseRequest.server_location = 'http://localhost:1234'
+    assert_that( _BuildUri( 'handler' ),
+                 equal_to( b'http://localhost:1234/handler' ) )
+
+
+  def test_BuildUri_InvalidScheme( self ):
+    BaseRequest.server_location = 'http://localhost:1234'
+    with self.assertRaisesRegex( RuntimeError, 'Invalid URI scheme' ):
+      _BuildUri( 'file:///etc/passwd' )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Enhancing the robustness of URI construction in `base_request.py` by validating the resulting scheme. Currently, `_BuildUri` uses `urljoin` which can return schemes like `file://` if a handler name is manipulated. Since `urllib.request.urlopen` supports various protocols, adding a strict validation to allow only `http` and `https` prevents potential misuse of the request client for local file access or other unintended schemes.

Validation at the `_BuildUri` level ensures that all communication with the ycmd server stays within the expected HTTP(S) protocol boundaries. This change aligns with technical best practices for handling dynamic URL construction even in local environments.

Tests in `BaseRequestTest` now verify both successful URI building with valid schemes and the expected failure when an invalid scheme is detected.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4331)
<!-- Reviewable:end -->
