### PR TITLE
Make mapping for `YcmShowDetailedDiagnostic` `<silent>`

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -374,7 +374,7 @@ function! s:SetUpKeyMappings()
   endif
 
   if !empty( g:ycm_key_detailed_diagnostics )
-    silent! exe 'nnoremap <unique> ' . g:ycm_key_detailed_diagnostics .
+    silent! exe 'nnoremap <unique> <silent> ' . g:ycm_key_detailed_diagnostics .
           \ ' :YcmShowDetailedDiagnostic<CR>'
   endif
 endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [x] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This change is not necessary, but it's moderately useful in that it avoids the unnecessary visual noise of echoing `:YcmShowDetailedDiagnostic` on the command line when triggering the detailed diagnostic popup, in the case that one has the following setting in place
```viml
let g:ycm_show_detailed_diag_in_popup = 1
```

# Rationale for not having a test

I think the change is uncontroversially useful, despite of very mild usefulness, and fundamentally safe. I don't think any existing reliance on this command not being `<silent>` would be justifiable in the first place.

[cont]: https://github.com/ycm-core/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/ycm-core/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/YouCompleteMe/4333)
<!-- Reviewable:end -->
